### PR TITLE
fix(agent): make upload rehydration mount-safe

### DIFF
--- a/apps/agent-worker/src/durable-objects/project-sandbox-project-files.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-project-files.ts
@@ -1,5 +1,5 @@
 import { workspacePathForSlug } from "@cheatcode/db";
-import { APIError } from "@cheatcode/observability";
+import { APIError, createLogger } from "@cheatcode/observability";
 import { DaytonaApiError } from "@cheatcode/tools-code";
 import {
   PROJECT_FILE_MAX_CURRENT_FILES,
@@ -11,6 +11,7 @@ import {
   ProjectFileUploadResponseSchema,
 } from "@cheatcode/types";
 import { z } from "zod";
+import { sleep } from "./project-sandbox-process-support";
 import { ProjectSandboxProcesses } from "./project-sandbox-processes";
 import {
   type ProjectListUploadedFilesInput,
@@ -27,6 +28,8 @@ const FILE_RECORD_PREFIX = "project-file:";
 const VERSION_RECORD_PREFIX = "project-file-version:";
 const DELETE_BATCH_SIZE = 128;
 const WORKSPACE_TIMESTAMP_TOLERANCE_MS = 2_000;
+const WORKSPACE_FILE_VISIBILITY_ATTEMPTS = 20;
+const WORKSPACE_FILE_VISIBILITY_DELAY_MS = 250;
 
 const ProjectFileVersionSchema = z
   .object({
@@ -163,28 +166,13 @@ export abstract class ProjectSandboxProjectFiles extends ProjectSandboxProcesses
     const sandboxId = await this.ensureSandbox();
     const projectRoot = workspacePathForSlug(input.workspaceSlug);
     const workspacePath = `${projectRoot}/${input.path}`;
-    let written: Uint8Array;
-    try {
-      written = await this.writeProjectFileToWorkspace(
-        sandboxId,
-        projectRoot,
-        workspacePath,
-        input.bytes,
-        workspaceTimestamp,
-      );
-    } catch (error) {
-      if (!isRecoverableWorkspaceMountError(error)) {
-        throw error;
-      }
-      await this.restartSandboxForWorkspaceRecovery(sandboxId);
-      written = await this.writeProjectFileToWorkspace(
-        sandboxId,
-        projectRoot,
-        workspacePath,
-        input.bytes,
-        workspaceTimestamp,
-      );
-    }
+    const written = await this.writeProjectFileWithRecovery(
+      sandboxId,
+      projectRoot,
+      workspacePath,
+      input.bytes,
+      workspaceTimestamp,
+    );
     if (
       written.byteLength !== input.bytes.byteLength ||
       (await sha256Hex(written)) !== contentSha256
@@ -194,6 +182,36 @@ export abstract class ProjectSandboxProjectFiles extends ProjectSandboxProcesses
         "upstream_sandbox_failed",
         "Project file could not be verified in the workspace",
         { retriable: true },
+      );
+    }
+  }
+
+  private async writeProjectFileWithRecovery(
+    sandboxId: string,
+    projectRoot: string,
+    workspacePath: string,
+    bytes: Uint8Array,
+    workspaceTimestamp: string,
+  ): Promise<Uint8Array> {
+    try {
+      return await this.writeProjectFileToWorkspace(
+        sandboxId,
+        projectRoot,
+        workspacePath,
+        bytes,
+        workspaceTimestamp,
+      );
+    } catch (error) {
+      if (!isRecoverableWorkspaceMountError(error)) {
+        throw error;
+      }
+      await this.restartSandboxForWorkspaceRecovery(sandboxId);
+      return this.writeProjectFileToWorkspace(
+        sandboxId,
+        projectRoot,
+        workspacePath,
+        bytes,
+        workspaceTimestamp,
       );
     }
   }
@@ -208,9 +226,33 @@ export abstract class ProjectSandboxProjectFiles extends ProjectSandboxProcesses
     const uploadsPath = `${projectRoot}/uploads`;
     await this.prepareUploadedFileWrite(sandboxId, uploadsPath, workspacePath);
     await this.client().uploadFile(sandboxId, workspacePath, bytes);
-    const written = await this.client().downloadFile(sandboxId, workspacePath, bytes.byteLength);
-    await this.protectUploadedFile(sandboxId, uploadsPath, workspacePath, workspaceTimestamp);
+    const written = await this.downloadUploadedFile(sandboxId, workspacePath, bytes.byteLength);
+    await this.protectUploadedFile(sandboxId, uploadsPath, workspacePath, workspaceTimestamp).catch(
+      (error: unknown) => {
+        logWorkspaceProtectionFailure(error, "file");
+      },
+    );
     return written;
+  }
+
+  private async downloadUploadedFile(
+    sandboxId: string,
+    workspacePath: string,
+    maxBytes: number,
+  ): Promise<Uint8Array> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < WORKSPACE_FILE_VISIBILITY_ATTEMPTS; attempt += 1) {
+      try {
+        return await this.client().downloadFile(sandboxId, workspacePath, maxBytes);
+      } catch (error) {
+        if (!(error instanceof DaytonaApiError) || (error.status !== 404 && !error.retriable)) {
+          throw error;
+        }
+        lastError = error;
+        await sleep(WORKSPACE_FILE_VISIBILITY_DELAY_MS);
+      }
+    }
+    throw lastError ?? new Error("Uploaded project file did not become readable");
   }
 
   private async writeAndVerifyObject(
@@ -295,16 +337,19 @@ export abstract class ProjectSandboxProjectFiles extends ProjectSandboxProcesses
         continue;
       }
       const bytes = await this.readStoredProjectFile(current.version);
