### PR TITLE
chore(sandbox): promote skill creator snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
     "DAYTONA_PREVIEW_HOST_SUFFIXES": "daytonaproxy01.net,proxy.daytona.work",
     "DAYTONA_TARGET": "us",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-3135caf07ec8-29682200713",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-df6e8265f913-29685267604",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production",
     "OUTPUT_DOWNLOAD_BASE_URL": "https://gateway.trycheatcode.com",
     "PREVIEW_HOSTNAME": "trycheatcode.com",


### PR DESCRIPTION
## Summary

- promote the immutable Daytona snapshot built from exact main commit `df6e8265f913a16598ea2cd57c80816b8b4067a8`
- point new project sandboxes at `cheatcode-sandbox-viewer-bundle-df6e8265f913-29685267604`
- leave all existing snapshots and active sandboxes untouched

## Decision exposed

The snapshot is promoted by reviewed configuration, not by mutating an existing Daytona snapshot. This keeps the runtime artifact immutable and makes rollback a one-line configuration change.

## Verification

- protected snapshot workflow: https://github.com/cheatcode-ai/cheatcode/actions/runs/29685267604
- Trivy configuration/image scan passed
- candidate runtime smoke test passed
- Daytona publication and clean-sandbox verification passed
- published digest: `sha256:fa3e6ceb9371793a508a4aa5ab1edb832ca0f8597d06ce35b7ecc71972e1ad48`
- `pnpm turbo lint --filter=@cheatcode/agent-worker`
- `pnpm turbo typecheck --filter=@cheatcode/agent-worker`
- `git diff --check`
