### PR TITLE
ci: scope checks and worker deployments

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -13,66 +13,438 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  static-checks:
+  changes:
+    name: Detect affected surfaces
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 5
+    outputs:
+      audit: ${{ steps.scope.outputs.audit }}
+      audit_app_generators: ${{ steps.scope.outputs.audit_app_generators }}
+      audit_browser_driver: ${{ steps.scope.outputs.audit_browser_driver }}
+      audit_doc_runtime: ${{ steps.scope.outputs.audit_doc_runtime }}
+      audit_expo: ${{ steps.scope.outputs.audit_expo }}
+      audit_next: ${{ steps.scope.outputs.audit_next }}
+      audit_package_manager: ${{ steps.scope.outputs.audit_package_manager }}
+      audit_parquet_viewer: ${{ steps.scope.outputs.audit_parquet_viewer }}
+      audit_python: ${{ steps.scope.outputs.audit_python }}
+      audit_root: ${{ steps.scope.outputs.audit_root }}
+      audit_skill_runtime: ${{ steps.scope.outputs.audit_skill_runtime }}
+      base_sha: ${{ steps.scope.outputs.base_sha }}
+      code: ${{ steps.scope.outputs.code }}
+      global_code: ${{ steps.scope.outputs.global_code }}
+      head_sha: ${{ steps.scope.outputs.head_sha }}
+      knip_browser_driver: ${{ steps.scope.outputs.knip_browser_driver }}
+      knip_skill_runtime: ${{ steps.scope.outputs.knip_skill_runtime }}
+      nonworkspace_code: ${{ steps.scope.outputs.nonworkspace_code }}
+      root_code: ${{ steps.scope.outputs.root_code }}
+      skills: ${{ steps.scope.outputs.skills }}
+      workflow: ${{ steps.scope.outputs.workflow }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version: 22.22.2
-          cache: pnpm
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: false
-          version: 0.11.28
-      - uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
-        with:
-          cache: true
-          version: v0.72.0
-      - run: pnpm install --frozen-lockfile
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - name: Validate pull request title
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import re
+          import sys
+
+          title = os.environ["PR_TITLE"]
+          pattern = re.compile(
+              r"(?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)"
+              r"(?:\([a-z0-9][a-z0-9._/-]*\))?!?: \S.*"
+          )
+          if len(title) > 72 or pattern.fullmatch(title) is None:
+              print(
+                  "Pull request titles must use Conventional Commits and be at most 72 characters.",
+                  file=sys.stderr,
+              )
+              raise SystemExit(1)
+          PY
+      - name: Classify changed files
+        id: scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BEFORE_SHA: ${{ github.event.before }}
+          EVENT_HEAD_SHA: ${{ github.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -Eeuo pipefail
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base_sha="$PR_BASE_SHA"
+            head_sha="$PR_HEAD_SHA"
+          else
+            base_sha="$EVENT_BEFORE_SHA"
+            head_sha="$EVENT_HEAD_SHA"
+          fi
+
+          force_global=false
+          if [[ ! "$base_sha" =~ ^[0-9a-f]{40}$ ]] ||
+             [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            if parent_sha="$(git rev-parse "$head_sha^" 2>/dev/null)"; then
+              base_sha="$parent_sha"
+            else
+              base_sha="$head_sha"
+              force_global=true
+            fi
+          fi
+
+          code="$force_global"
+          global_code="$force_global"
+          nonworkspace_code="$force_global"
+          root_code="$force_global"
+          skills=false
+          workflow=false
+          audit_root=false
+          audit_expo=false
+          audit_next=false
+          audit_python=false
+          audit_app_generators=false
+          audit_browser_driver=false
+          audit_doc_runtime=false
+          audit_package_manager=false
+          audit_parquet_viewer=false
+          audit_skill_runtime=false
+          knip_browser_driver=false
+          knip_skill_runtime=false
+
+          while IFS= read -r -d '' file; do
+            case "$file" in
+              .github/actions/* | .github/workflows/*)
+                workflow=true
+                ;;
+            esac
+
+            case "$file" in
+              apps/* | packages/*)
+                if [[ "$file" != *.md ]]; then code=true; fi
+                ;;
+              skills/*)
+                code=true
+                nonworkspace_code=true
+                skills=true
+                ;;
+              scripts/*.ts)
+                code=true
+                nonworkspace_code=true
+                root_code=true
+                ;;
+              .dependency-cruiser.cjs | .npmrc | .nvmrc | biome.jsonc | knip.jsonc | package.json | pnpm-lock.yaml | pnpm-workspace.yaml | tsconfig.base.json | turbo.json)
+                code=true
+                global_code=true
+                nonworkspace_code=true
+                root_code=true
+                ;;
+              commitlint.config.js | lefthook.yml | tsconfig.scripts.json)
+                code=true
+                nonworkspace_code=true
+                root_code=true
+                ;;
+              infra/containers/sandbox/*.js | infra/containers/sandbox/*.json | infra/containers/sandbox/*.jsonc | infra/containers/sandbox/*.mjs | infra/containers/sandbox/*.ts | infra/containers/sandbox/*.tsx)
+                code=true
+                nonworkspace_code=true
+                ;;
+            esac
+
+            case "$file" in
+              pnpm-lock.yaml)
+                audit_root=true
+                ;;
+              infra/containers/sandbox/app-templates/expo/package.json | infra/containers/sandbox/app-templates/expo/pnpm-lock.yaml)
+                audit_expo=true
+                ;;
+              infra/containers/sandbox/app-templates/next/package.json | infra/containers/sandbox/app-templates/next/pnpm-lock.yaml)
+                audit_next=true
+                ;;
+              infra/containers/sandbox/requirements.txt)
+                audit_python=true
+                ;;
+              infra/containers/sandbox/app-generators/package.json | infra/containers/sandbox/app-generators/package-lock.json)
+                audit_app_generators=true
+                ;;
+              infra/containers/sandbox/browser-driver/*)
+                knip_browser_driver=true
+                case "$file" in
+                  */package.json | */package-lock.json) audit_browser_driver=true ;;
+                esac
+                ;;
+              infra/containers/sandbox/doc-runtime/package.json | infra/containers/sandbox/doc-runtime/package-lock.json)
+                audit_doc_runtime=true
+                ;;
+              infra/containers/sandbox/package-manager/package.json | infra/containers/sandbox/package-manager/package-lock.json)
+                audit_package_manager=true
+                ;;
+              infra/containers/sandbox/extension-overrides/parquet-viewer/package.json | infra/containers/sandbox/extension-overrides/parquet-viewer/package-lock.json)
+                audit_parquet_viewer=true
+                ;;
+              infra/containers/sandbox/skill-runtime/*)
+                knip_skill_runtime=true
+                case "$file" in
+                  */package.json | */package-lock.json) audit_skill_runtime=true ;;
+                esac
+                ;;
+            esac
+          done < <(git diff --name-only --diff-filter=ACMR -z "$base_sha" "$head_sha")
+
+          audit=false
+          for value in \
+            "$audit_root" \
+            "$audit_expo" \
+            "$audit_next" \
+            "$audit_python" \
+            "$audit_app_generators" \
+            "$audit_browser_driver" \
+            "$audit_doc_runtime" \
+            "$audit_package_manager" \
+            "$audit_parquet_viewer" \
+            "$audit_skill_runtime"; do
+            if [ "$value" = true ]; then audit=true; break; fi
+          done
+
+          {
+            echo "audit=$audit"
+            echo "audit_app_generators=$audit_app_generators"
+            echo "audit_browser_driver=$audit_browser_driver"
+            echo "audit_doc_runtime=$audit_doc_runtime"
+            echo "audit_expo=$audit_expo"
+            echo "audit_next=$audit_next"
+            echo "audit_package_manager=$audit_package_manager"
+            echo "audit_parquet_viewer=$audit_parquet_viewer"
+            echo "audit_python=$audit_python"
+            echo "audit_root=$audit_root"
+            echo "audit_skill_runtime=$audit_skill_runtime"
+            echo "base_sha=$base_sha"
+            echo "code=$code"
+            echo "global_code=$global_code"
+            echo "head_sha=$head_sha"
+            echo "knip_browser_driver=$knip_browser_driver"
+            echo "knip_skill_runtime=$knip_skill_runtime"
+            echo "nonworkspace_code=$nonworkspace_code"
+            echo "root_code=$root_code"
+            echo "skills=$skills"
+            echo "workflow=$workflow"
+          } >> "$GITHUB_OUTPUT"
+
+  workflow-lint:
+    name: Workflow lint
+    needs: changes
+    if: needs.changes.outputs.workflow == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Lint GitHub Actions and embedded shell
         uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
         with:
           pyflakes: false
           shellcheck: true
           version: 1.7.12
