### PR TITLE
fix(infra): remove unsupported worker limit override

### DIFF
--- a/apps/webhooks-worker/wrangler.jsonc
+++ b/apps/webhooks-worker/wrangler.jsonc
@@ -6,9 +6,6 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-07-15",
   "compatibility_flags": ["nodejs_compat"],
-  "limits": {
-    "subrequests": 10000
-  },
   "version_metadata": {
     "binding": "CF_VERSION_METADATA"
   },


### PR DESCRIPTION
## Summary
- remove the webhooks Worker subrequest limit override rejected by the Cloudflare Free plan
- preserve all runtime bindings and deployment behavior

## Validation
- `git diff --check`
- `pnpm --filter @cheatcode/webhooks-worker lint`
- `pnpm --filter @cheatcode/webhooks-worker typecheck`
- `pnpm exec wrangler deploy --config apps/webhooks-worker/wrangler.jsonc --dry-run`