### PR TITLE
chore(agent): promote sandbox snapshot 66d3adbe9083

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -15,7 +15,7 @@
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
     "DAYTONA_PREVIEW_HOST_SUFFIXES": "daytonaproxy01.net,proxy.daytona.work",
     "DAYTONA_TARGET": "us",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-b0d3572dc6d5-30268573116",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-66d3adbe9083-30338274543",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production",
     "OUTPUT_DOWNLOAD_BASE_URL": "https://gateway.trycheatcode.com",
     "PREVIEW_HOSTNAME": "trycheatcode.com"


### PR DESCRIPTION
Adopt the immutable candidate `cheatcode-sandbox-viewer-bundle-66d3adbe9083-30338274543` built from merge commit `66d3adb` (run 30338274543: Trivy-scanned, runtime smoke-tested, office-materialization step verified in the build log). Image content at the three office paths is byte-identical to the currently promoted snapshot; this switches new-sandbox provisioning to the deduped-source build. Existing user sandboxes are unaffected.