### PR TITLE
fix(api): remove dead error documentation links

### DIFF
--- a/apps/preview-proxy/README.md
+++ b/apps/preview-proxy/README.md
@@ -207,11 +207,11 @@ the shared `@cheatcode/observability` emitters.
 - Worker route: `*.${PREVIEW_HOSTNAME}/*` points only to
   `cheatcode-preview-proxy`. Cloudflare's most-specific-route rule lets the exact
   gateway and webhooks routes override it.
-- Exact no-script routes for `clerk.trycheatcode.com/*`,
-  `docs.trycheatcode.com/*`, and `www.trycheatcode.com/*` negate the wildcard
-  for Clerk, documentation, and the Vercel frontend hostname. The preview
-  wildcard accepts only well-formed `{sandboxId}--{port}` hostnames; arbitrary
-  wildcard labels are rejected by the normal preview-host validation.
+- Exact no-script routes for `clerk.trycheatcode.com/*` and
+  `www.trycheatcode.com/*` negate the wildcard for Clerk and the Vercel frontend
+  hostname. The preview wildcard accepts only well-formed
+  `{sandboxId}--{port}` hostnames; arbitrary wildcard labels are rejected by
+  the normal preview-host validation.
 - The wildcard route is declared in
   [`apps/preview-proxy/wrangler.jsonc`](./wrangler.jsonc) and deployed directly
   by [`.github/workflows/deploy-cloudflare.yml`](../../.github/workflows/deploy-cloudflare.yml).

--- a/packages/observability/src/errors.ts
+++ b/packages/observability/src/errors.ts
@@ -17,7 +17,6 @@ export class APIError extends Error {
     hint?: string;
     retriable?: boolean;
     details?: Record<string, unknown>;
-    doc_url?: string;
   };
 
   public constructor(
@@ -29,7 +28,6 @@ export class APIError extends Error {
       hint?: string;
       retriable?: boolean;
       details?: Record<string, unknown>;
-      doc_url?: string;
     } = {},
   ) {
     super(message, opts.cause === undefined ? undefined : { cause: opts.cause });
@@ -47,7 +45,6 @@ export class APIError extends Error {
           hint: this.opts.hint,
           retriable: this.retriable,
           request_id: requestId,
-          doc_url: this.opts.doc_url ?? `https://docs.trycheatcode.com/errors/${this.code}`,
           details: this.opts.details,
         },
       },

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -57,7 +57,6 @@ export const ErrorResponseSchema = z.strictObject({
     hint: z.string().optional(),
     retriable: z.boolean(),
     request_id: z.string(),
-    doc_url: z.string().url(),
     details: z.record(z.string(), z.unknown()).optional(),
   }),
 });


### PR DESCRIPTION
## Summary

- Remove the nonexistent `docs.trycheatcode.com` URL from every structured API error.
- Remove `doc_url` from the strict shared error-response schema and APIError options.
- Correct preview-proxy routing documentation so it lists only active hostname reservations.

## Decision

The API contract drops the field completely instead of retaining an optional compatibility property. A documentation URL can be introduced later only with a real, deployed documentation surface.

## Verification notes

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm turbo build --force`
- [x] `pnpm deadcode`
- [x] `pnpm architecture:check`
- [x] `pnpm turbo skills:build`

The complete Docker Compose stack started successfully. Direct Chrome QA requested a preview route without a token and confirmed the real 401 Worker response contained `code`, `message`, `retriable`, and `request_id` with no `doc_url`. Browser console and Worker logs showed only the expected authentication failure.