### PR TITLE
fix(webhooks): make health route service-binding-only

### DIFF
--- a/apps/webhooks-worker/README.md
+++ b/apps/webhooks-worker/README.md
@@ -137,7 +137,9 @@ The handler therefore resolves that Composio-project-global ID through the datab
 primary key; ownership and toolkit assignment are immutable after insertion,
 and terminal status changes atomically reconcile the user's active default.
 
-Production binds one immutable `CHEATCODE_RELEASE_SHA`, exposed by `/health`.
+Production binds one immutable `CHEATCODE_RELEASE_SHA`, exposed by `/health`
+only to the gateway's service-binding probe (`https://webhooks.internal/health`);
+on the public webhook host the route answers as not found.
 HTTP, cron, idempotency, deletion, and workflow continuation paths use their
 normal durable ownership and idempotency contracts; database migrations retain
 their separate target, role, lock, and schema validation.

--- a/apps/webhooks-worker/src/index.ts
+++ b/apps/webhooks-worker/src/index.ts
@@ -165,14 +165,20 @@ webhooksApp.use(
   }),
 );
 
-webhooksApp.get("/health", (c) =>
-  c.json({
+webhooksApp.get("/health", (c) => {
+  // Service-binding-only surface: the gateway probes https://webhooks.internal/health
+  // for release aggregation. The public webhook host must answer like the route does
+  // not exist so release metadata never leaks on an unauthenticated endpoint.
+  if (new URL(c.req.url).hostname !== "webhooks.internal") {
+    return c.notFound();
+  }
+  return c.json({
     ok: true,
     releaseSha: c.env.CHEATCODE_RELEASE_SHA ?? "development",
     versionId: c.env.CF_VERSION_METADATA?.id ?? null,
     worker: "webhooks",
-  }),
-);
+  });
+});
 
 webhooksApp.post("/clerk", async (c) => {
   const signingSecret = await clerkWebhookSigningSecret(c.env);


### PR DESCRIPTION
## Summary

Closes the last finding from the public-surface sweep that followed #103: `webhooks.trycheatcode.com/health` answered publicly (200, unauthenticated, unrate-limited) with `releaseSha`/`versionId`, while its only real consumer — the gateway's release aggregation — reaches it through the WEBHOOKS service binding as `https://webhooks.internal/health`.

The route now gates on the internal hostname and returns Hono's plain `notFound()` on any other host, indistinguishable from a route that does not exist. Same rule as #103: every public route must have a named external consumer. The four provider webhook POST endpoints (signature-verified) are untouched.

## Deploy safety

Gateway is unchanged; its binding fetch already carries the `webhooks.internal` hostname, so the gate passes for old and new gateway alike — no deploy-order coupling, no skew window. Roll-forward as usual.

## Verification

- Gates: lint, typecheck, full `turbo build --force` (19 packages incl. web), knip, dependency-cruiser (844 modules, 0 violations), skills bundle — all green
- Post-deploy: public `GET webhooks.trycheatcode.com/health` → 404; gateway `/health/release` still 200 with the webhooks leg (proves the internal path intact)