### PR TITLE
fix(agent): stabilize DeepSeek app previews

### DIFF
--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder-scaffold.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder-scaffold.ts
@@ -84,7 +84,7 @@ export async function scaffoldExpoApp(
   logger: AgentRunLogger,
   dir: string,
 ): Promise<void> {
-  // Copy the template CONTENTS (`src/.` → `dst/`), never `cp -a src dst`: the latter nests as
+  // Copy the template CONTENTS (`src/.` → `dst/`), never `cp -R src dst`: the latter nests as
   // `dst/cheatcode-expo-template/` when `dst` already exists (the run-start `mkdir -p` of the
   // workspace dir can win the race), silently yielding a project with no package.json at its root.
   // `test -f` verifies the baked, lockfile-backed layout. A missing template means the immutable
@@ -102,7 +102,7 @@ export async function scaffoldAppBuilder(
   logger: AgentRunLogger,
   dir: string,
 ): Promise<void> {
-  // Copy template CONTENTS into the project dir (see scaffoldExpoApp): `cp -a src dst` nests as
+  // Copy template CONTENTS into the project dir (see scaffoldExpoApp): `cp -R src dst` nests as
   // `dst/cheatcode-next-template/` when `dst` already exists, leaving no package.json at the root.
   if (await copyTemplateContents(sandbox, NEXT_TEMPLATE_DIR, dir)) {
     logger.info("sandbox_next_template_copied", { targetDir: dir });
@@ -216,9 +216,12 @@ export async function ensureExpoWebSupport(
 }
 
 // Populate `dir` with the CONTENTS of a baked template (`src/.` copies dotfiles too), then verify a
-// package.json landed at the root. Returns false instead of throwing so callers fall back to a
-// generator only on a genuine failure. `dir` is a filesystem-safe /workspace/<slug> path (no shell
-// metacharacters), so the interpolation is safe; the whole script is shell-quoted by the exec layer.
+// package.json landed at the root. `/workspace` is Daytona's object-store FUSE mount: recursive copy
+// is intentional because archive mode tries to preserve ownership, modes, and timestamps that the
+// mount does not support, making a tiny source-only scaffold hang until its timeout. Immutable
+// dependencies remain on the snapshot-local filesystem. `dir` is a filesystem-safe
+// /workspace/<slug> path (no shell metacharacters), so interpolation is safe; the whole script is
+// shell-quoted by the exec layer.
 async function copyTemplateContents(
   sandbox: ProjectSandboxStub,
   templateDir: string,
@@ -226,9 +229,9 @@ async function copyTemplateContents(
 ): Promise<boolean> {
   const copied = await executeShellTerminal(
     {
-      command: `mkdir -p ${dir} && cp -a ${templateDir}/. ${dir}/ && test -f ${dir}/package.json`,
+      command: `mkdir -p ${dir} && cp -R -- ${templateDir}/. ${dir}/ && test -f ${dir}/package.json`,
       cwd: "/workspace",
-      timeoutMs: 30_000,
+      timeoutMs: 60_000,
     },
     { sandbox },
   );

--- a/apps/agent-worker/src/durable-objects/llm-provider.ts
+++ b/apps/agent-worker/src/durable-objects/llm-provider.ts
@@ -200,7 +200,7 @@ async function resolveProviderKey(
 
 /**
  * Transport rule: (a) the user's direct provider key
- * always wins. The platform DeepSeek key then serves the `deepseek-v4-flash` SKU —
+ * always wins. The platform DeepSeek key then serves the `deepseek-v4-pro` SKU —
  * before OpenRouter when the user explicitly picked it, or after OpenRouter as the last
  * resort for an Auto/implicit run with no usable key. (c) Otherwise a non-OpenRouter
  * selection routes through OpenRouter when a key is present. Runs inside the caller's
@@ -219,12 +219,12 @@ async function resolveTransportKey(
     return transportCredential(directKey, logicalModelId, selection);
   }
 
-  const wantsPlatformFlash =
+  const wantsPlatformPro =
     selection.provider === "deepseek" && selection.modelId === DEFAULT_DEEPSEEK_MODEL_ID;
   const platformKey = allowedPlatformKey(platformFallback);
 
   // (b) Explicit platform-model pick → platform key before OpenRouter.
-  if (wantsPlatformFlash && platformKey) {
+  if (wantsPlatformPro && platformKey) {
     return platformTransport(platformKey);
   }
 

--- a/packages/agent-core/src/mastra/agents/general.ts
+++ b/packages/agent-core/src/mastra/agents/general.ts
@@ -81,7 +81,7 @@ function createOpenRouterByokModel(
 
 /**
  * DeepSeek model — serves both the included platform route and user BYOK keys.
- * Pass the bare provider id (`deepseek-v4-flash`); non-thinking mode is selected at the
+ * Pass the bare provider id (`deepseek-v4-pro`); non-thinking mode is selected at the
  * stream call site via providerOptions so tool-calling stays clean.
  */
 function createDeepSeekModel(

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -21,7 +21,7 @@ function logicalModelId<const Value extends string>(value: Value): Value & Logic
 const RAW_CATALOG_MODEL_IDS = {
   claudeOpus: "anthropic/claude-opus-4-8",
   claudeSonnet: "anthropic/claude-sonnet-4-6",
-  deepseekFlash: "deepseek/deepseek-v4-flash",
+  deepseekPro: "deepseek/deepseek-v4-pro",
   gptMini: "openai/gpt-5.4-mini",
   gptThinking: "openai/gpt-5.4-thinking",
 } as const;
@@ -31,14 +31,14 @@ const RAW_CATALOG_MODEL_ID_VALUES = [
   RAW_CATALOG_MODEL_IDS.claudeOpus,
   RAW_CATALOG_MODEL_IDS.gptThinking,
   RAW_CATALOG_MODEL_IDS.gptMini,
-  RAW_CATALOG_MODEL_IDS.deepseekFlash,
+  RAW_CATALOG_MODEL_IDS.deepseekPro,
 ] as const;
 
 /**
  * The single source of truth for the agent model catalog shown in the picker.
  *
  * Curated to the live Models list: Claude Sonnet 4.6, Claude Opus 4.8,
- * GPT-5.4 Thinking, GPT-5.4 Mini, and the included DeepSeek V4 model. Gemini 2.5
+ * GPT-5.4 Thinking, GPT-5.4 Mini, and the included DeepSeek V4 Pro model. Gemini 2.5
  * Flash and the standalone OpenRouter-Auto row stay reachable as provider-prefixed
  * request ids routed through OpenRouter, but are not drawn in the picker.
  *
@@ -71,8 +71,8 @@ export const AGENT_MODEL_CATALOG = [
     description: "Fast fallback model for lower-cost utility runs.",
   },
   {
-    id: logicalModelId(RAW_CATALOG_MODEL_IDS.deepseekFlash),
-    label: "DeepSeek V4",
+    id: logicalModelId(RAW_CATALOG_MODEL_IDS.deepseekPro),
+    label: "DeepSeek V4 Pro",
     provider: "deepseek",
     description: "Included by Cheatcode with no provider key required.",
   },
@@ -92,7 +92,7 @@ export const FALLBACK_MODEL_ID = logicalModelId(
  * without a provider key and the only model served by Cheatcode's DeepSeek key.
  */
 export const INCLUDED_DEEPSEEK_MODEL_ID = logicalModelId(
-  RAW_CATALOG_MODEL_IDS.deepseekFlash,
+  RAW_CATALOG_MODEL_IDS.deepseekPro,
 ) satisfies CatalogModelId;
 
 /** Validate against raw literals first; Zod enums cannot retain branded string tuples. */

--- a/skills/product-self-knowledge/SKILL.md
+++ b/skills/product-self-knowledge/SKILL.md
@@ -47,7 +47,7 @@ The visible model catalog is:
 | Claude Opus 4.8 | Anthropic | Highest-capability Anthropic option |
 | GPT-5.4 Thinking | OpenAI | Reasoning-focused option |
 | GPT-5.4 Mini | OpenAI | Fast utility option |
-| DeepSeek V4 | DeepSeek | Included platform route |
+| DeepSeek V4 Pro | DeepSeek | Included platform route |
 
 Cheatcode accepts provider-prefixed OpenRouter and Google model IDs even though those providers are not shown as separate catalog rows. BYOK keys are configured in Models and are decrypted only for the active request. Supported provider key families are Anthropic, OpenAI, Google, OpenRouter, DeepSeek, Exa, and Firecrawl. BYOK key counts are not limited by subscription-plan slots.
 


### PR DESCRIPTION
## Summary

- route the included DeepSeek model through the official deepseek-v4-pro transport
- show DeepSeek V4 Pro in the product catalog and bundled product knowledge
- copy source-only app templates without archive metadata operations on Daytona FUSE

## Why

Production diagnostics showed the sandbox starts correctly, but archive-mode template copies try to preserve metadata unsupported by the S3-backed workspace mount and can time out. A separate DeepSeek V4 Flash run also showed weak adherence to the managed app scaffold. This change removes the filesystem failure and moves the included model to V4 Pro for an exact production comparison.

## Verification

- pnpm turbo typecheck lint build --force
- pnpm architecture:check
- pnpm deadcode
- git diff --check
- direct Daytona CLI inspection of the production sandbox and workspace mount
- direct agent-browser production QA after deployment