### PR TITLE
ci: skip unaffected Vercel builds

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "pnpm exec turbo run build --filter=@cheatcode/web"
+  "buildCommand": "pnpm exec turbo run build --filter=@cheatcode/web",
+  "ignoreCommand": "B=${VERCEL_GIT_PREVIOUS_SHA:-HEAD^};git -C ../.. diff --quiet $B HEAD -- . ':(exclude).github/**' ':(exclude)docs/**' ':(exclude)**/*.md'||npx -y turbo@2.10.5 query affected --cwd ../.. --packages @cheatcode/web --base $B --head HEAD --exit-code"
 }


### PR DESCRIPTION
## Summary
- add an ignored-build fallback for Vercel using the pinned Turbo affected graph
- skip documentation and GitHub-workflow-only commits before graph evaluation
- fail open to a deployment if affected detection errors

## Validation
- workflow-only merge exits 0 (skip)
- backend-only historical change leaves `@cheatcode/web` unaffected
- web-only historical change marks `@cheatcode/web` affected
- `pnpm exec biome check apps/web/vercel.json`
- `git diff --check`