-      - name: Audit pnpm lockfiles
-        run: |
-          trivy fs --scanners vuln --include-dev-deps --severity MEDIUM,HIGH,CRITICAL --exit-code 1 pnpm-lock.yaml
-          trivy fs --scanners vuln --include-dev-deps --severity MEDIUM,HIGH,CRITICAL --exit-code 1 infra/containers/sandbox/app-templates/expo
-          trivy fs --scanners vuln --include-dev-deps --severity MEDIUM,HIGH,CRITICAL --exit-code 1 infra/containers/sandbox/app-templates/next
+
+  dependency-audit:
+    name: Dependency audit
+    needs: changes
+    if: needs.changes.outputs.audit == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Set up Node for npm lockfile audits
+        if: >-
+          needs.changes.outputs.audit_app_generators == 'true' ||
+          needs.changes.outputs.audit_browser_driver == 'true' ||
+          needs.changes.outputs.audit_doc_runtime == 'true' ||
+          needs.changes.outputs.audit_package_manager == 'true' ||
+          needs.changes.outputs.audit_parquet_viewer == 'true' ||
+          needs.changes.outputs.audit_skill_runtime == 'true'
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22.22.2
+      - name: Set up uv for Python lockfile audit
+        if: needs.changes.outputs.audit_python == 'true'
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          enable-cache: false
+          version: 0.11.28
+      - name: Set up Trivy for pnpm lockfile audits
+        if: >-
+          needs.changes.outputs.audit_root == 'true' ||
+          needs.changes.outputs.audit_expo == 'true' ||
+          needs.changes.outputs.audit_next == 'true'
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          cache: true
+          version: v0.72.0
+      - name: Audit root pnpm lockfile
+        if: needs.changes.outputs.audit_root == 'true'
+        run: trivy fs --scanners vuln --include-dev-deps --severity MEDIUM,HIGH,CRITICAL --exit-code 1 pnpm-lock.yaml
+      - name: Audit Expo template lockfile
+        if: needs.changes.outputs.audit_expo == 'true'
+        run: trivy fs --scanners vuln --include-dev-deps --severity MEDIUM,HIGH,CRITICAL --exit-code 1 infra/containers/sandbox/app-templates/expo
+      - name: Audit Next.js template lockfile
+        if: needs.changes.outputs.audit_next == 'true'
+        run: trivy fs --scanners vuln --include-dev-deps --severity MEDIUM,HIGH,CRITICAL --exit-code 1 infra/containers/sandbox/app-templates/next
       - name: Audit sandbox Python lockfile
