### PR TITLE
chore(sandbox): promote snapshot 3135caf07ec8

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
     "DAYTONA_PREVIEW_HOST_SUFFIXES": "daytonaproxy01.net,proxy.daytona.work",
     "DAYTONA_TARGET": "us",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-3336016022d8",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-3135caf07ec8-29682200713",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production",
     "OUTPUT_DOWNLOAD_BASE_URL": "https://gateway.trycheatcode.com",
     "PREVIEW_HOSTNAME": "trycheatcode.com",


### PR DESCRIPTION
## Summary

- promote the immutable Daytona snapshot built from main commit 3135caf07ec8d0b654038413a555463f110a9f52
- update the production agent worker to use cheatcode-sandbox-viewer-bundle-3135caf07ec8-29682200713
- retain the previous snapshot in Daytona for rollback

## Verification

- protected snapshot workflow 29682200713 passed image build, Trivy scans, runtime smoke tests, publication, and remote active-state verification
- pnpm exec biome check apps/agent-worker/wrangler.jsonc
- git diff --check

## Deployment

Merging updates DAYTONA_SANDBOX_SNAPSHOT in the production worker configuration. The immutable candidate is already active in Daytona; no existing snapshot was deleted or replaced.