### PR TITLE
fix(agent): route projectless build prompts

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -109,7 +109,7 @@ answer segmentation. The Workflow controller owns admission, execution identity,
 at-most-once fence, and ownership leases. The shell retains only Durable Object identity,
 cancellation, status, and dependency wiring.
 
-An explicit app-builder mode remains authoritative. On a projectless first run, a narrowly
+An explicit app-builder mode remains authoritative. In a projectless chat, a narrowly
 matched imperative such as “build a website” or “create a mobile app” also enters the matching
 app-builder path before model execution. That high-confidence fallback materializes the project,
 scaffolds its canonical workspace, and registers the managed preview even when the selected model

--- a/apps/agent-worker/src/durable-objects/agent-run-path.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-path.ts
@@ -110,7 +110,7 @@ function appBuilderModeForRun(input: StartRunInput): "app-builder" | "app-builde
   if (isAppBuilderMode(input.projectMode)) {
     return input.projectMode;
   }
-  if (!input.isFirstRun || input.projectId || !IMPERATIVE_BUILD_PATTERN.test(input.messageText)) {
+  if (input.projectId || !IMPERATIVE_BUILD_PATTERN.test(input.messageText)) {
     return null;
   }
   if (MOBILE_APP_PATTERN.test(input.messageText)) {

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -33,7 +33,7 @@ export const GitHubRepoUrlSchema = z
 const PROJECT_MODES = ["app-builder", "app-builder-mobile", "general"] as const;
 export const ProjectModeSchema = z.enum(PROJECT_MODES);
 
-/** Product modes selected by UI intent or a high-confidence first-run build imperative. */
+/** Product modes selected by UI intent or a high-confidence projectless build imperative. */
 const RUN_INTENTS = ["skill-creator"] as const;
 export const RunIntentSchema = z.enum(RUN_INTENTS);
 


### PR DESCRIPTION
## What changed
- route high-confidence imperative website and mobile-app prompts into the managed builder whenever the chat has no project
- stop treating `isFirstRun` as the first run of a chat; it represents the user account’s first-ever agent run
- keep explicit project modes and existing-project follow-ups authoritative

## Why
Production DeepSeek V4 QA after PR #120 exposed the semantic mismatch: workspace confinement worked, but a returning user’s new projectless build chat remained in general mode and could still omit the managed preview.

## Verification
- `pnpm typecheck`
- `pnpm turbo lint`
- `pnpm turbo build --force`
- architecture checks: 847 modules / 1,753 dependencies, zero violations
- dead-code check: exit 0 (four existing configuration hints only)

After merge and Cloudflare deployment, this will be re-tested through the production UI with DeepSeek V4.