+        if: needs.changes.outputs.audit_python == 'true'
         run: uvx --from pip-audit==2.10.1 pip-audit --disable-pip -r infra/containers/sandbox/requirements.txt
-      - name: Audit sandbox npm lockfiles
+      - name: Audit app generator lockfile
+        if: needs.changes.outputs.audit_app_generators == 'true'
+        run: npm --prefix infra/containers/sandbox/app-generators audit --audit-level=moderate
+      - name: Audit browser driver lockfile
+        if: needs.changes.outputs.audit_browser_driver == 'true'
+        run: npm --prefix infra/containers/sandbox/browser-driver audit --audit-level=moderate
+      - name: Audit document runtime lockfile
+        if: needs.changes.outputs.audit_doc_runtime == 'true'
+        run: npm --prefix infra/containers/sandbox/doc-runtime audit --audit-level=moderate
+      - name: Audit package manager lockfile
+        if: needs.changes.outputs.audit_package_manager == 'true'
+        run: npm --prefix infra/containers/sandbox/package-manager audit --audit-level=moderate
+      - name: Audit Parquet viewer overlay lockfile
+        if: needs.changes.outputs.audit_parquet_viewer == 'true'
+        run: npm --prefix infra/containers/sandbox/extension-overrides/parquet-viewer audit --audit-level=moderate
+      - name: Audit skill runtime lockfile
+        if: needs.changes.outputs.audit_skill_runtime == 'true'
+        run: npm --prefix infra/containers/sandbox/skill-runtime audit --audit-level=moderate
+
+  code-checks:
+    name: Affected code checks
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      BASE_SHA: ${{ needs.changes.outputs.base_sha }}
+      GLOBAL_CODE: ${{ needs.changes.outputs.global_code }}
+      HEAD_SHA: ${{ needs.changes.outputs.head_sha }}
+      SKILLS_CHANGED: ${{ needs.changes.outputs.skills }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.changes.outputs.head_sha }}
+      - uses: ./.github/actions/setup-repository
+      - name: Resolve dependency-aware workspace scope
+        id: workspace-scope
         run: |
