### PR TITLE
ci: dependabot title exemption, dependency floors, masked account id

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -24,7 +24,7 @@ jobs:
   build-snapshot:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    environment: production
+    environment: Production
     steps:
       - name: Authorize snapshot publication
         env:

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -70,5 +70,5 @@ jobs:
               --var "CHEATCODE_RELEASE_SHA:$GITHUB_SHA"
           done
         env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -38,21 +38,24 @@ jobs:
       - name: Validate pull request title
         if: github.event_name == 'pull_request'
         env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           python3 - <<'PY'
           import os
           import re
 
+          author = os.environ["PR_AUTHOR"]
           title = os.environ["PR_TITLE"]
           pattern = re.compile(
               r"(?:build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)"
               r"(?:\([a-z0-9][a-z0-9._/-]*\))?!?: \S.*"
           )
-          if len(title) > 72 or pattern.fullmatch(title) is None:
-              raise SystemExit(
-                  "Pull request titles must use Conventional Commits and be at most 72 characters."
-              )
+          if pattern.fullmatch(title) is None:
+              raise SystemExit("Pull request titles must use Conventional Commits.")
+          # Dependabot titles are machine-generated from group/directory names, grow past 72 chars, and are not configurable; commitlint's own ceiling is 100.
+          if len(title) > 72 and author != "dependabot[bot]":
+              raise SystemExit("Pull request titles must be at most 72 characters.")
           PY
 
       - name: Classify changed files

--- a/infra/containers/sandbox/Dockerfile
+++ b/infra/containers/sandbox/Dockerfile
@@ -35,6 +35,7 @@ COPY package-manager/package.json package-manager/package-lock.json /opt/cheatco
 COPY doc-runtime/package.json doc-runtime/package-lock.json /opt/cheatcode-doc-runtime/
 # npm, pnpm, and code-server ship their own dependency trees, so ordinary
 # top-level overrides cannot replace vulnerable packages inside those bundles.
+# Dependabot alerts #9 (brace-expansion) and #8 (tar) are lockfile-metadata findings mitigated by this overlay because npm has not re-bundled the fixed versions.
 COPY runtime-security-overrides/package.json runtime-security-overrides/package-lock.json /opt/cheatcode-runtime-security-overrides/
 COPY skill-runtime/package.json skill-runtime/package-lock.json skill-runtime/tsconfig.json /opt/cheatcode-skill-runtime/
 COPY skill-runtime/bin/ /opt/cheatcode-skill-runtime/bin/

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,7 +198,8 @@ overrides:
   '@tootallnate/once@>=2.0.0 <2.0.1': 2.0.1
   '@vercel/node@5.8.25>undici': 6.27.0
   ajv@>=8.0.0 <8.18.0: 8.20.0
-  dompurify@<=3.4.10: 3.4.11
+  body-parser@>=2.0.0 <2.3.0: 2.3.0
+  dompurify@<=3.4.11: 3.4.12
   fast-uri@<3.1.4: 3.1.4
   js-yaml@<3.15.0: 3.15.0
   js-yaml@>=4.0.0 <4.3.0: 4.3.0
@@ -3811,8 +3812,8 @@ packages:
   bn.js@5.2.4:
     resolution: {integrity: sha512-QL7sb18rJ1PbdsKsqPA0guxL563vIMwRHgzNrW/uzQuRGN1Cjqd/wonUBAVqHox9KwzHA6vCbM0lXx3k4iQMow==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   borsh@0.7.0:
@@ -4309,8 +4310,8 @@ packages:
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -9595,10 +9596,10 @@ snapshots:
 
   bn.js@5.2.4: {}
 
-  body-parser@2.2.2(supports-color@10.2.2):
+  body-parser@2.3.0(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3(supports-color@10.2.2)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
@@ -10126,7 +10127,7 @@ snapshots:
 
   dijkstrajs@1.0.3: {}
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10315,7 +10316,7 @@ snapshots:
   express@5.2.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2(supports-color@10.2.2)
+      body-parser: 2.3.0(supports-color@10.2.2)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -11302,7 +11303,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       es-toolkit: 1.47.1
       katex: 0.16.47
       khroma: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,8 @@ overrides:
   '@tootallnate/once@>=2.0.0 <2.0.1': 2.0.1
   '@vercel/node@5.8.25>undici': 6.27.0
   'ajv@>=8.0.0 <8.18.0': 8.20.0
-  'dompurify@<=3.4.10': 3.4.11
+  'body-parser@>=2.0.0 <2.3.0': 2.3.0
+  'dompurify@<=3.4.11': 3.4.12
   'fast-uri@<3.1.4': 3.1.4
   'js-yaml@<3.15.0': 3.15.0
   'js-yaml@>=4.0.0 <4.3.0': 4.3.0


### PR DESCRIPTION
Phase C of the OSS-ready program.

- **PR-title gate**: Conventional-Commits pattern still enforced for all; the 72-char ceiling now exempts `dependabot[bot]` (titles are machine-generated and unshortenable — #76/#78 fail today solely on length; commitlint's own ceiling is 100).
- **Dependency floors**: `dompurify` → 3.4.12 (closes alert #5); `body-parser` → 2.3.0 (resolved 2.2.2 was in-range via express + MCP-SDK paths, closes alert #4).
- **`CLOUDFLARE_ACCOUNT_ID`** now read from secrets (masked in public run logs; secret created beforehand; the variable is deleted after the next validated dispatch — historical logs remain unredacted regardless).
- `build-snapshot` environment casing normalized to `Production`; sandbox Dockerfile comment ties alerts #9/#8 to the existing overlay mitigation.

## Verification notes

- [x] `pnpm lint` / `pnpm typecheck` / `pnpm turbo build --force` / `pnpm deadcode` / `pnpm architecture:check` / `pnpm turbo skills:build` — independent clean-install rerun
- Lockfile diff limited to the two override resolutions; `pnpm why body-parser` single-resolves 2.3.0.
- Post-merge: rebase #76/#78 (title gate), re-run #96 (expired quarantine), merge #81 after diff re-check; dispatch deploy to validate the secret-backed account id; then delete the variable.