### PR TITLE
fix: center files state and suppress emojis

### DIFF
--- a/packages/agent-core/src/mastra/system-prompt.ts
+++ b/packages/agent-core/src/mastra/system-prompt.ts
@@ -253,7 +253,8 @@ Narration voice:
 - Write in the first person, one short sentence per step. Say what you just did and what you'll do next — e.g. "The deck is built; I'll render it to images and check each slide."
 - When something fails or you switch approach, say so plainly in one line and state your fix — e.g. "pdftoppm isn't available, so I'll render with Python instead." State the problem as a fact, decide the fix, move on. No apologising, no dwelling.
 - Keep momentum: every line points at the next concrete action, and names the real thing — "slide 2's footer is too faint", not "improving quality".
-- No filler ("Let me…", "Great!"), no hype, no emoji, no walls of text. Calm and competent, like a capable colleague working over your shoulder.
+- No filler ("Let me…", "Great!"), no hype, and no walls of text. Calm and competent, like a capable colleague working over your shoulder.
+- Never emit emoji characters in any user-visible response, including headings, bullets, status lines, and final answers. If a skill, template, or source contains emojis, rewrite them as plain text or standard punctuation before showing the user. Only use emojis when the user explicitly asks for them.
 
 For anything past a one-step request, think first and work to a plan. Hold the plan in your head, or keep a todo.md in the workspace for long jobs, and let your narration reveal it one step at a time. Do the reasoning silently — never print a numbered plan, a status table, or a "step 3 of 7" counter.`,
 

--- a/packages/preview-bridge/src/index.ts
+++ b/packages/preview-bridge/src/index.ts
@@ -120,7 +120,7 @@ style.textContent=[
 ".cheatcode-directory-action-primary{background:var(--vscode-button-background,#191919);color:var(--vscode-button-foreground,#fff)}",
 ".cheatcode-directory-action-secondary{background:var(--vscode-button-secondaryBackground,#e7e7e7);color:var(--vscode-button-secondaryForeground,#333)}",
 ".cheatcode-computer-empty{position:absolute;inset:0;z-index:5;display:flex;align-items:center;justify-content:center;background:var(--vscode-editor-background,#fff);overflow:hidden}",
-".cheatcode-computer-mark{position:fixed;left:50vw;top:50vh;width:72px;height:72px;transform:translate(-50%,-50%);color:var(--vscode-disabledForeground,#f0f0f0)}",
+".cheatcode-computer-mark{position:absolute;left:50%;top:50%;width:72px;height:72px;transform:translate(-50%,-50%);color:var(--vscode-disabledForeground,#f0f0f0)}",
 ".cheatcode-computer-mark-main,.cheatcode-computer-mark-small{position:absolute;display:block;line-height:1;font-family:Georgia,serif}",
 ".cheatcode-computer-mark-main{inset:0;font-size:72px}",
 ".cheatcode-computer-mark-small{right:-2px;bottom:2px;font-size:28px}"


### PR DESCRIPTION
## Summary

- Centers the Files empty-state mark within the editor surface instead of the full iframe viewport, so the explorer width no longer shifts it left.
- Strengthens the agent narration contract so user-visible responses omit emojis unless the user explicitly requests them.

## Decisions Made

| Decision | Choice | Reasoning |
|---|---|---|
| Empty-state positioning | Absolute positioning inside the editor empty-state container | The container already owns the editor bounds; viewport-fixed positioning incorrectly included the explorer pane. |
| Emoji handling | System-prompt invariant with explicit rewriting guidance | Covers headings, status lines, templates, skills, and sourced content without changing rendering behavior. |

## Edge Cases Handled

| Scenario | Handling |
|---|---|
| Explorer width changes | The mark remains centered against the editor pane. |
| Skill or template contains emoji | The agent rewrites it to plain text unless emojis were requested. |

## How to Review

1. Review packages/preview-bridge/src/index.ts for the positioning scope.
2. Review packages/agent-core/src/mastra/system-prompt.ts for the response-style invariant.

## Validation

- [x] pnpm lint
- [x] pnpm turbo typecheck
- [x] pnpm build
- [x] Direct agent-browser QA in the embedded Files tab with an empty folder
- [x] Direct agent-browser QA of a fresh celebratory response; zero Extended_Pictographic characters
- [x] Browser console checked with no new application errors