-          npm --prefix infra/containers/sandbox/app-generators audit --audit-level=moderate
-          npm --prefix infra/containers/sandbox/browser-driver audit --audit-level=moderate
-          npm --prefix infra/containers/sandbox/doc-runtime audit --audit-level=moderate
-          npm --prefix infra/containers/sandbox/extension-overrides/parquet-viewer audit --audit-level=moderate
-          npm --prefix infra/containers/sandbox/package-manager audit --audit-level=moderate
-      - name: Validate pull request title
-        if: github.event_name == 'pull_request'
+          set -Eeuo pipefail
+          filters=()
+          if [ "$GLOBAL_CODE" != true ]; then
+            filters+=("--filter=...[$BASE_SHA...$HEAD_SHA]")
+            if [ "$SKILLS_CHANGED" = true ]; then
+              filters+=("--filter=...@cheatcode/skills")
+            fi
+          fi
+          scope="$(pnpm exec turbo run build "${filters[@]}" --dry-run=json)"
+          echo "packages=$(jq --compact-output '[.packages[] | select(. != "//")] | unique' <<< "$scope")" >> "$GITHUB_OUTPUT"
+          echo "directories=$(jq --compact-output '[.tasks[].directory] | unique' <<< "$scope")" >> "$GITHUB_OUTPUT"
+      - name: Lint all files under a changed global configuration
+        if: needs.changes.outputs.global_code == 'true'
+        run: pnpm lint
+      - name: Lint changed non-workspace files
+        if: needs.changes.outputs.global_code != 'true' && needs.changes.outputs.nonworkspace_code == 'true'
+        run: |
+          set -Eeuo pipefail
+          lintable=()
+          while IFS= read -r -d '' file; do
+            case "$file" in
+              *.css | *.js | *.json | *.jsonc | *.jsx | *.mjs | *.ts | *.tsx)
+                lintable+=("$file")
+                ;;
+            esac
+          done < <(git diff --name-only --diff-filter=ACMR -z "$BASE_SHA" "$HEAD_SHA")
+          if [ "${#lintable[@]}" -gt 0 ]; then
+            pnpm exec biome check --error-on-warnings --no-errors-on-unmatched "${lintable[@]}"
+          fi
+      - name: Lint, typecheck, and build affected workspaces
+        if: steps.workspace-scope.outputs.packages != '[]'
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: printf '%s\n' "$PR_TITLE" | pnpm exec commitlint
-      - run: pnpm lint
-      - run: pnpm architecture:check
-      - run: pnpm deadcode
-      - run: pnpm typecheck
-      - run: pnpm build
-        env:
-          # Static compilation must never expose a real Clerk Backend API credential
-          # to pull-request code. These syntactically valid, non-deployed values
-          # exercise the development-key branch without authenticating anywhere.
           CLERK_SECRET_KEY: sk_test_static_checks_do_not_authenticate
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_c3RhdGljLWNoZWNrcy0wMC5jbGVyay5hY2NvdW50cy5kZXYk
           NEXT_PUBLIC_GATEWAY_URL: ${{ vars.NEXT_PUBLIC_GATEWAY_URL }}
           NEXT_PUBLIC_PREVIEW_HOSTNAME: trycheatcode.com
           NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
-          # Never expose a future remote-cache credential to pull-request code.
-          TURBO_TOKEN: ${{ github.event_name == 'push' && secrets.TURBO_TOKEN || '' }}
           TURBO_TEAM: cheatcode
+          TURBO_TOKEN: ${{ github.event_name == 'push' && secrets.TURBO_TOKEN || '' }}
+        run: |
+          set -Eeuo pipefail
+          filters=()
+          if [ "$GLOBAL_CODE" != true ]; then
+            filters+=("--filter=...[$BASE_SHA...$HEAD_SHA]")
+            if [ "$SKILLS_CHANGED" = true ]; then
+              filters+=("--filter=...@cheatcode/skills")
+            fi
+          fi
+          pnpm exec turbo run lint typecheck build "${filters[@]}"
+      - name: Typecheck operational scripts
+        if: needs.changes.outputs.root_code == 'true'
+        run: pnpm typecheck:scripts
+      - name: Check affected architecture boundaries
+        if: steps.workspace-scope.outputs.directories != '[]'
+        env:
+          DIRECTORIES: ${{ steps.workspace-scope.outputs.directories }}
+        run: |
+          set -Eeuo pipefail
+          mapfile -t directories < <(jq --raw-output '.[]' <<< "$DIRECTORIES")
+          pnpm exec dependency-cruise \
+            --config .dependency-cruiser.cjs \
+            --ts-config tsconfig.base.json \
+            --exclude '(^|/)(dist|\.next|\.turbo|node_modules)/' \
+            "${directories[@]}"
+      - name: Check dead code
+        env:
+          KNIP_BROWSER_DRIVER: ${{ needs.changes.outputs.knip_browser_driver }}
+          KNIP_SKILL_RUNTIME: ${{ needs.changes.outputs.knip_skill_runtime }}
+          PACKAGES: ${{ steps.workspace-scope.outputs.packages }}
+          ROOT_CODE: ${{ needs.changes.outputs.root_code }}
+        run: |
+          set -Eeuo pipefail
+          if [ "$GLOBAL_CODE" = true ] || [ "$ROOT_CODE" = true ]; then
+            pnpm deadcode
+            exit 0
+          fi
+
+          workspaces=()
+          while IFS= read -r package; do
+            workspaces+=(--workspace "$package")
+          done < <(jq --raw-output '.[]' <<< "$PACKAGES")
+          if [ "$KNIP_BROWSER_DRIVER" = true ]; then
+            workspaces+=(--workspace @cheatcode/sandbox-browser-driver)
+          fi
+          if [ "$KNIP_SKILL_RUNTIME" = true ]; then
+            workspaces+=(--workspace @cheatcode/sandbox-skills-runtime)
+          fi
+          if [ "${#workspaces[@]}" -gt 0 ]; then
+            pnpm exec knip --cache "${workspaces[@]}"
+          fi
+
+  static-checks:
+    name: static-checks
+    needs: [changes, workflow-lint, dependency-audit, code-checks]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require every applicable check to pass
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CODE_RESULT: ${{ needs.code-checks.result }}
+          DEPENDENCY_AUDIT_RESULT: ${{ needs.dependency-audit.result }}
+          WORKFLOW_LINT_RESULT: ${{ needs.workflow-lint.result }}
+        run: |
+          set -Eeuo pipefail
+          for result in \
+            "$CHANGES_RESULT" \
+            "$CODE_RESULT" \
+            "$DEPENDENCY_AUDIT_RESULT" \
+            "$WORKFLOW_LINT_RESULT"; do
+            case "$result" in
+              success | skipped) ;;
+              *) exit 1 ;;
+            esac
+          done

