### PR TITLE
fix(agent): restore previews after sandbox idle

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -148,6 +148,9 @@ Managed processes use required stable IDs and a maximum of 32 live metadata slot
 sandbox. Reusing an ID atomically replaces that slot. At capacity, ProjectSandbox reconciles the
 bounded record set against Daytona, removes missing or completed sessions and their port state,
 and rejects a new distinct slot only when all 32 remain live.
+App-preview identity and port allocation derive from the canonical project workspace root, while
+the launch command may run in any descendant folder. Nested app layouts therefore retain the same
+project-scoped wake, console, cleanup, and restart identity after Daytona idle-stops the sandbox.
 
 Each user has one durable Daytona sandbox. Projects are lexically confined to their
 folders under `/workspace`, and run leases keep the sandbox active while the agent is
@@ -173,6 +176,13 @@ development. Local Compose service-binds that same Worker behind
 proxy injects only bounded code-server workbench HTML and pins parent messaging
 to the environment's exact app origin; generated-app preview HTML remains
 streamed.
+
+Opening Files starts code-server directly against the requested workspace. It does not recursively
+enumerate the project first, so dependency trees and large generated projects are outside the cold
+start critical path. After an idle stop, a current tracked code-server session is relaunched from its
+durable command instead of repeating installation and cleanup probes. A project with no tracked
+app-preview record returns the terminal `none` state without starting Daytona or entering the
+preview wake polling loop.
 
 AgentRun does not count, persist, bill, or emit model-token or model-cost data,
 and it does not apply per-run or daily dollar caps. Provider usage remains an

