### PR TITLE
fix(agent): repair incomplete app dependencies

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -41,10 +41,10 @@ small current/version namespace records and mirrors the current version to
 `/workspace/<workspaceSlug>/uploads/` on the user's persistent Daytona volume before exposing it.
 An exact replay is idempotent; uploading new bytes at the same path creates a retained version and
 updates the working copy. First-run app scaffolding preserves the `uploads/` directory, and restored
-template projects reuse their persistent dependency installation instead of rebuilding the
-workspace. Project deletion removes the namespace during fenced workspace cleanup and the existing
-resource-deletion prefix sweep removes every immutable object. Account deletion clears both through
-the existing account state and R2 lifecycle phases.
+template projects reuse a complete persistent dependency installation or repair an interrupted one
+instead of rebuilding the workspace. Project deletion removes the namespace during fenced workspace
+cleanup and the existing resource-deletion prefix sweep removes every immutable object. Account
+deletion clears both through the existing account state and R2 lifecycle phases.
 
 Run creation validates the gateway payload with the shared `CreateRunSchema` from
 `packages/types` before selecting the run-scoped `AgentRun` Durable Object. The

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder-scaffold.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder-scaffold.ts
@@ -84,13 +84,13 @@ export async function installAppBuilderDependencies(
   dir: string,
   mobile = false,
 ): Promise<void> {
-  const networkTimeoutMs = mobile ? 300_000 : 120_000;
+  const installTimeoutMs = mobile ? 300_000 : 120_000;
   try {
     await executeShellExec(
       {
         command: ["pnpm", "install", "--frozen-lockfile", "--offline"],
         cwd: dir,
-        timeoutMs: 120_000,
+        timeoutMs: installTimeoutMs,
       },
       { sandbox },
     );
@@ -111,7 +111,7 @@ export async function installAppBuilderDependencies(
         "4",
       ],
       cwd: dir,
-      timeoutMs: networkTimeoutMs,
+      timeoutMs: installTimeoutMs,
     },
     { sandbox },
   );

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -196,7 +196,7 @@ async function prepareTemplateWorkspace(
   setRunStage(mobile ? "Preparing the Expo workspace." : "Preparing the Next.js workspace.");
   if (!shouldBootstrap) {
     setRunStage("Restoring the app workspace.");
-    if (!(await hasInstalledAppBuilderDependencies(sandbox, workspace.dir))) {
+    if (!(await hasInstalledAppBuilderDependencies(sandbox, workspace.dir, mobile))) {
       await installAppBuilderDependencies(sandbox, logger, workspace.dir, mobile);
     }
     if (mobile) {
@@ -599,10 +599,19 @@ async function hasExistingAppBuilderWorkspace(
 async function hasInstalledAppBuilderDependencies(
   sandbox: ProjectSandboxStub,
   dir: string,
+  mobile: boolean,
 ): Promise<boolean> {
+  const requiredPaths = mobile
+    ? [
+        "node_modules/.pnpm",
+        "node_modules/@expo/metro-runtime",
+        "node_modules/react-dom",
+        "node_modules/react-native-web",
+      ]
+    : ["node_modules/.pnpm", "node_modules/next", "node_modules/react", "node_modules/react-dom"];
   const result = await executeShellTerminal(
     {
-      command: `test -d ${dir}/node_modules/.pnpm`,
+      command: requiredPaths.map((path) => `test -d ${dir}/${path}`).join(" && "),
       cwd: "/workspace",
       timeoutMs: 10_000,
     },


### PR DESCRIPTION
## Summary
- validates the runtime-specific dependency links before reusing a persistent app workspace
- repairs interrupted pnpm installs instead of accepting a partial `node_modules` tree
- gives mobile offline installation the same five-minute recovery window as the network fallback

## Context
Post-deploy QA proved uploaded-file persistence and agent reads. A mobile QA workspace damaged by the pre-fix destructive bootstrap still had `node_modules/.pnpm` but lacked Expo web links, so the old coarse restore check incorrectly treated it as complete.

## Decisions
| Decision | Choice | Reasoning |
|---|---|---|
| Restore readiness | Check concrete runtime dependencies | A package-store directory alone does not prove usable symlinks |
| Recovery | Re-run the pinned install when links are incomplete | The lockfile and snapshot store remain the clean source of truth |
| Timeout | Five minutes for mobile offline installs | Daytona volume I/O can exceed the previous two-minute window |

## Verification
- [x] agent-worker lint, typecheck, and production dry-run build — 23/23 tasks passed
- [x] production upload/read flow passed in two newly created projects
- [ ] verify the damaged mobile QA workspace self-repairs after deploy

No database change or migration is included. No Linear issue or plan document is associated with this production QA fix.