### PR TITLE
fix: patch production snapshot vulnerabilities

### DIFF
--- a/.github/actions/setup-repository/action.yml
+++ b/.github/actions/setup-repository/action.yml
@@ -17,8 +17,6 @@ runs:
         RELEASE_SHA: ${{ inputs.release-sha }}
       run: test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
     - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      with:
-        version: 11.8.0
     - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: 22.22.2

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -21,8 +21,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 11.8.0
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22.22.2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ source tree on July 13, 2026; the repository now contains V2 code only.
 | Observability | Workers Logs + Workers Tracing + Workers Analytics Engine (no third-party APM in the initial release) |
 | Lint/format | Biome 2.5.2 (single config, no ESLint+Prettier except next plugin) |
 | QA | Direct `agent-browser --auto-connect --session cheatcode-debug` UI operation + console/network/log review; no scripted test harnesses |
-| Monorepo | pnpm 11.8.0 + Turborepo 2.10.5 |
+| Monorepo | pnpm 11.15.0 + Turborepo 2.10.5 |
 
 ## Repo layout
 
@@ -57,7 +57,7 @@ scripts/                 Operational helpers only: build skills, local startup, 
 ## Build
 
 ```bash
-pnpm install                            # Install workspace deps (use pnpm@11.8.0, not npm/yarn)
+pnpm install                            # Install workspace deps (use pnpm@11.15.0, not npm/yarn)
 pnpm turbo skills:build                 # Bundle skills/ into packages/skills/src/generated.ts (REQUIRED before build)
 pnpm turbo db:generate                  # Generate Drizzle types from schema
 pnpm turbo build                        # Production build

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pnpm dev
 ```
 
 `pnpm dev` is the complete local entrypoint. Docker Compose builds the pinned
-Node 22.22.2/pnpm 11.8.0 development image, starts the Vault-capable Postgres
+Node 22.22.2/pnpm 11.15.0 development image, starts the Vault-capable Postgres
 database, provisions isolated `app_gateway`, `app_agent`, and `app_webhooks`
 roles, applies all three local migration phases, and then starts Next.js plus the
 chained Workers. Source changes sync into

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "packageManager": "pnpm@11.8.0",
+  "packageManager": "pnpm@11.15.0",
   "engines": {
     "node": "22.22.2"
   },

