### PR TITLE
ci(vercel): disable preview deployments

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": {
+      "*": false,
+      "main": true
+    }
+  },
   "buildCommand": "pnpm exec turbo run build --filter=@cheatcode/web",
   "ignoreCommand": "B=${VERCEL_GIT_PREVIOUS_SHA:-HEAD^};git -C ../.. diff --quiet $B HEAD -- . ':(exclude).github/**' ':(exclude)docs/**' ':(exclude)**/*.md'||npx -y turbo@2.10.5 query affected --cwd ../.. --packages @cheatcode/web --base $B --head HEAD --exit-code"
 }


### PR DESCRIPTION
## Summary
- deploy the web app automatically only from `main`
- prevent pull requests and dependency branches from creating noisy or failing Vercel Preview deployments
- retain the affected-build guard for production commits

## Decision
Use Vercel's checked-in `git.deploymentEnabled` branch rules so the behavior is versioned with the project. `*` disables every branch, while the explicit `main: true` rule preserves production deployments because Vercel treats any matching `true` rule as enabled.

## Scope
- `apps/web/vercel.json`

## Validation
- `jq empty apps/web/vercel.json`
- `pnpm exec biome check apps/web/vercel.json`
- `git diff --check`
