### PR TITLE
fix(workers): resolve maintenance secrets on demand

### DIFF
--- a/apps/agent-worker/src/internal-maintenance.ts
+++ b/apps/agent-worker/src/internal-maintenance.ts
@@ -1,5 +1,4 @@
 import {
-  assertDistinctHmacSecrets,
   assertInternalMaintenanceEnvelope,
   verifyInternalMaintenanceRequest,
 } from "@cheatcode/auth";
@@ -70,7 +69,11 @@ async function verifyAgentRequest(
   input: AgentMaintenanceRequestInput,
   capability: "agent-lifecycle" | "database-readiness" | "durable-object-schema",
 ): Promise<void> {
-  const secrets = await requireAgentMaintenanceSecrets(input.secrets);
+  const secret = await requireAgentMaintenanceSecret(
+    capability === "agent-lifecycle"
+      ? input.secrets.WEBHOOKS_TO_AGENT_LIFECYCLE_SECRET
+      : input.secrets.RELEASE_DATABASE_READINESS_SECRET,
+  );
   await verifyInternalMaintenanceRequest({
     expectedAudience: "agent",
     expectedCapability: capability,
@@ -79,7 +82,7 @@ async function verifyAgentRequest(
     expectedPathname: input.expectedPathname,
     rawBody: input.rawBody,
     request: input.request,
-    secret: capability === "agent-lifecycle" ? secrets.agentLifecycle : secrets.databaseReadiness,
+    secret,
   });
 }
 
@@ -93,17 +96,9 @@ export function parseInternalMaintenanceJson(rawBody: string): unknown {
   }
 }
 
