### PR TITLE
fix(skills): use brand mark in recovery cards

### DIFF
--- a/apps/web/src/components/skills/integration-skills-grid.tsx
+++ b/apps/web/src/components/skills/integration-skills-grid.tsx
@@ -3,8 +3,9 @@ import type { ToolkitCatalogEntry, UserSkill } from "@cheatcode/types/api";
 import { IntegrationBrandLogo } from "@/components/skills/integration-brand-logo";
 import type { IntegrationDrawerHandlers } from "@/components/skills/integration-skill-drawer";
 import { UserSkillCard, type UserSkillsCatalog } from "@/components/skills/user-skills-section";
-import { Loader2, Sparkles } from "@/components/ui";
+import { Loader2 } from "@/components/ui";
 import { CheatcodeLoader } from "@/components/ui/cheatcode-loader";
+import { CheatcodeMark } from "@/components/ui/cheatcode-mark";
 import { RecoveryCard } from "@/components/ui/recovery-card";
 import { cn } from "@/lib/ui/cn";
 
@@ -80,7 +81,7 @@ function InlineToolsError({ isRetrying, onRetry }: { isRetrying: boolean; onRetr
           pendingLabel: "Loading skills…",
         }}
         description="Cheatcode couldn't reach the skills catalog. Check your connection and try again."
-        icon={Sparkles}
+        icon={CheatcodeMark}
         size="compact"
         title="Skills couldn't load"
       />
@@ -156,7 +157,7 @@ function ToolsError({ isRetrying, onRetry }: { isRetrying: boolean; onRetry: () 
           pendingLabel: "Loading skills…",
         }}
         description="Cheatcode couldn't reach the skills catalog. Check your connection and try again."
-        icon={Sparkles}
+        icon={CheatcodeMark}
         size="compact"
         title="Skills couldn't load"
       />

--- a/apps/web/src/components/ui/icons.ts
+++ b/apps/web/src/components/ui/icons.ts
@@ -44,7 +44,6 @@ export {
   Search,
   SlidersHorizontal,
   Smartphone,
-  Sparkles,
   Square,
   SquareAsterisk,
   Star,

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -45,7 +45,6 @@ export {
   Search,
   SlidersHorizontal,
   Smartphone,
-  Sparkles,
   Square,
   SquareAsterisk,
   Star,


### PR DESCRIPTION
## Summary
- replace the two remaining generic Lucide `Sparkles` icons in skills-catalog recovery cards with `CheatcodeMark`
- remove the now-unused `Sparkles` exports from the web icon barrels
- preserve the custom orange onboarding `Sparkle` artwork and vendored Office schema value

## Context
Follow-up to #115 from a direct codebase audit; no Linear issue or plan document was created for this focused cleanup.

## Decisions Made
| Decision | Choice | Alternatives considered | Reasoning |
|---|---|---|---|
| Skills recovery visual | Reuse `CheatcodeMark` through the existing `RecoveryCard` component slot | Keep the generic icon or add a brand-specific mode | Matches onboarding recovery states without duplicating surfaces or adding boolean API modes |
| Remaining sparkle artwork | Preserve the custom onboarding SVGs | Replace every star-shaped visual | Those SVGs are intentional Paper design-system artwork, not generic Lucide placeholders |
| Icon barrel | Remove `Sparkles` entirely | Leave an unused export | Prevents accidental reuse and is verified by the dead-code and repository search checks |

## How to Review
1. Review `integration-skills-grid.tsx` for both recovery-state callers.
2. Confirm `icons.ts` and `index.ts` only remove the unused Lucide export.

## Verification
- [x] repository search finds no `Sparkles` or `lucide-sparkles` references
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm turbo build --force`
- [x] `pnpm deadcode`
- [x] `pnpm architecture:check`
- [x] `pnpm turbo skills:build`
- [x] local Next.js process started and the Clerk sign-in route returned HTTP 200
- [ ] protected `/skills` visual state was not entered because the browser's autofilled development account is not registered in this Clerk instance; no auth data was created or changed