-      await this.writeProjectFileToWorkspace(
+      const written = await this.writeProjectFileWithRecovery(
         sandboxId,
         projectRoot,
         `${projectRoot}/${current.file.path}`,
         bytes,
         current.file.updatedAt,
       );
+      await assertWorkspaceProjectFile(written, current.file);
       restoredFileCount += 1;
     }
-    await this.protectUploadedDirectory(sandboxId, uploadsPath);
+    await this.protectUploadedDirectory(sandboxId, uploadsPath).catch((error: unknown) => {
+      logWorkspaceProtectionFailure(error, "directory");
+    });
     return { restoredFileCount };
   }
 
@@ -373,22 +418,21 @@ export abstract class ProjectSandboxProjectFiles extends ProjectSandboxProcesses
     uploadsPath: string,
     workspacePath: string,
   ): Promise<void> {
+    await this.client().createFolder(sandboxId, uploadsPath);
     const prepared = await this.client().execute(sandboxId, {
       command: [
-        `install -d -m 0755 ${shellQuote(uploadsPath)}`,
-        `if test -e ${shellQuote(workspacePath)}; then chmod 0644 ${shellQuote(workspacePath)}; fi`,
+        `chmod 0777 -- ${shellQuote(uploadsPath)}`,
+        `if test -e ${shellQuote(workspacePath)}; then chmod 0666 -- ${shellQuote(workspacePath)}; fi`,
       ].join(" && "),
       timeout: 10,
     });
     if (prepared.exitCode !== 0) {
-      throw new APIError(
-        502,
-        "upstream_sandbox_failed",
-        "Project file workspace could not be prepared",
-        { retriable: true },
+      logWorkspaceProtectionFailure(
+        new Error("Workspace cache permissions could not be opened"),
+        "prepare",
+        prepared.exitCode,
       );
     }
-    await this.client().createFolder(sandboxId, uploadsPath);
   }
 
   private async protectUploadedFile(
@@ -399,10 +443,17 @@ export abstract class ProjectSandboxProjectFiles extends ProjectSandboxProcesses
   ): Promise<void> {
     const protectedFile = await this.client().execute(sandboxId, {
       command: [
-        `touch -d ${shellQuote(workspaceTimestamp)} -- ${shellQuote(workspacePath)}`,
-        `chmod 0444 -- ${shellQuote(workspacePath)}`,
-        `chmod 0555 -- ${shellQuote(uploadsPath)}`,
-      ].join(" && "),
+        "attempt=0",
+        `while test "$attempt" -lt ${WORKSPACE_FILE_VISIBILITY_ATTEMPTS}; do`,
+        `if test -f ${shellQuote(workspacePath)}; then`,
+        `touch -d ${shellQuote(workspaceTimestamp)} -- ${shellQuote(workspacePath)} && chmod 0444 -- ${shellQuote(workspacePath)} && chmod 0555 -- ${shellQuote(uploadsPath)}`,
+        "exit $?",
+        "fi",
+        "attempt=$((attempt + 1))",
+        `sleep ${WORKSPACE_FILE_VISIBILITY_DELAY_MS / 1_000}`,
+        "done",
+        "exit 1",
+      ].join("\n"),
       timeout: 10,
     });
     if (protectedFile.exitCode !== 0) {
@@ -493,6 +544,28 @@ function assertCurrentProjectFile(file: ProjectFile, version: ProjectFileVersion
       retriable: false,
     });
   }
