### PR TITLE
chore(sandbox): promote rich skill snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
     "DAYTONA_PREVIEW_HOST_SUFFIXES": "daytonaproxy01.net,proxy.daytona.work",
     "DAYTONA_TARGET": "us",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-df6e8265f913-29685267604",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-6e926e583e76-29695426038",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production",
     "OUTPUT_DOWNLOAD_BASE_URL": "https://gateway.trycheatcode.com",
     "PREVIEW_HOSTNAME": "trycheatcode.com",


### PR DESCRIPTION
## Summary

Promotes the verified Daytona snapshot candidate built from `main` commit `6e926e583e76e238a2ba60cb9f8c603f12c3ee00`.

- Candidate: `cheatcode-sandbox-viewer-bundle-6e926e583e76-29695426038`
- Build workflow: https://github.com/cheatcode-ai/cheatcode/actions/runs/29695426038
- Keeps the previous snapshot name in Git history as the immediate rollback target.

## Verification

- Protected snapshot workflow passed provenance checks.
- Image build completed for linux/amd64.
- Trivy configuration, vulnerability, and secret scans passed.
- Runtime smoke tests passed.
- Daytona published and re-read the immutable candidate as active.
- `pnpm lint` passes locally.