### PR TITLE
fix: bind immutable release SHA during Worker deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ repository. Deploy the Cloudflare backend Workers from a reviewed checkout with:
 pnpm cloudflare:deploy
 ```
 
+The deploy command refuses a dirty tree, a non-`main` branch, or a checkout that
+does not exactly match `origin/main`. It injects that immutable commit SHA into
+every Worker and deploys the gateway last, after its agent and webhooks service
+dependencies share the same release identity.
+
 There is no second release orchestrator, compatibility deploy command, or hidden
 workspace-reconciliation command. Schema migrations, Worker deployment, and
 Vercel deployment are explicit operations; operators must sequence them using

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "architecture:check": "dependency-cruise --config .dependency-cruiser.cjs --ts-config tsconfig.base.json --exclude '(^|/)(dist|\\.next|\\.turbo|node_modules)/' apps packages",
     "audit:archive": "tsx scripts/archive-audit-log.ts",
     "build": "turbo build",
-    "cloudflare:deploy": "pnpm --filter @cheatcode/agent-worker run deploy && pnpm --filter @cheatcode/webhooks-worker run deploy && pnpm --filter @cheatcode/preview-proxy run deploy && pnpm --filter @cheatcode/gateway-worker run deploy",
+    "cloudflare:deploy": "tsx scripts/deploy-cloudflare.ts",
     "cloudflare:set-hyperdrive": "tsx scripts/set-hyperdrive-id.ts",
     "db:migrate": "tsx scripts/migrate.ts",
     "db:generate": "turbo db:generate",

--- a/scripts/deploy-cloudflare.ts
+++ b/scripts/deploy-cloudflare.ts
@@ -1,0 +1,72 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runCapturedBoundedCommand } from "./bounded-command";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const COMMAND_TIMEOUT_MS = 5 * 60 * 1_000;
+const MAX_OUTPUT_BYTES = 2 * 1_024 * 1_024;
+const RELEASE_SHA_PATTERN = /^[0-9a-f]{40}$/u;
+const WORKERS = [
+  "apps/agent-worker/wrangler.jsonc",
+  "apps/webhooks-worker/wrangler.jsonc",
+  "apps/preview-proxy/wrangler.jsonc",
+  "apps/gateway-worker/wrangler.jsonc",
+] as const;
+
+function writeLine(line = ""): void {
+  process.stdout.write(`${line}\n`);
+}
+
+async function run(command: string, args: readonly string[]): Promise<string> {
+  const result = await runCapturedBoundedCommand(command, args, {
+    cwd: ROOT,
+    maxOutputBytes: MAX_OUTPUT_BYTES,
+    timeoutMs: COMMAND_TIMEOUT_MS,
+  });
+  if (result.code !== 0) {
+    process.stderr.write(result.output);
+    throw new Error(`${command} exited with status ${result.code}.`);
+  }
+  return result.stdout.trim();
+}
+
+async function reviewedReleaseSha(): Promise<string> {
+  const status = await run("git", ["status", "--porcelain"]);
+  if (status) throw new Error("Cloudflare deployment requires a clean worktree.");
+
+  const branch = await run("git", ["branch", "--show-current"]);
+  if (branch !== "main") throw new Error("Cloudflare deployment is allowed only from main.");
+
+  await run("git", ["fetch", "--quiet", "origin", "main"]);
+  const [head, remoteMain] = await Promise.all([
+    run("git", ["rev-parse", "HEAD"]),
+    run("git", ["rev-parse", "origin/main"]),
+  ]);
+  if (head !== remoteMain) throw new Error("Local main must exactly match origin/main.");
+  if (!RELEASE_SHA_PATTERN.test(head)) throw new Error("Git returned an invalid release SHA.");
+  return head;
+}
+
+async function deployWorker(configPath: string, releaseSha: string): Promise<void> {
+  writeLine(`Deploying ${configPath} at ${releaseSha}.`);
+  const output = await run(process.platform === "win32" ? "pnpm.cmd" : "pnpm", [
+    "exec",
+    "wrangler",
+    "deploy",
+    "--config",
+    configPath,
+    "--var",
+    `CHEATCODE_RELEASE_SHA:${releaseSha}`,
+  ]);
+  writeLine(output);
+}
+
+async function main(): Promise<void> {
+  const releaseSha = await reviewedReleaseSha();
+  for (const configPath of WORKERS) {
+    await deployWorker(configPath, releaseSha);
+  }
+  writeLine(`Cloudflare Workers are deployed at ${releaseSha}.`);
+}
+
+await main();


### PR DESCRIPTION
## Summary
- Replace the unsafe Worker deploy chain with one guarded operational command.
- Require a clean, synchronized `main` checkout and bind its exact commit SHA to every Worker.
- Deploy agent and webhooks before the gateway so release health converges deterministically.

## Decision
The release SHA is derived from the reviewed Git checkout instead of operator input. This prevents omitted, malformed, or mismatched release identities from reaching production.

## Verification
- [x] Biome check
- [x] Scripts TypeScript check
- [x] Dirty-worktree guard refuses deployment before Cloudflare mutation
- [x] Live gateway health verified with matching agent, webhooks, and gateway SHAs