### PR TITLE
fix(db): supabase-target checks vs platform-managed state

### DIFF
--- a/scripts/supabase-target/index.ts
+++ b/scripts/supabase-target/index.ts
@@ -200,7 +200,20 @@ async function validateRoleMemberships(client: PgClient): Promise<string[]> {
       where member.rolname = any($1::text[]) or granted.rolname = any($1::text[])`,
     [[...RUNTIME_DATABASE_ROLES]],
   );
-  return result.rows.map(
+  // Supabase's supautils grants every role that `postgres` creates back to
+  // `postgres` (grantor supabase_admin) so the platform admin can manage it.
+  // That membership is platform-managed and appears on every project the
+  // moment the runtime roles are created; only memberships beyond it are
+  // divergences.
+  const runtimeRoles: readonly string[] = RUNTIME_DATABASE_ROLES;
+  const rows = result.rows.filter(
+    (row) =>
+      !(
+        stringField(row, "member_role") === "postgres" &&
+        runtimeRoles.includes(stringField(row, "granted_role") ?? "")
+      ),
+  );
+  return rows.map(
     (row) =>
       `Runtime role membership ${stringField(row, "granted_role")} -> ${stringField(row, "member_role")} must be revoked.`,
   );
@@ -391,7 +404,7 @@ async function validateDataApiDefaultAcl(client: PgClient): Promise<string[]> {
 
 function runtimeAclQuery(): string {
   return `select grantee.rolname as role_name, 'table' as object_kind,
-                 relation.relname as object_name,
+                 relation.relname::text as object_name,
                  (entry).privilege_type as privilege, (entry).is_grantable
             from pg_class relation
             join pg_namespace namespace on namespace.oid = relation.relnamespace


### PR DESCRIPTION
Two checker corrections found by the first post-Wave-B `--apply` against production (the assertion had not run since the contract was tightened). Both live-probe-verified on production AND a fresh 2026 project:

1. **63-byte truncation**: the runtime-ACL union's first branch selected `relname` (type `name`), so the union resolved `object_name` to `name` and truncated every function signature past 63 bytes — the six long-signature `webhooks_*` functions could never match the expected set. One-line `::text` cast.
2. **supautils auto-membership**: every role `postgres` creates is granted back to `postgres` (grantor `supabase_admin`) on every Supabase project — verified by creating a probe role on a fresh project. The zero-membership check now exempts exactly `app_* → postgres` and flags all else.

## Verification notes

- [x] `pnpm lint` / `pnpm typecheck`
- [x] Live `pnpm db:migrate -- --dry-run` against production with the fixed checker: **"Production schema contract verified."** with 0000 baselined and 0001/0002/0003 applied.

(DB-state note recorded in the PR trail: the one-time 0000 ledger-hash update documented in #108 was executed before the apply; two stale `max`-tier entitlement rows were normalized to `premium` to satisfy 0001's CHECK constraint.)