### PR TITLE
fix(agent): prevent projectless app builds

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -109,6 +109,12 @@ answer segmentation. The Workflow controller owns admission, execution identity,
 at-most-once fence, and ownership leases. The shell retains only Durable Object identity,
 cancellation, status, and dependency wiring.
 
+An explicit app-builder mode remains authoritative. On a projectless first run, a narrowly
+matched imperative such as “build a website” or “create a mobile app” also enters the matching
+app-builder path before model execution. That high-confidence fallback materializes the project,
+scaffolds its canonical workspace, and registers the managed preview even when the selected model
+would otherwise attempt generic shell work and finish without a Computer target.
+
 AgentRun keeps one compact exact SQLite shape for run identity, replay parts, and
 coordination state. Dormant objects are reconciled transactionally on activation;
 target detection checks column order, affinity, nullability, primary keys, and

--- a/apps/agent-worker/src/durable-objects/agent-run-path.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-path.ts
@@ -33,7 +33,9 @@ type ProjectBoundAgentRunPathOptions = AgentRunPathOptions & {
 export async function executeAgentRunPath(
   options: AgentRunPathOptions,
 ): Promise<"completed" | "continue"> {
-  if (isAppBuilderMode(options.input.projectMode)) {
+  const appBuilderMode = appBuilderModeForRun(options.input);
+  if (appBuilderMode) {
+    options.input.projectMode = appBuilderMode;
     await options.workspaceResolver();
     return executeAppBuilderPath({
       ...options,
@@ -92,6 +94,27 @@ function requireProjectBinding(input: StartRunInput): ProjectBoundStartRunInput 
   return input as ProjectBoundStartRunInput;
 }
 
-function isAppBuilderMode(mode: StartRunInput["projectMode"]): boolean {
+function isAppBuilderMode(
+  mode: StartRunInput["projectMode"],
+): mode is "app-builder" | "app-builder-mobile" {
   return mode === "app-builder" || mode === "app-builder-mobile";
+}
+
+const IMPERATIVE_BUILD_PATTERN =
+  /^(?:please\s+)?(?:(?:can|could|would)\s+you\s+)?(?:build|create|make|design|develop|implement|code|scaffold|redesign|clone)\b/iu;
+const MOBILE_APP_PATTERN = /\b(?:mobile app|expo|react native|ios app|android app|iphone app)\b/iu;
+const WEB_APP_PATTERN =
+  /\b(?:web ?app|website|web ?site|landing ?page|home ?page|web ?page|dashboard|next\.?js|frontend|front-end|saas)\b/iu;
+
+function appBuilderModeForRun(input: StartRunInput): "app-builder" | "app-builder-mobile" | null {
+  if (isAppBuilderMode(input.projectMode)) {
+    return input.projectMode;
+  }
+  if (!input.isFirstRun || input.projectId || !IMPERATIVE_BUILD_PATTERN.test(input.messageText)) {
+    return null;
+  }
+  if (MOBILE_APP_PATTERN.test(input.messageText)) {
+    return "app-builder-mobile";
+  }
+  return WEB_APP_PATTERN.test(input.messageText) ? "app-builder" : null;
 }

--- a/apps/agent-worker/src/durable-objects/agent-run-workspace.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-workspace.ts
@@ -77,6 +77,9 @@ async function materializeWorkspaceProject(input: WorkspaceResolverInput) {
       materializeThreadProject(
         tx,
         {
+          ...(input.input.projectMode === "general"
+            ? {}
+            : { projectMode: input.input.projectMode }),
           threadId: toThreadId(input.input.threadId),
           userId,
         },

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -36,7 +36,10 @@ project's allocated port when necessary, and is distinct from generic background
 process tools so idle recovery always has a canonical process record.
 Browser-only runs use the account sandbox without materializing a persistent project;
 workspace-backed file, shell, document, chart, or artifact work resolves the thread's
-project lazily when durable project storage is actually needed.
+project lazily when durable project storage is actually needed. Code tools expose `/workspace`
+as a virtual project root and remap path references inside argv, shell payloads, and inline code
+to the canonical project folder. Projectless calculations and environment probes run from `/tmp`,
+so a weaker model cannot accidentally leave durable files outside a project.
 
 ## Code Checks
 

--- a/packages/agent-core/src/mastra/tool-defs/code-tools.ts
+++ b/packages/agent-core/src/mastra/tool-defs/code-tools.ts
@@ -42,6 +42,7 @@ import {
   WriteFileInputSchema,
   WriteFileOutputSchema,
 } from "../../tools/code";
+import { containsWorkspaceReference } from "../../tools/code/workspace-paths";
 import { codeRuntimeFromContext, workspaceRuntimeFromContext } from "./tool-runtime-context";
 import { StartDevServerInputSchema, StartDevServerOutputSchema } from "./tool-schemas";
 
@@ -52,8 +53,12 @@ export const mastraRunCode = createTool({
   inputSchema: RunCodeInputSchema,
   outputSchema: RunCodeOutputSchema,
   execute: async (input, context) => {
-    const runtimeContext = codeRuntimeFromContext(context);
     const parsedInput = RunCodeInputSchema.parse(input);
+    const baseRuntime = codeRuntimeFromContext(context);
+    const runtimeContext =
+      baseRuntime.workspaceDir || containsWorkspaceReference(parsedInput.code)
+        ? await workspaceRuntimeFromContext(context)
+        : baseRuntime;
     const output = await executeRunCode(parsedInput, runtimeContext);
     return RunCodeOutputSchema.parse(output);
   },
@@ -69,9 +74,11 @@ export const mastraShellExec = createTool({
     const parsedInput = ShellExecInputSchema.parse(input);
     const baseRuntime = codeRuntimeFromContext(context);
     const runtimeContext =
-      baseRuntime.workspaceDir || parsedInput.cwd
+      baseRuntime.workspaceDir ||
+      parsedInput.cwd ||
+      parsedInput.command.some(containsWorkspaceReference)
         ? await workspaceRuntimeFromContext(context)
-        : { ...baseRuntime, workspaceDir: "/workspace" };
+        : baseRuntime;
     return executeShellExec(parsedInput, runtimeContext);
   },
 });

--- a/packages/agent-core/src/tools/code/preview.ts
+++ b/packages/agent-core/src/tools/code/preview.ts
@@ -5,7 +5,11 @@ import {
   type SandboxStartProcessInput,
 } from "@cheatcode/sandbox-contracts";
 import { z } from "zod";
-import { resolveProjectWorkspacePath, WorkspacePathSchema } from "./workspace-paths";
+import {
+  remapProjectWorkspaceReferences,
+  resolveProjectWorkspacePath,
+  WorkspacePathSchema,
+} from "./workspace-paths";
 
 const StartDevServerInputSchema = z.strictObject({
   command: z.array(z.string().min(1).max(8_192)).min(1).max(128),
@@ -76,7 +80,10 @@ export async function prepareStartDevServer(
   const isExpo = isExpoStartCommand(parsedInput.command);
   const isMobile = isExpo || parsedInput.isMobile;
   const port = await allocateDevServerPort(runtimeContext, slug, isMobile);
-  const command = remapRequestedDevServerPort(parsedInput.command, parsedInput.port, port);
+  const workspaceCommand = parsedInput.command.map((argument) =>
+    remapProjectWorkspaceReferences(argument, runtimeContext.workspaceDir),
+  );
+  const command = remapRequestedDevServerPort(workspaceCommand, parsedInput.port, port);
   return {
     mayUseNetwork: isExpo,
     port,

--- a/packages/agent-core/src/tools/code/run-code.ts
+++ b/packages/agent-core/src/tools/code/run-code.ts
@@ -1,7 +1,7 @@
 import { APIError } from "@cheatcode/observability";
 import type { CodeRuntimeContextFor } from "@cheatcode/sandbox-contracts";
 import { z } from "zod";
-import { resolveProjectWorkspacePath } from "./workspace-paths";
+import { remapProjectWorkspaceReferences, resolveProjectWorkspacePath } from "./workspace-paths";
 
 export const RunCodeInputSchema = z.strictObject({
   language: z
@@ -25,10 +25,11 @@ export async function executeRunCode(
   runtimeContext: CodeRuntimeContextFor<"runCode">,
 ): Promise<RunCodeOutput> {
   const parsedInput = RunCodeInputSchema.parse(input);
+  const workspaceDir = runtimeContext.workspaceDir;
   const result = await runtimeContext.sandbox.runCode({
     language: parsedInput.language,
-    code: parsedInput.code,
-    cwd: resolveProjectWorkspacePath(undefined, runtimeContext.workspaceDir),
+    code: remapProjectWorkspaceReferences(parsedInput.code, workspaceDir),
+    cwd: workspaceDir ? resolveProjectWorkspacePath(undefined, workspaceDir) : "/tmp",
   });
 
   const output = {

--- a/packages/agent-core/src/tools/code/shell.ts
+++ b/packages/agent-core/src/tools/code/shell.ts
@@ -4,7 +4,11 @@ import {
   EnvironmentVariablesSchema,
 } from "@cheatcode/sandbox-contracts";
 import { z } from "zod";
-import { resolveProjectWorkspacePath, WorkspacePathSchema } from "./workspace-paths";
+import {
+  remapProjectWorkspaceReferences,
+  resolveProjectWorkspacePath,
+  WorkspacePathSchema,
+} from "./workspace-paths";
 
 export const ShellExecInputSchema = z.strictObject({
   command: z
@@ -97,9 +101,13 @@ export async function executeShellExec(
   runtimeContext: CodeRuntimeContextFor<"exec">,
 ): Promise<ShellExecOutput> {
   const parsedInput = ShellExecInputSchema.parse(input);
+  const workspaceDir = runtimeContext.workspaceDir;
   const result = await runtimeContext.sandbox.exec({
-    command: parsedInput.command,
-    cwd: resolveProjectWorkspacePath(parsedInput.cwd, runtimeContext.workspaceDir),
+    command: remapCommandWorkspaceReferences(parsedInput.command, workspaceDir),
+    cwd:
+      workspaceDir || parsedInput.cwd
+        ? resolveProjectWorkspacePath(parsedInput.cwd, workspaceDir)
+        : "/tmp",
     ...(parsedInput.env ? { env: parsedInput.env } : {}),
     ...(parsedInput.timeoutMs ? { timeoutMs: parsedInput.timeoutMs } : {}),
   });
@@ -130,7 +138,7 @@ export async function executeShellStartProcess(
     : undefined;
   return ShellProcessOutputSchema.parse(
     await runtimeContext.sandbox.startProcess({
-      command: parsedInput.command,
+      command: remapCommandWorkspaceReferences(parsedInput.command, runtimeContext.workspaceDir),
       cwd: resolveProjectWorkspacePath(parsedInput.cwd, runtimeContext.workspaceDir),
       ...(parsedInput.env ? { env: parsedInput.env } : {}),
       keepAliveTimeoutMs: parsedInput.keepAliveTimeoutMs,
@@ -162,9 +170,20 @@ export async function executeShellTerminal(
   const parsedInput = ShellTerminalInputSchema.parse(input);
   return ShellExecOutputSchema.parse(
     await runtimeContext.sandbox.exec({
-      command: ["sh", "-lc", parsedInput.command],
+      command: [
+        "sh",
+        "-lc",
+        remapProjectWorkspaceReferences(parsedInput.command, runtimeContext.workspaceDir),
+      ],
       cwd: resolveProjectWorkspacePath(parsedInput.cwd, runtimeContext.workspaceDir),
       timeoutMs: parsedInput.timeoutMs,
     }),
   );
+}
+
+function remapCommandWorkspaceReferences(
+  command: readonly string[],
+  workspaceDir: string | undefined,
+): string[] {
+  return command.map((argument) => remapProjectWorkspaceReferences(argument, workspaceDir));
 }

--- a/packages/agent-core/src/tools/code/workspace-paths.ts
+++ b/packages/agent-core/src/tools/code/workspace-paths.ts
@@ -48,7 +48,7 @@ export function resolveProjectWorkspacePath(
     });
   }
   const requested = canonicalWorkspacePath(value ?? projectRoot);
-  const resolved = requested === "/workspace" ? projectRoot : requested;
+  const resolved = resolveVirtualWorkspacePath(requested, projectRoot);
   if (resolved !== projectRoot && !resolved.startsWith(`${projectRoot}/`)) {
     throw new APIError(
       400,
@@ -61,6 +61,55 @@ export function resolveProjectWorkspacePath(
     );
   }
   return resolved;
+}
+
+/**
+ * Rewrites the virtual `/workspace` namespace inside a command or inline program to the active
+ * project's real folder. References that already use the real project root remain unchanged.
+ */
+export function remapProjectWorkspaceReferences(
+  value: string,
+  workspaceDir: string | undefined,
+): string {
+  const projectRoot = canonicalWorkspacePath(workspaceDir ?? "/workspace");
+  if (projectRoot === "/workspace") {
+    return value;
+  }
+  return value.replace(WORKSPACE_REFERENCE_PATTERN, (reference, offset: number) =>
+    isProjectRootReference(value, offset, projectRoot) ? reference : projectRoot,
+  );
+}
+
+export function containsWorkspaceReference(value: string): boolean {
+  WORKSPACE_REFERENCE_PATTERN.lastIndex = 0;
+  return WORKSPACE_REFERENCE_PATTERN.test(value);
+}
+
+const WORKSPACE_REFERENCE_PATTERN = /(?<![\p{L}\p{N}_./-])\/workspace(?=\/|$|[\s"'`,;:)}\]])/gu;
+
+function resolveVirtualWorkspacePath(requested: string, projectRoot: string): string {
+  if (requested === projectRoot || requested.startsWith(`${projectRoot}/`)) {
+    return requested;
+  }
+  if (requested === "/workspace") {
+    return projectRoot;
+  }
+  if (requested.startsWith("/workspace/")) {
+    return `${projectRoot}${requested.slice("/workspace".length)}`;
+  }
+  return requested;
+}
+
+function isProjectRootReference(value: string, offset: number, projectRoot: string): boolean {
+  if (!value.startsWith(projectRoot, offset)) {
+    return false;
+  }
+  const nextCharacter = value.at(offset + projectRoot.length);
+  return nextCharacter === undefined || isPathBoundary(nextCharacter);
+}
+
+function isPathBoundary(value: string): boolean {
+  return /[/\s"'`,;:)}\]]/u.test(value);
 }
 
 function isSafeWorkspaceRelativePath(path: string): boolean {

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -93,7 +93,8 @@ Public exports include:
 - BYOK and integration helpers
 - entitlement and usage helpers
 - caller-configured user-skill list primitives plus locked count/insert/update composition
-- entitlement-read/project-lock composition for billing-owned lazy-materialization limits
+- entitlement-read/project-lock composition for billing-owned lazy-materialization limits and
+  the run's resolved project mode
 - lifecycle job discovery, claim, renewal, progression, and completion helpers
 - locked refund-intent reads/writes that execute caller-owned transition policy in-transaction
 - audit and maintenance helpers

--- a/packages/db/src/runs.ts
+++ b/packages/db/src/runs.ts
@@ -208,7 +208,7 @@ async function lockRunIdempotencyKey(db: Database, input: CreateAgentRunInput): 
 /** Materialize a project atomically when a workspace-backed tool first needs it. */
 export async function materializeThreadProject(
   db: Database,
-  input: { threadId: ThreadId; userId: UserId },
+  input: { projectMode?: ProjectMode; threadId: ThreadId; userId: UserId },
   resolveMaxActiveProjects: (entitlement: AgentEntitlementRecord | null) => number,
 ): Promise<MaterializeThreadProjectResult> {
   return db.transaction(async (tx) => {
@@ -226,7 +226,7 @@ export async function materializeThreadProject(
 
 async function materializeThreadProjectInLockedTx(
   db: Database,
-  input: { threadId: ThreadId; userId: UserId },
+  input: { projectMode?: ProjectMode; threadId: ThreadId; userId: UserId },
   maxActiveProjects: number,
 ): Promise<MaterializeThreadProjectResult> {
   const [locked] = await db
@@ -267,7 +267,7 @@ async function materializeThreadProjectInLockedTx(
   }
   const intent: ThreadLaunchIntent = locked.launchIntent ?? {};
   const project = await createProject(db, {
-    mode: intent.mode ?? "general",
+    mode: input.projectMode ?? intent.mode ?? "general",
     name: projectNameFromTitle(locked.title),
     userId: input.userId,
     ...(intent.defaultModel ? { defaultModel: intent.defaultModel } : {}),

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -33,7 +33,7 @@ export const GitHubRepoUrlSchema = z
 const PROJECT_MODES = ["app-builder", "app-builder-mobile", "general"] as const;
 export const ProjectModeSchema = z.enum(PROJECT_MODES);
 
-/** Explicit one-run product modes. These are UI intent, never inferred from prompt text. */
+/** Product modes selected by UI intent or a high-confidence first-run build imperative. */
 const RUN_INTENTS = ["skill-creator"] as const;
 export const RunIntentSchema = z.enum(RUN_INTENTS);
 


### PR DESCRIPTION
## Summary

- Route high-confidence first-run web/mobile build imperatives through the managed app-builder path.
- Treat `/workspace` as a virtual project root across file, shell, inline-code, and preview commands.
- Run genuinely projectless calculations and environment probes from `/tmp` so they cannot leave orphaned durable files.
- Persist the resolved builder mode when lazy project materialization creates the project.

## Context

A production DeepSeek run wrote a complete site into `/workspace/beautiful-site` without attaching a project or registering a managed preview, then claimed the result was available in Computer. Files therefore had no project to open and Browser had no preview record.

No Linear issue or standalone plan document is linked; this is a production QA follow-up to the preview recovery work in #118 and #119.

## Architecture

A narrowly matched imperative first message (for example, “build a website”) is promoted from general mode into the existing app-builder path before model execution. The builder creates the canonical project and managed preview first. Tool execution then remaps the model-facing virtual `/workspace` namespace into that project root. Commands with no workspace intent remain projectless and use `/tmp`.

## Decisions Made

| Decision | Choice | Alternatives considered | Reasoning |
| --- | --- | --- | --- |
| Model variance | Enforce the invariant in runtime code | More prompt wording | Weaker models may ignore descriptions; project/preview correctness cannot depend on compliance. |
| Build inference | Only first-run, projectless, imperative web/mobile prompts | Classify every website mention | Avoids creating projects for informational questions or existing-project follow-ups. |
| Projectless cwd | `/tmp` | Shared `/workspace` root | Environment probes stay ephemeral and cannot create unindexed durable files. |
| Workspace paths | Remap virtual paths into the canonical project | Reject common `/workspace/*` inputs | Keeps models compatible while preventing sibling-project writes. |

## Edge Cases Handled

| Scenario | Handling |
| --- | --- |
| DeepSeek writes an absolute `/workspace/*` path in argv or inline code | The path binds and remaps to the active project. |
| A throwaway calculation uses no project path | It runs in `/tmp` without creating a project. |
| A model requests a familiar preview port | Workspace remapping happens before stable port remapping. |
| A project already exists or the run is a follow-up | No inferred builder bootstrap occurs. |
| UI explicitly selected app-builder mode | Explicit mode remains authoritative. |

## How to Review

1. Start with `agent-run-path.ts` for the high-confidence first-run builder routing.
2. Review `workspace-paths.ts` and the code-tool adapters for confinement/remapping.
3. Review `runs.ts` for persisted resolved project mode.
4. Skim README updates for the documented runtime contract.

## Test Plan

- [x] Full monorepo typecheck, including scripts
- [x] Full monorepo lint
- [x] Forced production build for all 19 packages and Worker dry-runs
- [x] Dependency architecture check
- [x] Dead-code check
- [ ] Production DeepSeek first-run build after merge/deploy
- [ ] Confirm Files and Browser both open the materialized project and managed preview
