### PR TITLE
ci: remove duplicate post-merge checks

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -2,8 +2,6 @@ name: Static Checks
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- run the protected static-check gate once on pull requests
- avoid repeating the same checks after the reviewed commit reaches `main`
- retain the required always-reporting `static-checks` status

## Validation

- `actionlint -shellcheck=/opt/homebrew/bin/shellcheck .github/workflows/static-checks.yml`
- `pnpm exec biome check .github/workflows/static-checks.yml`
- `git diff --check`

## Expected selective run

This workflow-only change should run change detection, workflow lint, and the final required aggregator. It should skip dependency audit and repository code checks.