--- a/apps/agent-worker/src/agent-routing.ts
+++ b/apps/agent-worker/src/agent-routing.ts
@@ -10,7 +10,6 @@ import {
   findAgentEntitlementByUserId,
   findAgentRunForUser,
   getProject,
-  getProjectWriteState,
   getThread,
   type RunPersonalization,
   withUserDb,
@@ -73,10 +72,10 @@ export async function requireWritableThreadProject(
   env: AgentEnv,
   userId: string,
   threadId: string,
-): Promise<void> {
+): Promise<{ id: string; name: string; workspaceSlug: string } | null> {
   const parsedUserId = toUserId(userId);
   return withUserDb(env, parsedUserId, async ({ transaction }) => {
-    await transaction(async (tx) => {
+    return transaction(async (tx) => {
       const thread = await getThread(tx, { threadId: toThreadId(threadId), userId: parsedUserId });
       if (!thread) {
         throw new APIError(404, "resource_thread_not_found", "Thread not found", {
@@ -85,32 +84,33 @@ export async function requireWritableThreadProject(
       }
       if (!thread.projectId) {
         // Project-less chats stay writable until a workspace-backed tool materializes a project.
-        return;
+        return null;
       }
-      const state = await getProjectWriteState(tx, {
+      const project = await getProject(tx, {
         projectId: thread.projectId,
         userId: parsedUserId,
       });
-      if (!state) {
+      if (!project) {
         throw new APIError(404, "resource_project_not_found", "Project not found", {
           retriable: false,
         });
       }
-      if (state.readOnly) {
+      if (project.readOnly) {
         throw new APIError(
           403,
           "permission_plan_required",
           "Project is read-only after downgrade",
           {
             details: {
-              archiveAfter: state.archiveAfter?.toISOString() ?? null,
-              overQuota: state.overQuota,
+              archiveAfter: project.archiveAfter?.toISOString() ?? null,
+              overQuota: project.overQuota,
             },
             hint: "Delete or archive over-limit projects, or upgrade your plan to continue editing this project.",
             retriable: false,
           },
         );
       }
+      return { id: project.id, name: project.name, workspaceSlug: project.workspaceSlug };
     });
   });
 }

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -64,6 +64,7 @@ interface AppBuilderWorkspace {
   mobile: boolean;
   port: number;
   slot: string;
+  slug: string;
 }
 
 function isMobileBuild(input: AgentRunAppBuilderInput): boolean {
@@ -120,7 +121,7 @@ async function resolveAppWorkspace(
   const slug = input.workspaceSlug;
   const slot = `app-preview:${slug}`;
   const port = await allocateAppPort(sandbox, slug, mobile, logger);
-  return { dir, mobile, port, slot };
+  return { dir, mobile, port, slot, slug };
 }
 
 interface RunAppBuilderOptions {
@@ -538,7 +539,7 @@ async function startExpoDevServer(
       port: workspace.port,
       timeoutMs: 180_000,
     },
-    { sandbox },
+    { sandbox, workspaceDir: workspace.dir, workspaceSlug: workspace.slug },
   );
 }
 
@@ -591,7 +592,7 @@ async function startAppBuilderDevServer(
       port: workspace.port,
       timeoutMs: 180_000,
     },
-    { sandbox },
+    { sandbox, workspaceDir: workspace.dir, workspaceSlug: workspace.slug },
   );
 }
 

--- a/apps/agent-worker/src/durable-objects/agent-run-mastra-stream.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-mastra-stream.ts
@@ -193,13 +193,17 @@ function agentRequestContext(
     ensureWorkspace: async () => {
       const workspace = await options.workspaceResolver();
       codeRuntime.workspaceDir = workspace.workspaceDir;
+      codeRuntime.workspaceSlug = workspace.workspaceSlug;
       return workspace;
     },
     sandbox: options.sandbox,
     ...(isSkillCreator
       ? { workspaceDir: "/workspace" }
       : input.workspaceSlug
-        ? { workspaceDir: workspacePathForSlug(input.workspaceSlug) }
+        ? {
+            workspaceDir: workspacePathForSlug(input.workspaceSlug),
+            workspaceSlug: input.workspaceSlug,
+          }
         : {}),
   };
   return createCodeRequestContext(codeRuntime, {

--- a/apps/agent-worker/src/durable-objects/project-sandbox-content.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-content.ts
@@ -441,26 +441,29 @@ async function wakePreview(
   input: ProjectWakePreviewInput,
 ): Promise<ProjectWakePreviewResult> {
   const parsed = ProjectWakePreviewInputSchema.parse(input);
-  const id = await context.runtime.ensureSandbox();
   const slot = parsed.workspaceSlug
     ? `${APP_PREVIEW_SLOT_PREFIX}${parsed.workspaceSlug}`
     : "app-preview";
   const record = await context.dependencies.process.processRecord(slot);
-  if (!record?.port) return { running: false, state: "started" };
+  if (!record?.port) return { running: false, state: "none" };
+  const id = await context.runtime.ensureSandbox();
   const mobile = await mobileExpoProxy(context.runtime, id, record);
   const repaired = record.isMobile
     ? await ensureMobileMetroForwardedHostConfig(context.runtime, id, record.cwd)
     : false;
   let running = await context.dependencies.process.isPortAlive(id, record.port);
   if (!running || repaired) {
-    await context.dependencies.process.relaunchDevServer(
+    const relaunched = await context.dependencies.process.relaunchDevServer(
       id,
       slot,
       record,
       mobile?.restartEnv ?? restartEnvironment(slot, record),
     );
     await context.dependencies.process
-      .waitForPort(id, record.port, "/", PREVIEW_WAKE_TIMEOUT_MS)
+      .waitForPort(id, record.port, "/", PREVIEW_WAKE_TIMEOUT_MS, {
+        cmdId: relaunched.cmdId,
+        sessionId: relaunched.sessionId,
+      })
       .catch(() => undefined);
     running = await context.dependencies.process.isPortAlive(id, record.port);
   }
@@ -501,14 +504,14 @@ async function projectPreviewStatus(
   input: ProjectPreviewStatusInput,
 ): Promise<{ running: boolean; state: string }> {
   const parsed = ProjectPreviewStatusInputSchema.parse(input);
+  const record = await context.dependencies.process.processRecord(
+    `${APP_PREVIEW_SLOT_PREFIX}${parsed.workspaceSlug}`,
+  );
+  if (!record?.port) return { running: false, state: "none" };
   const runtimeState = await context.dependencies.sandboxRuntimeState();
   if (runtimeState.state !== "started" || !runtimeState.sandboxId) {
     return { running: false, state: runtimeState.state };
   }
-  const record = await context.dependencies.process.processRecord(
-    `${APP_PREVIEW_SLOT_PREFIX}${parsed.workspaceSlug}`,
-  );
-  if (!record?.port) return { running: false, state: runtimeState.state };
   const running = await context.dependencies.process.httpPortReady(
     runtimeState.sandboxId,
     record.port,
@@ -597,10 +600,16 @@ async function ensureMobileMetroForwardedHostConfig(
 }
 
 async function ensureCodeServer(context: ContentContext, id: string): Promise<void> {
-  if (
-    (await context.dependencies.process.httpPortReady(id, CODE_SERVER_PORT, "/", 5_000)) &&
-    (await hasCodeServerSettingsMarker(context.runtime, id))
-  ) {
+  const [isPortReady, hasCurrentSettings] = await Promise.all([
+    context.dependencies.process.httpPortReady(id, CODE_SERVER_PORT, "/", 5_000),
+    hasCodeServerSettingsMarker(context.runtime, id),
+  ]);
+  if (isPortReady && hasCurrentSettings) {
+    return;
+  }
+  const tracked = await context.dependencies.process.processRecord(CODE_SERVER_PROCESS_ID);
+  if (hasCurrentSettings && tracked?.port === CODE_SERVER_PORT) {
+    await relaunchTrackedCodeServer(context, id, tracked);
     return;
   }
   if (!(await hasCodeServerRuntime(context.runtime, id))) {
@@ -628,15 +637,31 @@ async function ensureCodeServer(context: ContentContext, id: string): Promise<vo
   }
 }
 
+async function relaunchTrackedCodeServer(
+  context: ContentContext,
+  id: string,
+  record: ProcessRecord,
+): Promise<void> {
+  const relaunched = await context.dependencies.process.relaunchDevServer(
+    id,
+    CODE_SERVER_PROCESS_ID,
+    record,
+    codeServerEnvironment(context.runtime.previewHostname()),
+  );
+  await context.dependencies.process.waitForPort(
+    id,
+    CODE_SERVER_PORT,
+    "/",
+    CODE_SERVER_START_TIMEOUT_MS,
+    { cmdId: relaunched.cmdId, sessionId: relaunched.sessionId },
+  );
+}
+
 async function startCodeServer(context: ContentContext): Promise<void> {
   await context.dependencies.coordinatedProcess.startProcess({
     command: ["bash", "-lc", codeServerStartCommand()],
     cwd: WORKSPACE_DIR,
-    env: {
-      CODE_SERVER_PORT: String(CODE_SERVER_PORT),
-      CODE_SERVER_TRUSTED_ORIGINS: codeServerTrustedOrigins(context.runtime.previewHostname()),
-      CODE_SERVER_WORKSPACE: WORKSPACE_DIR,
-    },
+    env: codeServerEnvironment(context.runtime.previewHostname()),
     keepAliveTimeoutMs: 0,
     maxRestarts: 3,
     processId: CODE_SERVER_PROCESS_ID,
@@ -648,6 +673,14 @@ async function startCodeServer(context: ContentContext): Promise<void> {
       timeoutMs: CODE_SERVER_START_TIMEOUT_MS,
     },
   });
+}
+
+function codeServerEnvironment(previewHostname: string): Record<string, string> {
+  return {
+    CODE_SERVER_PORT: String(CODE_SERVER_PORT),
+    CODE_SERVER_TRUSTED_ORIGINS: codeServerTrustedOrigins(previewHostname),
+    CODE_SERVER_WORKSPACE: WORKSPACE_DIR,
+  };
 }
 
 async function hasCodeServerRuntime(runtime: ContentRuntime, id: string): Promise<boolean> {

--- a/apps/agent-worker/src/durable-objects/project-sandbox-process-control.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-process-control.ts
@@ -53,7 +53,7 @@ export interface ProcessControl {
     name: string,
     record: ProcessRecord,
     restartEnv?: Record<string, string>,
-  ) => Promise<void>;
+  ) => Promise<ProcessRecord>;
   releaseProcessPort: (processId: string) => Promise<void>;
   terminateUntrackedSandboxProcesses: (id: string) => Promise<void>;
   waitForPort: (
@@ -116,7 +116,7 @@ async function relaunchDevServer(
   name: string,
   record: ProcessRecord,
   restartEnv?: Record<string, string>,
-): Promise<void> {
+): Promise<ProcessRecord> {
   const sessionId = record.sessionId || `cc-${name}`;
   await runtime.client().deleteSession(id, sessionId);
   const exec = await control.launchSessionProcess(
@@ -127,16 +127,18 @@ async function relaunchDevServer(
     supervisedProcessCommand(record.command, record),
     restartEnv ?? restartEnvironment(name, record),
   );
+  const relaunched = {
+    ...record,
+    cmdId: exec.cmdId ?? sessionId,
+    startedAtMs: Date.now(),
+  } satisfies ProcessRecord;
   try {
-    await runtime.storage.put(`${PROC_PREFIX}${name}`, {
-      ...record,
-      cmdId: exec.cmdId ?? sessionId,
-      startedAtMs: Date.now(),
-    } satisfies ProcessRecord);
+    await runtime.storage.put(`${PROC_PREFIX}${name}`, relaunched);
   } catch (error) {
     await control.cleanupLaunchedProcess(id, sessionId, name);
     throw error;
   }
+  return relaunched;
 }
 
 async function waitForPort(

--- a/apps/agent-worker/src/sandbox-preview-http-routes.ts
+++ b/apps/agent-worker/src/sandbox-preview-http-routes.ts
@@ -11,9 +11,7 @@ import { requireWritableThreadProject, sandboxForUser } from "./agent-routing";
 import {
   readSandboxStateCache,
   SANDBOX_WORKSPACE_ROOT,
-  selectInitialCodeServerFile,
   terminalDisplayCwd,
-  terminalProjectForThread,
 } from "./sandbox-route-support";
 import { parseThreadRouteParam, readGatewayUserId } from "./tenancy";
 
@@ -38,31 +36,19 @@ async function openComputerIde(c: AgentContext): Promise<Response> {
 async function openThreadIde(c: AgentContext): Promise<Response> {
   const userId = readGatewayUserId(c.req.raw.headers);
   const threadId = parseThreadRouteParam(c.req.param("threadId") ?? "");
-  await requireWritableThreadProject(c.env, userId, threadId);
-  const project = await terminalProjectForThread(c.env, userId, threadId);
+  const project = await requireWritableThreadProject(c.env, userId, threadId);
   const sandbox = await sandboxForUser(c.env, userId);
   const workspacePath = project
     ? workspacePathForSlug(project.workspaceSlug)
     : SANDBOX_WORKSPACE_ROOT;
-  const initialFilePath = project
-    ? selectInitialCodeServerFile(
-        (await sandbox.listFiles({ includeHidden: false, path: workspacePath, recursive: true }))
-          .files,
-        workspacePath,
-      )
-    : undefined;
-  const session = await sandbox.exposeCodeServer({
-    ...(initialFilePath ? { initialFilePath } : {}),
-    workspacePath,
-  });
+  const session = await sandbox.exposeCodeServer({ workspacePath });
   return ideSessionResponse(c, session);
 }
 
 async function wakeThreadPreview(c: AgentContext): Promise<Response> {
   const userId = readGatewayUserId(c.req.raw.headers);
   const threadId = parseThreadRouteParam(c.req.param("threadId") ?? "");
-  await requireWritableThreadProject(c.env, userId, threadId);
-  const project = await terminalProjectForThread(c.env, userId, threadId);
+  const project = await requireWritableThreadProject(c.env, userId, threadId);
   const sandbox = await sandboxForUser(c.env, userId);
   const result = await sandbox.wakePreview({
     ...(project ? { workspaceSlug: project.workspaceSlug } : {}),
@@ -74,8 +60,7 @@ async function wakeThreadPreview(c: AgentContext): Promise<Response> {
 async function threadPreviewStatus(c: AgentContext): Promise<Response> {
   const userId = readGatewayUserId(c.req.raw.headers);
   const threadId = parseThreadRouteParam(c.req.param("threadId") ?? "");
-  await requireWritableThreadProject(c.env, userId, threadId);
-  const project = await terminalProjectForThread(c.env, userId, threadId);
+  const project = await requireWritableThreadProject(c.env, userId, threadId);
   const sandbox = await sandboxForUser(c.env, userId);
   if (project) {
     const status = await sandbox.projectPreviewStatus({ workspaceSlug: project.workspaceSlug });

--- a/apps/agent-worker/src/sandbox-route-support.ts
+++ b/apps/agent-worker/src/sandbox-route-support.ts
@@ -1,7 +1,6 @@
 import { getProject, getThread, withUserDb } from "@cheatcode/db";
 import { APIError } from "@cheatcode/observability";
 import { toProjectId, toThreadId, toUserId } from "@cheatcode/types";
-import type { SandboxFileEntry } from "@cheatcode/types/api";
 import { z } from "zod";
 import type { AgentEnv } from "./agent-env";
 import { shellQuote } from "./sandbox-support";
@@ -9,46 +8,6 @@ import { shellQuote } from "./sandbox-support";
 export const SANDBOX_WORKSPACE_ROOT = "/workspace";
 export const TERMINAL_DISPLAY_WORKSPACE = "/home/user/computer";
 
-const APP_ENTRY_FILE_NAMES = new Set([
-  "app.js",
-  "index.html",
-  "next.config.js",
-  "package.json",
-  "vite.config.js",
-]);
-const CODE_SERVER_IGNORED_SEGMENTS = new Set([
-  ".git",
-  ".next",
-  ".turbo",
-  "dist",
-  "node_modules",
-  "out",
-]);
-const CODE_SERVER_DELIVERABLE_EXTENSIONS = new Set([
-  ".doc",
-  ".docx",
-  ".odp",
-  ".ods",
-  ".odt",
-  ".pdf",
-  ".ppt",
-  ".pptx",
-  ".xls",
-  ".xlsx",
-]);
-const CODE_SERVER_ENTRY_RELATIVE_PATHS = [
-  "index.html",
-  "package.json",
-  "src/app/page.tsx",
-  "src/app/page.jsx",
-  "src/App.tsx",
-  "src/App.jsx",
-  "src/main.tsx",
-  "src/main.jsx",
-  "app.js",
-  "main.py",
-  "README.md",
-];
 const SandboxStateCacheSchema = z.strictObject({
   state: z.string().min(1).max(50),
   updatedAt: z.string().optional(),
@@ -83,55 +42,6 @@ export async function terminalProjectForThread(
       return { id: project.id, name: project.name, workspaceSlug: project.workspaceSlug };
     });
   });
-}
-
-export function selectInitialCodeServerFile(
-  files: SandboxFileEntry[],
-  workspacePath: string,
-): string | undefined {
-  const candidates = files
-    .filter((file) => file.type === "file" && isCodeServerCandidate(file.path, workspacePath))
-    .sort(
-      (left, right) =>
-        codeServerFileScore(right, workspacePath) - codeServerFileScore(left, workspacePath),
-    );
-  return candidates[0]?.path;
-}
-
-function isCodeServerCandidate(path: string, workspacePath: string): boolean {
-  if (!path.startsWith(`${workspacePath}/`)) {
-    return false;
-  }
-  const relativePath = path.slice(workspacePath.length + 1);
-  return !relativePath.split("/").some((segment) => CODE_SERVER_IGNORED_SEGMENTS.has(segment));
-}
-
-function codeServerFileScore(file: SandboxFileEntry, workspacePath: string): number {
-  const relativePath = file.path.slice(workspacePath.length + 1);
-  const extension = extensionOf(file.name);
-  if (CODE_SERVER_DELIVERABLE_EXTENSIONS.has(extension)) {
-    return 1_000 - relativePath.split("/").length;
-  }
-  const entryIndex = CODE_SERVER_ENTRY_RELATIVE_PATHS.indexOf(relativePath);
-  if (entryIndex !== -1) {
-    return 900 - entryIndex;
-  }
-  if (APP_ENTRY_FILE_NAMES.has(file.name)) {
-    return 800;
-  }
-  if (isLikelySourceExtension(extension)) {
-    return 500 - relativePath.split("/").length;
-  }
-  return 100 - relativePath.length / 1_000;
-}
-
-function extensionOf(filename: string): string {
-  const dotIndex = filename.lastIndexOf(".");
-  return dotIndex <= 0 ? "" : filename.slice(dotIndex).toLowerCase();
-}
-
-function isLikelySourceExtension(extension: string): boolean {
-  return [".css", ".html", ".js", ".jsx", ".json", ".md", ".py", ".ts", ".tsx"].includes(extension);
 }
 
 export function terminalDisplayCwd(cwd: string): string {

--- a/apps/agent-worker/src/sandbox-terminal-http-routes.ts
+++ b/apps/agent-worker/src/sandbox-terminal-http-routes.ts
@@ -85,8 +85,7 @@ async function executeThreadTerminalCommand(c: AgentContext): Promise<Response> 
   const userId = readGatewayUserId(c.req.raw.headers);
   const threadId = parseThreadRouteParam(c.req.param("threadId") ?? "");
   const body = await readTerminalCommand(c);
-  await requireWritableThreadProject(c.env, userId, threadId);
-  const project = await terminalProjectForThread(c.env, userId, threadId);
+  const project = await requireWritableThreadProject(c.env, userId, threadId);
   const sandbox = await sandboxForUser(c.env, userId);
   const workspaceDir = project
     ? workspacePathForSlug(project.workspaceSlug)

--- a/packages/agent-core/src/mastra/tool-defs/tool-runtime-context.ts
+++ b/packages/agent-core/src/mastra/tool-defs/tool-runtime-context.ts
@@ -37,6 +37,7 @@ export async function workspaceRuntimeFromContext(context: unknown) {
     const workspace = await runtime.ensureWorkspace?.();
     if (workspace) {
       runtime.workspaceDir = workspace.workspaceDir;
+      runtime.workspaceSlug = workspace.workspaceSlug;
     }
   }
   if (!runtime.workspaceDir) {

--- a/packages/agent-core/src/tools/code/preview.ts
+++ b/packages/agent-core/src/tools/code/preview.ts
@@ -66,8 +66,13 @@ export async function prepareStartDevServer(
   runtimeContext: CodeRuntimeContextFor<"allocateProjectPort">,
 ): Promise<PreparedStartDevServer> {
   const parsedInput = StartDevServerInputSchema.parse(input);
+  if (!runtimeContext.workspaceDir || !runtimeContext.workspaceSlug) {
+    throw new APIError(500, "internal_service_error", "Project workspace is unavailable", {
+      retriable: false,
+    });
+  }
   const cwd = resolveProjectWorkspacePath(parsedInput.cwd, runtimeContext.workspaceDir);
-  const slug = deriveWorkspaceSlug(cwd);
+  const slug = runtimeContext.workspaceSlug;
   const isExpo = isExpoStartCommand(parsedInput.command);
   const isMobile = isExpo || parsedInput.isMobile;
   const port = await allocateDevServerPort(runtimeContext, slug, isMobile);
@@ -151,17 +156,6 @@ function expoWebCommand(port: number): string[] {
     "node /tmp/cc-restore-expo-deps.js && rm -f pnpm-lock.yaml package-lock.json && CI=1 EXPO_NO_TELEMETRY=1 pnpm install --prefer-offline";
   const startMetro = `exec pnpm exec expo start -c --web --host lan --port ${port}`;
   return ["sh", "-lc", `${writeScript}; (${heal}) ; ${startMetro}`];
-}
-
-// The project's workspaceSlug = the last non-empty path segment of the cwd (/workspace/<slug>).
-// Every run has a project, so the forced cwd is always /workspace/<slug> and yields a slug here.
-function deriveWorkspaceSlug(cwd: string): string {
-  const segments = cwd.split("/").filter((segment) => segment.length > 0);
-  const slug = segments[segments.length - 1];
-  if (!slug) {
-    throw new Error(`Cannot derive a workspace slug from cwd: ${cwd}`);
-  }
-  return slug;
 }
 
 // Get-or-assign this project's stable dev-server port from the sandbox's per-project allocator

--- a/packages/sandbox-contracts/README.md
+++ b/packages/sandbox-contracts/README.md
@@ -22,6 +22,8 @@ objects are not cloned or stripped during validation.
 Long-running processes require a caller-owned stable `processId`. The sandbox uses that identity
 as an idempotency slot for replacement, inspection, cleanup, and bounded record reaping; anonymous
 fire-and-forget process records are not part of the contract.
+Project-backed `CodeRuntimeContext` values carry both the canonical `workspaceDir` and the explicit
+`workspaceSlug`. Process ownership uses the slug even when the command runs from a nested directory.
 Project preview ports have separate allocate and read capabilities so browser
 actions can prove that a loopback page is the active project's managed preview
 rather than trusting an arbitrary localhost port.

--- a/packages/sandbox-contracts/src/runtime.ts
+++ b/packages/sandbox-contracts/src/runtime.ts
@@ -7,6 +7,7 @@ export type { ArtifactKind } from "@cheatcode/types/artifacts";
 
 const ENVIRONMENT_VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/u;
 const MAX_ENVIRONMENT_VARIABLES = 128;
+const WORKSPACE_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
 
 /** A bounded, shell-safe process environment accepted at the sandbox boundary. */
 export const EnvironmentVariablesSchema = z
@@ -211,6 +212,8 @@ export interface CodeRuntimeContext {
   sandbox: SandboxLike;
   /** The project folder inside the shared per-user sandbox. */
   workspaceDir?: string | undefined;
+  /** Stable project identity; process slots must not infer this from a nested command cwd. */
+  workspaceSlug?: string | undefined;
 }
 
 /** Narrows a tool's sandbox dependency to only the methods it invokes. */
@@ -244,6 +247,7 @@ export const CodeRuntimeContextSchema = z.strictObject({
   ensureWorkspace: z.custom<WorkspaceResolver>((value) => typeof value === "function").optional(),
   sandbox: SandboxLikeSchema,
   workspaceDir: z.string().optional(),
+  workspaceSlug: z.string().min(1).max(64).regex(WORKSPACE_SLUG).optional(),
 });
 
 function isArtifactRuntime(value: unknown): value is ArtifactRuntime {

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -339,9 +339,9 @@ export const SandboxPreviewWakeSchema = z.strictObject({
 });
 
 /**
- * Current sandbox lifecycle state for the preview panel. Kept fresh by Daytona
- * `sandbox.state.updated` webhooks (falls back to a live read). `running` is true only in the
- * `started` state; the panel uses this to show a booting spinner or a resume affordance.
+ * Current app-preview state for the preview panel. `state: "none"` means this project has no
+ * tracked dev server; otherwise `state` carries the current sandbox lifecycle state and `running`
+ * reports whether the tracked server's port is live.
  */
 export const SandboxPreviewStatusSchema = z.strictObject({
   running: z.boolean(),


### PR DESCRIPTION
## Summary

- Key managed previews by the canonical project slug instead of nested command cwd.
- Skip recursive workspace enumeration before opening Files/code-server.
- Fast-relaunch tracked preview and code-server sessions after Daytona idle stops.
- Return an explicit no-preview state so the web client does not retry a useless wake loop.
- Collapse duplicate project lookups on preview, IDE, and terminal routes.

This fixes the production chat where Vite ran from a nested `studio-site` directory, while reopen looked for the project-level preview slot and could not restore it after idle shutdown.

## Architecture

`workspaceSlug` is now an explicit runtime contract. `cwd` remains the execution directory and no longer controls durable process identity. No legacy fallback or path-derived process key is retained.

## Verification notes

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm turbo build --force`
- [x] `pnpm deadcode`
- [x] `pnpm architecture:check`
- [x] `pnpm turbo skills:build`

Full forced production builds completed for all 19 packages and every Worker dry-run. Architecture analysis reported 847 modules and 1,752 dependencies with no violations. Knip exited cleanly with only four existing configuration hints.

Production browser QA follows the main-branch Cloudflare deployment because the acceptance case requires stopping and reopening the real persistent Daytona sandbox. The planned check covers the exact affected chat, preview recovery, Files startup, console, network, app logs, and a forced idle-stop cycle.

## Review focus

1. Follow `workspaceSlug` from agent-run workspace binding into `prepareStartDevServer`.
2. Review no-record behavior in `wakePreview` and `projectPreviewStatus`.
3. Review tracked code-server relaunch and the removed recursive file pre-scan.

No Linear issue or plan document exists; this is a directly reproduced production incident.