--- a/README.md
+++ b/README.md
@@ -91,18 +91,28 @@ pnpm cloudflare:set-hyperdrive -- \
 
 ## Production deployment
 
-The GitHub static-check workflow runs lint, typecheck, and build gates on pull
-requests and `main`. Vercel's Git integration deploys `apps/web` from the
-repository. Deploy the Cloudflare backend Workers from a reviewed checkout with:
+The required `static-checks` workflow classifies each change before allocating
+the heavier runners. It runs dependency-aware lint, typecheck, build,
+architecture, dead-code, workflow, and lockfile checks only for affected
+surfaces and their workspace dependents. Root build configuration changes still
+run the complete gate.
+
+Vercel's Git integration deploys `apps/web` from the repository. Its native
+monorepo dependency graph skips builds when neither the web app nor one of its
+declared workspace dependencies changed. Deploy the Cloudflare backend Workers
+from a clean reviewed checkout with:
 
 ```bash
 pnpm cloudflare:deploy
 ```
 
-The deploy command refuses a dirty tree, a non-`main` branch, or a checkout that
-does not exactly match `origin/main`. It injects that immutable commit SHA into
-every Worker and deploys the gateway last, after its agent and webhooks service
-dependencies share the same release identity.
+The deploy command refuses a dirty tree, reads the release SHA currently bound
+to each Worker, and uses the same workspace graph to deploy only affected
+Workers. The agent, webhooks, and gateway Workers remain an atomic release set
+because gateway readiness requires one shared release identity; the gateway is
+deployed last. The independent preview proxy deploys only when its dependency
+closure changed. If Cloudflare release metadata is unavailable or inconsistent,
+the command safely redeploys the relevant set instead of guessing.
 
 There is no second release orchestrator, compatibility deploy command, or hidden
 workspace-reconciliation command. Schema migrations, Worker deployment, and

--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -31,6 +31,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "typescript": "catalog:",
     "wrangler": "catalog:"

--- a/apps/gateway-worker/package.json
+++ b/apps/gateway-worker/package.json
@@ -25,6 +25,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "typescript": "catalog:",
     "wrangler": "catalog:"

--- a/apps/preview-proxy/package.json
+++ b/apps/preview-proxy/package.json
@@ -20,6 +20,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "typescript": "catalog:",
     "wrangler": "catalog:"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "zustand": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@tailwindcss/postcss": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/apps/webhooks-worker/package.json
