### PR TITLE
fix: avoid unauthorized refund row lock

### DIFF
--- a/packages/db/src/user-deletion-refund-intents.ts
+++ b/packages/db/src/user-deletion-refund-intents.ts
@@ -151,7 +151,6 @@ async function lockRefundIntent(
     .select(intentSelection())
     .from(userDeletionRefundIntents)
     .where(eq(userDeletionRefundIntents.jobId, jobId))
-    .for("update")
     .limit(1);
   return intent ? { ...intent, userId: toUserId(intent.userId) } : null;
 }


### PR DESCRIPTION
## Summary
- Removes a redundant refund-intent row lock that the least-privilege Webhooks role cannot acquire.
- Relies on the deletion-job lock already held in the same transaction to serialize refund reads and writes.

## Decision
The job lock is the authoritative serialization boundary because every supported refund reservation and evidence mutation locks that job before touching the intent.

## Test plan
- [x] DB package typecheck
- [x] DB package lint
- [ ] Resume production account-deletion workflows and confirm they advance beyond billing.