### PR TITLE
fix(db): paren-insensitive constraint-drift comparison

### DIFF
--- a/scripts/supabase-target/invariants.ts
+++ b/scripts/supabase-target/invariants.ts
@@ -181,7 +181,15 @@ export async function validateIntegrityConstraints(client: PgClient): Promise<st
     CANONICAL_PROVIDER_KEY_CONSTRAINT,
   ]) {
     const row = result.rows.find((candidate) => candidate["conname"] === contract.name);
-    if (row && normalizedSqlDefinition(row["definition"]) !== contract.definition) {
+    // pg_get_constraintdef's AND-chain grouping changed between Postgres
+    // minors (17.4 prints left-associated parentheses, 17.6 flattens), so the
+    // comparison ignores parentheses. Operator, literal, and regex changes
+    // still surface, which is what this drift check exists to catch.
+    if (
+      row &&
+      parenInsensitiveSqlDefinition(row["definition"]) !==
+        parenInsensitiveSqlDefinition(contract.definition)
+    ) {
       issues.push(`Security check public.${contract.tableName}.${contract.name} has drifted.`);
     }
   }
@@ -260,4 +268,8 @@ function stringField(row: Record<string, unknown>, key: string): string | undefi
 
 function normalizedSqlDefinition(value: unknown): string {
   return typeof value === "string" ? value.replaceAll(/\s+/g, " ").trim() : "";
+}
+
+function parenInsensitiveSqlDefinition(value: unknown): string {
+  return normalizedSqlDefinition(value).replaceAll(/[()]/g, "").replaceAll(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
Found by the fresh-project e2e's final target assertion: `pg_get_constraintdef` prints AND-chains left-associated on PG 17.4 (where the pinned definitions were dumped) but flattened on 17.6 (fresh Supabase projects today) — semantically identical, textually different, so the drift check false-fired. Also future-proofs production's own eventual minor upgrade.

Both sides of the comparison are now parenthesis-stripped; operator/literal/regex weakening still surfaces, which is what the check exists to catch.

## Verification notes
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm turbo build --force` / `pnpm deadcode` / `pnpm architecture:check`
- Post-merge: wizard resume must clear the target assertion on the fresh 17.6 project (migrations 0000-0003 already ledgered there) and proceed to provisioning + probes.