-async function requireAgentMaintenanceSecrets(env: AgentMaintenanceSecretBindings): Promise<{
-  agentLifecycle: string;
-  databaseReadiness: string;
-}> {
+async function requireAgentMaintenanceSecret(binding: WorkerSecret): Promise<string> {
   try {
-    const [agentLifecycle, databaseReadiness] = await Promise.all([
-      resolveRequiredSecret(env.WEBHOOKS_TO_AGENT_LIFECYCLE_SECRET),
-      resolveRequiredSecret(env.RELEASE_DATABASE_READINESS_SECRET),
-    ]);
-    assertDistinctHmacSecrets([agentLifecycle, databaseReadiness]);
-    return { agentLifecycle, databaseReadiness };
+    return await resolveRequiredSecret(binding);
   } catch {
     throw new APIError(
       503,

--- a/apps/gateway-worker/src/internal-maintenance.ts
+++ b/apps/gateway-worker/src/internal-maintenance.ts
@@ -1,4 +1,3 @@
-import { assertDistinctHmacSecrets } from "@cheatcode/auth";
 import { resolveWorkerSecret, type WorkerSecret } from "@cheatcode/env";
 import { APIError } from "@cheatcode/observability";
 
@@ -10,26 +9,18 @@ export interface GatewayMaintenanceSecretBindings {
 export async function requireResourceDeletionSecret(
   env: GatewayMaintenanceSecretBindings,
 ): Promise<string> {
-  return (await requireGatewayMaintenanceSecrets(env)).resourceDeletion;
+  return requireGatewayMaintenanceSecret(env.GATEWAY_TO_WEBHOOKS_RESOURCE_DELETION_SECRET);
 }
 
 export function requireDatabaseReadinessSecret(
   env: GatewayMaintenanceSecretBindings,
 ): Promise<string> {
-  return requireGatewayMaintenanceSecrets(env).then((secrets) => secrets.databaseReadiness);
+  return requireGatewayMaintenanceSecret(env.RELEASE_DATABASE_READINESS_SECRET);
 }
 
-async function requireGatewayMaintenanceSecrets(env: GatewayMaintenanceSecretBindings): Promise<{
-  databaseReadiness: string;
-  resourceDeletion: string;
-}> {
+async function requireGatewayMaintenanceSecret(binding: WorkerSecret): Promise<string> {
   try {
-    const [databaseReadiness, resourceDeletion] = await Promise.all([
-      resolveRequiredSecret(env.RELEASE_DATABASE_READINESS_SECRET),
-      resolveRequiredSecret(env.GATEWAY_TO_WEBHOOKS_RESOURCE_DELETION_SECRET),
-    ]);
-    assertDistinctHmacSecrets([databaseReadiness, resourceDeletion]);
-    return { databaseReadiness, resourceDeletion };
+    return await resolveRequiredSecret(binding);
   } catch {
     // Secret-store failures share one bounded internal-maintenance error contract.
   }

--- a/apps/webhooks-worker/src/internal-maintenance.ts
+++ b/apps/webhooks-worker/src/internal-maintenance.ts
@@ -1,4 +1,3 @@
-import { assertDistinctHmacSecrets } from "@cheatcode/auth";
 import { resolveWorkerSecret, type WorkerSecret } from "@cheatcode/env";
 import { APIError } from "@cheatcode/observability";
 
@@ -32,42 +31,30 @@ export interface WebhooksMaintenanceSecretBindings {
 export function requireWebhookReplaySecret(
   env: WebhooksMaintenanceSecretBindings,
 ): Promise<string> {
-  return requireWebhooksMaintenanceSecrets(env).then((secrets) => secrets.webhookReplay);
+  return requireWebhooksMaintenanceSecret(env.INTERNAL_WEBHOOK_REPLAY_SECRET);
 }
 
 export function requireResourceDeletionSecret(
   env: WebhooksMaintenanceSecretBindings,
 ): Promise<string> {
-  return requireWebhooksMaintenanceSecrets(env).then((secrets) => secrets.resourceDeletion);
+  return requireWebhooksMaintenanceSecret(env.GATEWAY_TO_WEBHOOKS_RESOURCE_DELETION_SECRET);
 }
 
 export function requireDatabaseReadinessSecret(
   env: WebhooksMaintenanceSecretBindings,
 ): Promise<string> {
-  return requireWebhooksMaintenanceSecrets(env).then((secrets) => secrets.databaseReadiness);
+  return requireWebhooksMaintenanceSecret(env.RELEASE_DATABASE_READINESS_SECRET);
 }
 
 export function requireAgentLifecycleSecret(
   env: WebhooksMaintenanceSecretBindings,
 ): Promise<string> {
-  return requireWebhooksMaintenanceSecrets(env).then((secrets) => secrets.agentLifecycle);
+  return requireWebhooksMaintenanceSecret(env.WEBHOOKS_TO_AGENT_LIFECYCLE_SECRET);
 }
 
-async function requireWebhooksMaintenanceSecrets(env: WebhooksMaintenanceSecretBindings): Promise<{
-  agentLifecycle: string;
-  databaseReadiness: string;
-  resourceDeletion: string;
-  webhookReplay: string;
-}> {
+async function requireWebhooksMaintenanceSecret(binding: WorkerSecret): Promise<string> {
   try {
-    const [agentLifecycle, databaseReadiness, resourceDeletion, webhookReplay] = await Promise.all([
-      resolveRequiredSecret(env.WEBHOOKS_TO_AGENT_LIFECYCLE_SECRET),
-      resolveRequiredSecret(env.RELEASE_DATABASE_READINESS_SECRET),
-      resolveRequiredSecret(env.GATEWAY_TO_WEBHOOKS_RESOURCE_DELETION_SECRET),
-      resolveRequiredSecret(env.INTERNAL_WEBHOOK_REPLAY_SECRET),
-    ]);
-    assertDistinctHmacSecrets([agentLifecycle, databaseReadiness, resourceDeletion, webhookReplay]);
-    return { agentLifecycle, databaseReadiness, resourceDeletion, webhookReplay };
+    return await resolveRequiredSecret(binding);
   } catch {
     // Secret-store failures share one bounded internal-maintenance error contract.
   }


### PR DESCRIPTION
## Summary
- resolve only the maintenance capability secret required by each request
- prevent Secret Store exhaustion during multi-owner workspace reconciliation
- keep secret values request-scoped across Gateway, Agent, and Webhooks Workers

## Verification
- affected Worker typechecks
- affected Worker lint
- affected Worker production dry-run builds