+++ b/apps/webhooks-worker/package.json
@@ -26,6 +26,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "typescript": "catalog:",
     "wrangler": "catalog:"

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,8 +1,9 @@
 {
   "$schema": "./node_modules/knip/schema.json",
-  // CLI launched by operational TypeScript through `pnpm exec wrangler`; Knip
-  // cannot infer child-process binary dependencies from argument arrays.
-  "ignoreDependencies": ["cloudflare", "wrangler"],
+  // The shared compiler config is declared for the workspace graph but loaded
+  // through tsconfig `extends` paths. Cloudflare CLIs are launched by operational
+  // TypeScript. Knip cannot infer either dependency shape.
+  "ignoreDependencies": ["@cheatcode/tsconfig", "cloudflare", "wrangler"],
   "workspaces": {
     ".": {
       // Skill TypeScript files are executable snapshot entrypoints discovered by
@@ -16,14 +17,16 @@
       "entry": ["drizzle.config.ts", "src/schema/drizzle.ts"]
     },
     "infra/containers/sandbox/browser-driver": {
-      // Stagehand resolves these peer packages dynamically for its local
-      // Playwright backend, so no source-level import is visible to Knip.
+      // The snapshot launches this service from start-browser-driver.sh.
+      "entry": ["server.js"],
+      // Stagehand resolves these peer packages dynamically inside the snapshot,
+      // so a clean root-only CI install exposes no source-level import to Knip.
       "ignoreDependencies": ["playwright-core", "zod"]
     },
     "infra/containers/sandbox/skill-runtime": {
       "entry": ["bin/*.mjs"],
       // Snapshot launchers resolve these executables by installed binary name;
-      // Knip cannot infer dependencies or binaries passed to child_process.
+      // a root-only install cannot expose those child-process edges to Knip.
       "ignoreDependencies": ["agent-browser", "tsx"],
       "ignoreBinaries": ["agent-browser"]
     }

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -38,6 +38,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,6 +22,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/byok/package.json
+++ b/packages/byok/package.json
@@ -24,6 +24,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/composio/package.json
+++ b/packages/composio/package.json
@@ -21,6 +21,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -29,6 +29,7 @@
     "pg": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@types/node": "catalog:",
     "@types/pg": "catalog:",
     "drizzle-kit": "catalog:",

--- a/packages/durable-storage/package.json
+++ b/packages/durable-storage/package.json
@@ -20,6 +20,7 @@
     "@cheatcode/types": "workspace:*"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -42,6 +42,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@cloudflare/workers-types": "catalog:",
     "@types/node": "catalog:",
     "typescript": "catalog:"

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -20,6 +20,7 @@
     "@cheatcode/types": "workspace:*"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/preview-bridge/package.json
+++ b/packages/preview-bridge/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/sandbox-contracts/package.json
+++ b/packages/sandbox-contracts/package.json
@@ -22,6 +22,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@types/node": "catalog:",
     "tsx": "catalog:",
     "typescript": "catalog:"

--- a/packages/tools-browser/package.json
+++ b/packages/tools-browser/package.json
@@ -22,6 +22,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/tools-code/package.json
+++ b/packages/tools-code/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/tools-data/package.json
+++ b/packages/tools-data/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/tools-docs/package.json
+++ b/packages/tools-docs/package.json
@@ -22,6 +22,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/tools-media/package.json
+++ b/packages/tools-media/package.json
@@ -23,6 +23,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/tools-research/package.json
+++ b/packages/tools-research/package.json
@@ -21,6 +21,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -45,6 +45,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "typescript": "catalog:"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,6 +40,7 @@
     "streamdown": "catalog:"
   },
   "devDependencies": {
+    "@cheatcode/tsconfig": "workspace:*",
     "@types/react": "catalog:",
     "react": "catalog:",
     "typescript": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260716.1
@@ -354,6 +357,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260716.1
@@ -385,6 +391,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260716.1
@@ -476,6 +485,9 @@ importers:
         specifier: 'catalog:'
         version: 5.0.14(@types/react@19.2.17)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.3.2
@@ -540,6 +552,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260716.1
@@ -610,6 +625,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -626,6 +644,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -645,6 +666,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -667,6 +691,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -680,6 +707,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -702,6 +732,9 @@ importers:
         specifier: 'catalog:'
         version: 8.22.0
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -721,6 +754,9 @@ importers:
         specifier: workspace:*
         version: link:../types
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260716.1
@@ -737,6 +773,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
         version: 5.20260716.1
@@ -753,12 +792,18 @@ importers:
         specifier: workspace:*
         version: link:../types
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
 
   packages/preview-bridge:
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -775,12 +820,18 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
 
   packages/skills:
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -803,6 +854,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -822,6 +876,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -841,6 +898,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -857,6 +917,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -876,6 +939,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -889,6 +955,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -908,6 +977,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -930,6 +1002,9 @@ importers:
         specifier: 'catalog:'
         version: 2.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(supports-color@10.2.2)
     devDependencies:
+      '@cheatcode/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.17

--- a/scripts/deploy-cloudflare.ts
+++ b/scripts/deploy-cloudflare.ts
@@ -1,20 +1,67 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { z } from "zod";
 import { runCapturedBoundedCommand } from "./bounded-command";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const COMMAND_TIMEOUT_MS = 5 * 60 * 1_000;
 const MAX_OUTPUT_BYTES = 2 * 1_024 * 1_024;
 const RELEASE_SHA_PATTERN = /^[0-9a-f]{40}$/u;
-const WORKERS = [
-  "apps/agent-worker/wrangler.jsonc",
-  "apps/webhooks-worker/wrangler.jsonc",
-  "apps/preview-proxy/wrangler.jsonc",
-  "apps/gateway-worker/wrangler.jsonc",
-] as const;
+const PNPM = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+interface WorkerTarget {
+  configPath: string;
+  packageName: string;
+}
+
+const AGENT_WORKER = {
+  configPath: "apps/agent-worker/wrangler.jsonc",
+  packageName: "@cheatcode/agent-worker",
+} as const satisfies WorkerTarget;
+const WEBHOOKS_WORKER = {
+  configPath: "apps/webhooks-worker/wrangler.jsonc",
+  packageName: "@cheatcode/webhooks-worker",
+} as const satisfies WorkerTarget;
+const GATEWAY_WORKER = {
+  configPath: "apps/gateway-worker/wrangler.jsonc",
+  packageName: "@cheatcode/gateway-worker",
+} as const satisfies WorkerTarget;
+const PREVIEW_PROXY = {
+  configPath: "apps/preview-proxy/wrangler.jsonc",
+  packageName: "@cheatcode/preview-proxy",
+} as const satisfies WorkerTarget;
+const CORE_WORKERS = [AGENT_WORKER, WEBHOOKS_WORKER, GATEWAY_WORKER] as const;
+const ALL_WORKERS = [...CORE_WORKERS, PREVIEW_PROXY] as const;
+const CORE_PACKAGE_NAMES = new Set(CORE_WORKERS.map((worker) => worker.packageName));
+
+const deploymentsSchema = z.array(
+  z.object({
+    versions: z.array(
+      z.object({
+        percentage: z.number(),
+        version_id: z.string().min(1),
+      }),
+    ),
+  }),
+);
+const versionSchema = z.object({
+  resources: z.object({
+    bindings: z.array(
+      z.object({
+        name: z.string(),
+        text: z.string().optional(),
+      }),
+    ),
+  }),
+});
+const turboScopeSchema = z.object({ packages: z.array(z.string()) });
 
 function writeLine(line = ""): void {
   process.stdout.write(`${line}\n`);
+}
+
+function writeWarning(message: string): void {
+  process.stderr.write(`Warning: ${message}\n`);
 }
 
 async function run(command: string, args: readonly string[]): Promise<string> {
@@ -34,39 +81,167 @@ async function reviewedReleaseSha(): Promise<string> {
   const status = await run("git", ["status", "--porcelain"]);
   if (status) throw new Error("Cloudflare deployment requires a clean worktree.");
 
-  const branch = await run("git", ["branch", "--show-current"]);
-  if (branch !== "main") throw new Error("Cloudflare deployment is allowed only from main.");
-
-  await run("git", ["fetch", "--quiet", "origin", "main"]);
-  const [head, remoteMain] = await Promise.all([
-    run("git", ["rev-parse", "HEAD"]),
-    run("git", ["rev-parse", "origin/main"]),
-  ]);
-  if (head !== remoteMain) throw new Error("Local main must exactly match origin/main.");
+  const head = await run("git", ["rev-parse", "HEAD"]);
   if (!RELEASE_SHA_PATTERN.test(head)) throw new Error("Git returned an invalid release SHA.");
   return head;
 }
 
-async function deployWorker(configPath: string, releaseSha: string): Promise<void> {
-  writeLine(`Deploying ${configPath} at ${releaseSha}.`);
-  const output = await run(process.platform === "win32" ? "pnpm.cmd" : "pnpm", [
+function latestVersionId(input: unknown): string {
+  const deployments = deploymentsSchema.parse(input);
+  const deployment = deployments.at(-1);
+  const version = deployment?.versions.find((candidate) => candidate.percentage === 100);
+  if (!version) throw new Error("Cloudflare returned no fully deployed Worker version.");
+  return version.version_id;
+}
+
+async function deployedReleaseSha(worker: WorkerTarget): Promise<string | null> {
+  try {
+    const deployments = JSON.parse(
+      await run(PNPM, [
+        "exec",
+        "wrangler",
+        "deployments",
+        "list",
+        "--config",
+        worker.configPath,
+        "--json",
+      ]),
+    );
+    const versionId = latestVersionId(deployments);
+    const version = versionSchema.parse(
+      JSON.parse(
+        await run(PNPM, [
+          "exec",
+          "wrangler",
+          "versions",
+          "view",
+          versionId,
+          "--config",
+          worker.configPath,
+          "--json",
+        ]),
+      ),
+    );
+    const releaseSha = version.resources.bindings.find(
+      (binding) => binding.name === "CHEATCODE_RELEASE_SHA",
+    )?.text;
+    return releaseSha && RELEASE_SHA_PATTERN.test(releaseSha) ? releaseSha : null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    writeWarning(`Could not read ${worker.packageName} release metadata: ${message}`);
+    return null;
+  }
+}
+
+async function isAncestor(baseSha: string, headSha: string): Promise<boolean> {
+  const result = await runCapturedBoundedCommand(
+    "git",
+    ["merge-base", "--is-ancestor", baseSha, headSha],
+    { cwd: ROOT, maxOutputBytes: MAX_OUTPUT_BYTES, timeoutMs: COMMAND_TIMEOUT_MS },
+  );
+  if (result.code === 0) return true;
+  if (result.code === 1) return false;
+  process.stderr.write(result.output);
+  throw new Error(`git merge-base exited with status ${result.code}.`);
+}
+
+async function changedFiles(baseSha: string, headSha: string): Promise<readonly string[]> {
+  const output = await run("git", ["diff", "--name-only", "--diff-filter=ACMR", baseSha, headSha]);
+  return output ? output.split("\n") : [];
+}
+
+function turboFilters(files: readonly string[], baseSha: string, headSha: string): string[] {
+  const filters = [`--filter=...[${baseSha}...${headSha}]`];
+  const hasSkillSourceChange = files.some(
+    (file) => file.startsWith("skills/") || file === "scripts/build-skills.ts",
+  );
+  if (hasSkillSourceChange) filters.push("--filter=...@cheatcode/skills");
+  return filters;
+}
+
+async function affectedPackages(baseSha: string, headSha: string): Promise<Set<string> | null> {
+  if (!(await isAncestor(baseSha, headSha))) return null;
+  const files = await changedFiles(baseSha, headSha);
+  const output = await run(PNPM, [
+    "exec",
+    "turbo",
+    "run",
+    "build",
+    ...turboFilters(files, baseSha, headSha),
+    "--dry-run=json",
+  ]);
+  const scope = turboScopeSchema.parse(JSON.parse(output));
+  return new Set(scope.packages.filter((packageName) => packageName !== "//"));
+}
+
+function sharedCoreBaseline(releases: ReadonlyMap<string, string | null>): string | null {
+  const values = CORE_WORKERS.map((worker) => releases.get(worker.packageName) ?? null);
+  const first = values[0];
+  return first && values.every((value) => value === first) ? first : null;
+}
+
+async function shouldDeploy(
+  baselineSha: string | null,
+  releaseSha: string,
+  packageNames: ReadonlySet<string>,
+): Promise<boolean> {
+  if (!baselineSha) return true;
+  const packages = await affectedPackages(baselineSha, releaseSha);
+  if (!packages) return true;
+  return [...packageNames].some((packageName) => packages.has(packageName));
+}
+
+async function deployWorker(worker: WorkerTarget, releaseSha: string): Promise<void> {
+  writeLine(`Deploying ${worker.packageName} at ${releaseSha}.`);
+  const output = await run(PNPM, [
     "exec",
     "wrangler",
     "deploy",
     "--config",
-    configPath,
+    worker.configPath,
     "--var",
     `CHEATCODE_RELEASE_SHA:${releaseSha}`,
   ]);
   writeLine(output);
 }
 
+async function deploymentPlan(releaseSha: string): Promise<readonly WorkerTarget[]> {
+  const deployedEntries = await Promise.all(
+    ALL_WORKERS.map(
+      async (worker) => [worker.packageName, await deployedReleaseSha(worker)] as const,
+    ),
+  );
+  const releases = new Map(deployedEntries);
+  const deployCore = await shouldDeploy(
+    sharedCoreBaseline(releases),
+    releaseSha,
+    CORE_PACKAGE_NAMES,
+  );
+  const previewBaseline = releases.get(PREVIEW_PROXY.packageName) ?? null;
+  const deployPreview = await shouldDeploy(
+    previewBaseline,
+    releaseSha,
+    new Set([PREVIEW_PROXY.packageName]),
+  );
+
+  if (deployCore && deployPreview)
+    return [AGENT_WORKER, WEBHOOKS_WORKER, PREVIEW_PROXY, GATEWAY_WORKER];
+  if (deployCore) return CORE_WORKERS;
+  if (deployPreview) return [PREVIEW_PROXY];
+  return [];
+}
+
 async function main(): Promise<void> {
   const releaseSha = await reviewedReleaseSha();
-  for (const configPath of WORKERS) {
-    await deployWorker(configPath, releaseSha);
+  const workers = await deploymentPlan(releaseSha);
+  if (workers.length === 0) {
+    writeLine(
+      `No Cloudflare Worker changes since the deployed releases; ${releaseSha} is a no-op.`,
+    );
+    return;
   }
-  writeLine(`Cloudflare Workers are deployed at ${releaseSha}.`);
+  for (const worker of workers) await deployWorker(worker, releaseSha);
+  writeLine(`Deployed ${workers.length} affected Cloudflare Worker(s) at ${releaseSha}.`);
 }
 
 await main();


### PR DESCRIPTION
## Summary
- Route CI by changed surface and workspace dependency closure.
- Preserve one required `static-checks` result while skipping inapplicable jobs.
- Skip unchanged Cloudflare Workers and rely on Vercel native monorepo skipping.
- Declare shared TypeScript configuration dependencies explicitly.

## Decisions
- Core agent, webhooks, and gateway Workers deploy as one release set because readiness requires a shared SHA.
- The preview proxy is independent and can deploy alone.
- Missing or inconsistent release metadata fails safe by redeploying the relevant set.
- Root build configuration changes retain the complete validation gate.

## Validation
- [x] Actionlint and ShellCheck
- [x] Biome lint
- [x] TypeScript typecheck
- [x] Dependency-cruiser architecture check
- [x] Knip dead-code check
- [x] Production build
- [x] Root Trivy lockfile scan
- [x] Scoped Knip checks for web, Worker, and sandbox runtime
- [x] Historical frontend/backend dependency-routing checks

## Review order
1. `.github/workflows/static-checks.yml`
2. `scripts/deploy-cloudflare.ts`
3. Workspace manifest dependency declarations and README