### PR TITLE
fix: fetch Worker deployment history

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout reviewed release
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- fetch complete Git history in the manual production Worker deployment
- allow affected-package planning to compare the deployed release SHA with the reviewed release

## Decision
Keep affected-only deployment intact and provide the history it requires instead of forcing every Worker to redeploy.

## Validation
- `actionlint .github/workflows/deploy-cloudflare.yml`
- `git diff --check`