### PR TITLE
fix(sandbox): resume verified workspace transitions

### DIFF
--- a/apps/agent-worker/src/durable-objects/project-sandbox-workspace-transition.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-workspace-transition.ts
@@ -72,9 +72,10 @@ export abstract class ProjectSandboxWorkspaceTransition extends ProjectSandboxPr
     const identity = await transitionIdentity(parsed);
     const existing = await this.loadWorkspaceTransitionState();
     if (existing) {
-      this.assertWorkspaceTransitionState(existing, parsed, identity);
+      this.assertWorkspaceTransitionIdentity(existing, identity);
       await this.verifyPreparedWorkspaceTransition(parsed.projects, existing.presentSlugs);
       await this.verifyStoredWorkspaceState(parsed.projects);
+      await this.adoptWorkspaceTransitionRelease(existing, parsed.releaseSha);
       return transitionResult(
         parsed,
         identity,
@@ -158,6 +159,28 @@ export abstract class ProjectSandboxWorkspaceTransition extends ProjectSandboxPr
     await this.ctx.storage.delete(WORKSPACE_TRANSITION_STATE_KEY);
     if ((await this.ctx.storage.get(WORKSPACE_TRANSITION_STATE_KEY)) !== undefined) {
       throw transitionError("Completed workspace transition state could not be removed.");
+    }
+  }
+
+  private async adoptWorkspaceTransitionRelease(
+    state: WorkspaceTransitionState,
+    releaseSha: string,
+  ): Promise<void> {
+    if (state.releaseSha === releaseSha) {
+      return;
+    }
+    await this.ctx.storage.put(
+      WORKSPACE_TRANSITION_STATE_KEY,
+      WorkspaceTransitionStateSchema.parse({ ...state, releaseSha }),
+    );
+  }
+
+  private assertWorkspaceTransitionIdentity(
+    state: WorkspaceTransitionState,
+    identity: WorkspaceTransitionIdentity,
+  ): void {
+    if (state.canonicalDigest !== identity.canonicalDigest) {
+      throw transitionError("Pending workspace transition belongs to another workspace contract.");
     }
   }
 


### PR DESCRIPTION
## Summary
- allow a failed release\x27s prepared workspace transition to roll forward to a new release
- require the canonical workspace digest to match
- re-verify sandbox folders and durable workspace state before adopting the new release SHA

## Verification
- pnpm --filter @cheatcode/agent-worker typecheck
- pnpm --filter @cheatcode/agent-worker lint
- pnpm exec wrangler deploy --dry-run --config apps/agent-worker/wrangler.jsonc --outdir /tmp/cheatcode-agent-dry-run