+}
+
+async function assertWorkspaceProjectFile(bytes: Uint8Array, file: ProjectFile): Promise<void> {
+  if (bytes.byteLength === file.sizeBytes && (await sha256Hex(bytes)) === file.sha256) {
+    return;
+  }
+  throw new APIError(
+    502,
+    "upstream_sandbox_failed",
+    "Project file restoration could not be verified",
+    {
+      retriable: true,
+    },
+  );
+}
+
+function logWorkspaceProtectionFailure(
+  error: unknown,
+  stage: "directory" | "file" | "prepare",
+  exitCode?: number,
+): void {
+  createLogger().warn("project_upload_workspace_protection_failed", { error, exitCode, stage });
 }
 
 async function prepareProjectFile(

--- a/apps/agent-worker/src/durable-objects/project-sandbox-runtime-manifest.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-runtime-manifest.ts
@@ -34,14 +34,7 @@ export async function writeSandboxRuntimeManifest(
   records: Map<string, unknown>,
 ): Promise<void> {
   const manifest = buildSandboxRuntimeManifest(records);
-  const temporaryPath = `${SANDBOX_RUNTIME_MANIFEST_PATH}.tmp-${crypto.randomUUID()}`;
-  const prepared = await client.execute(sandboxId, {
-    command: `install -d -m 0700 ${shellQuote(RUNTIME_DIRECTORY)}`,
-    timeout: 10,
-  });
-  if (prepared.exitCode !== 0) {
-    throw new Error("Could not prepare the sandbox runtime projection directory.");
-  }
+  const temporaryPath = `/workspace/.cheatcode-runtime-${crypto.randomUUID()}.tmp`;
   await client.uploadFile(
     sandboxId,
     temporaryPath,
@@ -49,10 +42,11 @@ export async function writeSandboxRuntimeManifest(
   );
   const moved = await client.execute(sandboxId, {
     command: [
+      `install -d -m 0700 ${shellQuote(RUNTIME_DIRECTORY)} || exit 1`,
       "attempt=0",
       'while test "$attempt" -lt 20; do',
       `if test -f ${shellQuote(temporaryPath)}; then`,
-      `mv -f ${shellQuote(temporaryPath)} ${shellQuote(SANDBOX_RUNTIME_MANIFEST_PATH)} && chmod 0600 ${shellQuote(SANDBOX_RUNTIME_MANIFEST_PATH)}`,
+      `mv -f ${shellQuote(temporaryPath)} ${shellQuote(SANDBOX_RUNTIME_MANIFEST_PATH)} && chmod 0700 ${shellQuote(RUNTIME_DIRECTORY)} && chmod 0600 ${shellQuote(SANDBOX_RUNTIME_MANIFEST_PATH)}`,
       "exit $?",
       "fi",
       "attempt=$((attempt + 1))",


### PR DESCRIPTION
## Why
Production recovery QA deliberately removed a disposable uploaded-file workspace cache while retaining its authoritative R2 version. The first rehydration implementation failed the run because Daytona's toolbox file plane and container mount can expose a write at slightly different times; permission hardening was treated as fatal. The same ordering kept the runtime manifest from publishing.

## What changed
- wait for uploaded bytes to become readable through Daytona, with bounded retry
- reuse the existing recoverable mount restart path for initial materialization and R2 restoration
- verify the reconstructed workspace bytes against the stored size and SHA-256
- poll container visibility before applying read-only modes
- keep Unix modes as defense-in-depth so a lag cannot fail the agent run; R2, file-tool authorization, and run-boundary repair remain authoritative
- stage the runtime manifest in writable `/workspace` before atomic publication into its protected directory
- emit a structured warning if secondary filesystem protection cannot be applied

## Verification
- reproduced the failure directly in production by deleting only the disposable workspace copy; R2 remained intact
- confirmed Agent Worker logs reported the sandbox write-boundary failure on both pre-run and cleanup restore
- `pnpm turbo lint typecheck build` — 76/76 tasks passed on Node 24.18.0
- targeted Biome and `git diff --check` passed
- no database change; the repository still has exactly one migration
