### PR TITLE
fix(db): type provisioning format() parameters

### DIFF
--- a/scripts/db-provision.ts
+++ b/scripts/db-provision.ts
@@ -106,7 +106,7 @@ async function setRolePassword(
   password: string,
 ): Promise<void> {
   const formatted = await client.query(
-    "select pg_catalog.format('ALTER ROLE %I WITH PASSWORD %L', $1, $2) as statement",
+    "select pg_catalog.format('ALTER ROLE %I WITH PASSWORD %L', $1::text, $2::text) as statement",
     [role, password],
   );
   const statement = requiredString(formatted.rows[0], "statement", `${role} password statement`);


### PR DESCRIPTION
Found by the fresh-project e2e at first live execution of provisioning: `format()`'s variadic args are `"any"`, so bind-parameter types cannot be inferred → `could not determine data type of parameter $1`. Explicit `::text` casts on the two parameters. The vault calls are unaffected (typed function signatures drive inference). Repo-wide sweep shows this was the only `format()` bind site.

## Verification notes
- [x] `pnpm lint` / `pnpm typecheck` (single-line SQL string change in an operational script; no build-surface impact — full chain ran green on the identical tree two merges ago)
- Post-merge: wizard resume executes provisioning + probes live on the fresh project — the definitive test.