### PR TITLE
fix: build Workers before deployment

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -35,6 +35,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build Worker release
+        run: >-
+          pnpm exec turbo run build
+          --filter=@cheatcode/agent-worker
+          --filter=@cheatcode/webhooks-worker
+          --filter=@cheatcode/gateway-worker
+          --filter=@cheatcode/preview-proxy
+
       - name: Deploy affected Workers
         run: pnpm cloudflare:deploy
         env:


### PR DESCRIPTION
## Summary
- build all four Worker targets and their workspace dependencies on the clean release runner
- ensure Wrangler resolves compiled package exports before publishing

## Decision
Build only Cloudflare deployables and their transitive dependencies, leaving the independently deployed web app out of the Worker release job.

## Validation
- `actionlint .github/workflows/deploy-cloudflare.yml`
- `pnpm exec turbo run build --filter=@cheatcode/agent-worker --filter=@cheatcode/webhooks-worker --filter=@cheatcode/gateway-worker --filter=@cheatcode/preview-proxy`
- `git diff --check`