### PR TITLE
fix(db): deterministic per-file search_path in migration runner

### DIFF
--- a/packages/db/src/drizzle-migrations.ts
+++ b/packages/db/src/drizzle-migrations.ts
@@ -42,6 +42,11 @@ async function applyDrizzleMigration(
 ): Promise<void> {
   await client.query("begin");
   try {
+    // Migration files share one session, and the pg_dump baseline empties the
+    // session search_path for correctness of its own qualified statements.
+    // Give every file a deterministic search_path scoped to its transaction so
+    // no file inherits another file's session mutations.
+    await client.query("set local search_path = public, pg_catalog");
     for (const statement of migration.statements) {
       if (statement.trim()) {
         await client.query(statement);


### PR DESCRIPTION
Found by the wizard's fresh-project e2e: the pg_dump baseline empties the session `search_path` (its own statements are fully qualified), and because migration files share one connection, 0001's unqualified `v2_entitlements` reference failed on a fresh project. Production never executed the baseline (ledgered), so this only bites fresh installs.

One line in the runner: `SET LOCAL search_path = public, pg_catalog` at the top of each per-file transaction — deterministic environment per file, reverted at commit.

## Verification notes
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm turbo build --force` / `pnpm deadcode` / `pnpm architecture:check`
- Post-merge: wizard resume on the half-migrated fresh project (0000 ledgered, 0001-0003 pending) must complete 0001→0003 + target assertion — the exact failed scenario.