### PR TITLE
fix(infra): invoke worker deploy scripts explicitly

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -19,6 +19,14 @@ for (const key of Object.keys(loadedRootEnvironment.parsedEnv ?? {})) {
   }
 }
 
+const vercelGitCommitSha = process.env["VERCEL_GIT_COMMIT_SHA"];
+if (
+  process.env["NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA"] === undefined &&
+  vercelGitCommitSha !== undefined
+) {
+  process.env["NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA"] = vercelGitCommitSha;
+}
+
 const WEB_BUILD_ENVIRONMENT = parseWebBuildEnvironment({
   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: process.env["NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY"],
   NEXT_PUBLIC_GATEWAY_URL: process.env["NEXT_PUBLIC_GATEWAY_URL"],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "architecture:check": "dependency-cruise --config .dependency-cruiser.cjs --ts-config tsconfig.base.json --exclude '(^|/)(dist|\\.next|\\.turbo|node_modules)/' apps packages",
     "audit:archive": "tsx scripts/archive-audit-log.ts",
     "build": "turbo build",
-    "cloudflare:deploy": "pnpm --filter @cheatcode/agent-worker deploy && pnpm --filter @cheatcode/webhooks-worker deploy && pnpm --filter @cheatcode/preview-proxy deploy && pnpm --filter @cheatcode/gateway-worker deploy",
+    "cloudflare:deploy": "pnpm --filter @cheatcode/agent-worker run deploy && pnpm --filter @cheatcode/webhooks-worker run deploy && pnpm --filter @cheatcode/preview-proxy run deploy && pnpm --filter @cheatcode/gateway-worker run deploy",
     "cloudflare:set-hyperdrive": "tsx scripts/set-hyperdrive-id.ts",
     "db:migrate": "tsx scripts/migrate.ts",
     "db:generate": "turbo db:generate",


### PR DESCRIPTION
## Summary

- invoke each Cloudflare package deployment through `pnpm run deploy`
- prevent pnpm from treating `deploy` as its workspace export command

## Validation

- `pnpm exec biome check package.json`
- `git diff --check`
- reproduced the broken release command before the fix