### PR TITLE
ci(vercel): cover nested preview branches

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -3,7 +3,7 @@
   "framework": "nextjs",
   "git": {
     "deploymentEnabled": {
-      "*": false,
+      "**": false,
       "main": true
     }
   },


### PR DESCRIPTION
## Summary
- change the Preview deployment deny pattern from `*` to `**`
- cover branch names containing `/`, including `dependabot/...` and `ci/...`
- preserve automatic Production deployments from `main`

## Reason
Vercel uses minimatch branch patterns. A single star does not cross slash boundaries, so namespaced branches could still trigger the noisy Preview deployments this rule is intended to stop.

## Validation
- `jq empty apps/web/vercel.json`
- `pnpm exec biome check apps/web/vercel.json`
- `git diff --check`
- controlled namespaced branch push
