### PR TITLE
fix(agent): preserve uploads during app bootstrap

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -40,9 +40,11 @@ the project path and content digest. R2 stores immutable bytes under the existin
 small current/version namespace records and mirrors the current version to
 `/workspace/<workspaceSlug>/uploads/` on the user's persistent Daytona volume before exposing it.
 An exact replay is idempotent; uploading new bytes at the same path creates a retained version and
-updates the working copy. Project deletion removes the namespace during fenced workspace cleanup
-and the existing resource-deletion prefix sweep removes every immutable object. Account deletion
-clears both through the existing account state and R2 lifecycle phases.
+updates the working copy. First-run app scaffolding preserves the `uploads/` directory, and restored
+template projects reuse their persistent dependency installation instead of rebuilding the
+workspace. Project deletion removes the namespace during fenced workspace cleanup and the existing
+resource-deletion prefix sweep removes every immutable object. Account deletion clears both through
+the existing account state and R2 lifecycle phases.
 
 Run creation validates the gateway payload with the shared `CreateRunSchema` from
 `packages/types` before selecting the run-scoped `AgentRun` Durable Object. The

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -160,11 +160,7 @@ export async function runAppBuilder(
   if (await hasImportedAppWorkspace(sandbox, workspace.dir)) {
     return restoreImportedWorkspace(workspaceOptions);
   }
-  const shouldBootstrap = !(await hasExistingAppBuilderWorkspace(
-    sandbox,
-    workspace.dir,
-    workspace.mobile,
-  ));
+  const shouldBootstrap = !(await hasExistingAppBuilderWorkspace(sandbox, workspace.dir));
   if (shouldBootstrap && input.importRepoUrl) {
     return importRepoWorkspace({ ...workspaceOptions, repoUrl: input.importRepoUrl });
   }
@@ -200,13 +196,15 @@ async function prepareTemplateWorkspace(
   setRunStage(mobile ? "Preparing the Expo workspace." : "Preparing the Next.js workspace.");
   if (!shouldBootstrap) {
     setRunStage("Restoring the app workspace.");
-    await installAppBuilderDependencies(sandbox, logger, workspace.dir, mobile);
+    if (!(await hasInstalledAppBuilderDependencies(sandbox, workspace.dir))) {
+      await installAppBuilderDependencies(sandbox, logger, workspace.dir, mobile);
+    }
     if (mobile) {
       await ensureExpoWebSupport(sandbox, workspace.dir);
     }
     return;
   }
-  await resetAppBuilderDirectory(sandbox, workspace.dir);
+  await resetTemplateAppBuilderDirectory(sandbox, workspace.dir);
   throwIfRunCanceled(options.abortSignal);
   if (mobile) {
     await scaffoldExpoApp(sandbox, logger, workspace.dir);
@@ -583,12 +581,28 @@ async function startAppBuilderDevServer(
 async function hasExistingAppBuilderWorkspace(
   sandbox: ProjectSandboxStub,
   dir: string,
-  mobile: boolean,
 ): Promise<boolean> {
-  const appDir = mobile ? "app" : "src/app";
+  const appDirs = ["src/app", "app"];
   const result = await executeShellTerminal(
     {
-      command: `test -f ${dir}/package.json && test -d ${dir}/${appDir}`,
+      command:
+        `test -f ${dir}/package.json && ` +
+        `(test -d ${dir}/${appDirs[0]} || test -d ${dir}/${appDirs[1]})`,
+      cwd: "/workspace",
+      timeoutMs: 10_000,
+    },
+    { sandbox },
+  );
+  return result.success;
+}
+
+async function hasInstalledAppBuilderDependencies(
+  sandbox: ProjectSandboxStub,
+  dir: string,
+): Promise<boolean> {
+  const result = await executeShellTerminal(
+    {
+      command: `test -d ${dir}/node_modules/.pnpm`,
       cwd: "/workspace",
       timeoutMs: 10_000,
     },
@@ -600,6 +614,36 @@ async function hasExistingAppBuilderWorkspace(
 async function resetAppBuilderDirectory(sandbox: ProjectSandboxStub, dir: string): Promise<void> {
   await executeShellExec(
     { command: ["rm", "-rf", dir], cwd: "/workspace", timeoutMs: 120_000 },
+    { sandbox },
+  );
+}
+
+async function resetTemplateAppBuilderDirectory(
+  sandbox: ProjectSandboxStub,
+  dir: string,
+): Promise<void> {
+  await executeShellExec(
+    {
+      command: [
+        "find",
+        dir,
+        "-mindepth",
+        "1",
+        "-maxdepth",
+        "1",
+        "!",
+        "-name",
+        "uploads",
+        "-exec",
+        "rm",
+        "-rf",
+        "--",
+        "{}",
+        "+",
+      ],
+      cwd: "/workspace",
+      timeoutMs: 120_000,
+    },
     { sandbox },
   );
 }


### PR DESCRIPTION
## Summary
- preserves `/uploads` when the first template workspace is scaffolded
- recognizes both `src/app` and `app` Expo Router layouts so valid projects are restored
- reuses an existing pnpm installation and only installs when `node_modules/.pnpm` is missing

## Context
Direct production QA showed a successful upload and visible composer chip, followed by an app-builder run that deleted the uploaded file and performed a redundant dependency install. The install then failed before the model could read the file.

## Decisions
| Decision | Choice | Reasoning |
|---|---|---|
| Upload persistence | Exclude `uploads` from first-run template cleanup | The project volume and R2 file record remain authoritative across chats |
| Workspace detection | Accept `src/app` and `app` | Both supported template layouts are valid and must not trigger destructive bootstrap |
| Dependency restore | Install only when the pnpm virtual store is absent | Persistent project workspaces should not reinstall on every prompt |

## Edge cases
- first prompt uploads survive template scaffolding
- existing Expo projects using either Router layout avoid destructive reset
- missing dependency stores still take the existing install/recovery path
- imported repository reset behavior is unchanged

## Verification
- [x] `pnpm turbo typecheck lint build` — 76/76 tasks passed
- [x] production migration verifier already passes against the single migration file
- [ ] repeat direct production upload, later-reference, and agent-read QA after deploy

No Linear issue or plan document is associated with this production QA fix.