### PR TITLE
fix(preview): remove public health endpoint

### DIFF
--- a/apps/preview-proxy/README.md
+++ b/apps/preview-proxy/README.md
@@ -209,9 +209,9 @@ the shared `@cheatcode/observability` emitters.
   gateway and webhooks routes override it.
 - Exact no-script routes for `clerk.trycheatcode.com/*`,
   `docs.trycheatcode.com/*`, and `www.trycheatcode.com/*` negate the wildcard
-  for Clerk, documentation, and the Vercel frontend hostname.
-  `preview.trycheatcode.com` deliberately has no exact route and inherits the
-  preview wildcard for release health checks.
+  for Clerk, documentation, and the Vercel frontend hostname. The preview
+  wildcard accepts only well-formed `{sandboxId}--{port}` hostnames; arbitrary
+  wildcard labels are rejected by the normal preview-host validation.
 - The wildcard route is declared in
   [`apps/preview-proxy/wrangler.jsonc`](./wrangler.jsonc) and deployed directly
   by [`.github/workflows/deploy-cloudflare.yml`](../../.github/workflows/deploy-cloudflare.yml).

--- a/apps/preview-proxy/src/index.ts
+++ b/apps/preview-proxy/src/index.ts
@@ -31,9 +31,6 @@ const SECURITY_VARY_HEADERS = [
 async function handlePreviewRequest(request: Request, env: PreviewProxyEnv): Promise<Response> {
   const url = new URL(request.url);
   const originalHost = url.host;
-  if (request.method === "GET" && url.pathname === "/health") {
-    return healthResponse(env);
-  }
   const target = requirePreviewTarget(url.hostname, env.PREVIEW_HOSTNAME);
   const secret = await requirePreviewSecret(env);
   const authorized = await authorizePreviewRequest({
@@ -103,15 +100,6 @@ function assertNavigationHandoff(isFromQuery: boolean, method: string): void {
       { retriable: false },
     );
   }
-}
-
-function healthResponse(env: PreviewProxyEnv): Response {
-  return Response.json({
-    ok: true,
-    releaseSha: env.CHEATCODE_RELEASE_SHA ?? "development",
-    versionId: env.CF_VERSION_METADATA?.id ?? null,
-    worker: WORKER_NAME,
-  });
 }
 
 function requirePreviewTarget(hostname: string, previewHostname: string) {


### PR DESCRIPTION
## Summary

- Remove the unauthenticated `GET /health` shortcut from the preview proxy.
- Send preview requests through the existing host and token validation path so release metadata is not exposed publicly.
- Update the route documentation to describe wildcard-host rejection.

## Decision

Preview deployment status remains available through Cloudflare deployment/version metadata. No replacement internal binding is added because no runtime consumer needs preview-proxy release aggregation. Existing gateway liveness and release-convergence endpoints remain unchanged.

## Validation

- [x] `pnpm turbo lint typecheck build` (55/55 tasks)
- [x] `pnpm typecheck:scripts`
- [x] `pnpm architecture:check`
- [x] `pnpm deadcode`
- [x] `pnpm dev` started the complete local stack
- [x] Direct browser check: gateway `/health/live` returned 200
- [x] Direct browser check: preview-host `/health` returned normal 401 token validation instead of release metadata