--- a/infra/containers/dev/Dockerfile
+++ b/infra/containers/dev/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates \
   && rm -rf /var/lib/apt/lists/* \
   && corepack enable \
-  && corepack prepare pnpm@11.8.0 --activate
+  && corepack prepare pnpm@11.15.0 --activate
 
 WORKDIR /workspace
 

--- a/infra/containers/sandbox/Dockerfile
+++ b/infra/containers/sandbox/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22.22.2-bookworm-slim@sha256:9f6d5975c7dca860947d3915877f85607946403fc
 
 ARG CODE_SERVER_VERSION=4.128.0
 ARG CODE_SERVER_SHA256=79ba26bf186e5268a22b7c17b30a5f288a16c37791f0b86c27859e8fef103188
-ARG DEBIAN_SNAPSHOT=20260713T000000Z
+ARG DEBIAN_SNAPSHOT=20260718T000000Z
 
 # Daytona injects its own daemon (host-mounted, PID 1) and overrides ENTRYPOINT,
 # so we do NOT bake a sandbox daemon. Headed Chromium uses Xvfb, which the
@@ -20,6 +20,7 @@ RUN set -eux; \
   sed -i 's|URIs: http://snapshot.debian.org|URIs: https://snapshot.debian.org|g' /etc/apt/sources.list.d/debian.sources; \
   rm -rf /var/lib/apt/lists/*; \
   apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 -o Acquire::Check-Valid-Until=false -o Acquire::https::No-Cache=true update; \
+  apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 -o Acquire::http::Pipeline-Depth=0 upgrade -y --no-install-recommends; \
   apt-get -o Acquire::ForceIPv4=true -o Acquire::Retries=5 -o Acquire::http::Pipeline-Depth=0 install -y --no-install-recommends \
   file python3 python3-pip python3-venv git curl wget gnupg netcat-openbsd sudo \
   procps xvfb x11vnc novnc websockify \

--- a/infra/containers/sandbox/app-templates/expo/package.json
+++ b/infra/containers/sandbox/app-templates/expo/package.json
@@ -3,7 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "private": true,
-  "packageManager": "pnpm@11.8.0",
+  "packageManager": "pnpm@11.15.0",
   "engines": {
     "node": "22.22.2"
   },

--- a/infra/containers/sandbox/app-templates/next/package.json
+++ b/infra/containers/sandbox/app-templates/next/package.json
@@ -2,7 +2,7 @@
   "name": "cheatcode-app",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@11.8.0",
+  "packageManager": "pnpm@11.15.0",
   "engines": {
     "node": "22.22.2"
   },

--- a/infra/containers/sandbox/package-manager/package-lock.json
+++ b/infra/containers/sandbox/package-manager/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "npm": "12.0.1",
-        "pnpm": "11.8.0"
+        "pnpm": "11.15.0"
       },
       "engines": {
         "node": "22.22.2"
@@ -1830,9 +1830,9 @@
       }
     },
     "node_modules/pnpm": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-11.8.0.tgz",
-      "integrity": "sha512-wfXnxMskHI8XS3Q4UdgvQrgCMkr8iw8Ra5atsVqgZmSUjd42lgo7oQebpbSyndAUATW5S1tfUmNZIknWjlVfJg==",
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/pnpm/-/pnpm-11.15.0.tgz",
+      "integrity": "sha512-Jm+JV6MNK+bpRo5eZrze3TWnlBdfcbBnuoUE1obM4dDA9CmzPDI8PFaa1IkeZnV0pJ/3HRuJoizGbxPGWBjFeA==",
       "license": "MIT",
       "bin": {
         "pn": "bin/pnpm.mjs",

--- a/infra/containers/sandbox/package-manager/package.json
+++ b/infra/containers/sandbox/package-manager/package.json
@@ -7,6 +7,9 @@
   },
   "dependencies": {
     "npm": "12.0.1",
-    "pnpm": "11.8.0"
+    "pnpm": "11.15.0"
+  },
+  "overrides": {
+    "undici": "6.27.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/cheatcode-ai/cheatcode.git"
   },
   "type": "module",
-  "packageManager": "pnpm@11.8.0",
+  "packageManager": "pnpm@11.15.0",
   "engines": {
     "node": "22.22.2"
   },


### PR DESCRIPTION
## Summary
- refresh the pinned Debian snapshot and upgrade installed OS packages
- align repository, development image, templates, and sandbox runtime on pnpm 11.15.0
- force patched undici 6.27.0 in the isolated sandbox package-manager bundle

## Plan
This is a release-blocking security correction within the existing sandbox snapshot architecture documented in `plan.md`.

## What's Included
### Runtime security
- move the reproducible Debian snapshot to the patched July 18 archive
- apply snapshot upgrades before installing runtime packages
- eliminate the vulnerable undici copy bundled by the previous pnpm release

### Version alignment
- pin pnpm 11.15.0 in root, web, development image, app templates, and documentation
- update the isolated npm package-manager lockfile

## Decisions Made
| Decision | Choice | Alternatives Considered | Reasoning |
|---|---|---|---|
| OS remediation | refresh the immutable Debian snapshot and upgrade from it | install individual security packages | preserves reproducibility while applying the complete patched package set |
| undici remediation | upgrade pnpm and add the package-manager override | mutate pnpm internals after install | keeps every installed package manager artifact on supported, auditable versions |
| release flow | use the protected snapshot workflow after merge | publish manually with Daytona CLI | preserves required provenance, scans, smoke checks, and environment approval |

## Edge Cases Handled
| Scenario | Handling |
|---|---|
| pnpm embeds its own undici copy | pnpm 11.15.0 contains undici 6.27.0 and the npm install is also overridden |
| stale Debian base packages remain after snapshot refresh | explicit package upgrade runs before runtime dependency installation |
| template/runtime version drift | every repository and container pnpm pin is aligned |

## How to Review
1. Review `infra/containers/sandbox/Dockerfile` for the reproducible OS update.
2. Review `infra/containers/sandbox/package-manager/` for the pnpm and undici remediation.
3. Confirm the remaining pin changes are mechanical version alignment.

## Test Plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] exact production Docker image build
- [x] protected-workflow-equivalent runtime smoke checks
- [x] Trivy Dockerfile configuration scan
- [x] Trivy HIGH/CRITICAL vulnerability scan
- [x] Trivy secret scan
- [x] isolated package-manager `npm audit --omit=dev`

After merge, the exact-main static checks and protected Production snapshot workflow remain required before Daytona publication.