### PR TITLE
chore(sandbox): promote Node 24 snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -15,7 +15,7 @@
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
     "DAYTONA_PREVIEW_HOST_SUFFIXES": "daytonaproxy01.net,proxy.daytona.work",
     "DAYTONA_TARGET": "us",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-6e926e583e76-29695426038",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-b0d3572dc6d5-30268573116",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production",
     "OUTPUT_DOWNLOAD_BASE_URL": "https://gateway.trycheatcode.com",
     "PREVIEW_HOSTNAME": "trycheatcode.com"


### PR DESCRIPTION
## Decision

Promote the immutable Daytona snapshot built from main at `b0d3572dc6d5bb199c2f7128da3e0eb4cb72e2a0`.

## Why

The prior Node 22 snapshot can hit mounted-volume timestamp failures during dependency recovery. The replacement uses Node 24.18.0 and includes the reviewed bundled-dependency security patches from #83 and #84.

## Evidence

- Protected snapshot run: https://github.com/cheatcode-ai/cheatcode/actions/runs/30268573116
- Published active snapshot: `cheatcode-sandbox-viewer-bundle-b0d3572dc6d5-30268573116`
- Image vulnerability, secret, and configuration scans passed
- Runtime smoke checks passed, including exact Node/NSS/embedded-package versions and all bundled tools, templates, and skills
- Agent-worker lint, typecheck, and production dry-run build pass locally under Node 24.18.0

## Scope

One reviewed configuration change only. No schema or migration changes.