### PR TITLE
fix(web): refresh composer auth token

### DIFF
--- a/apps/web/src/components/home/home-composer-auth.ts
+++ b/apps/web/src/components/home/home-composer-auth.ts
@@ -1,31 +1,7 @@
-"use client";
-
-type ClerkBrowserSession = {
-  session?: {
-    getToken?: () => Promise<null | string>;
-    lastActiveToken?: {
-      getRawString?: () => string;
-    };
-  };
-};
+type ClerkTokenGetter = (options?: { skipCache?: boolean }) => Promise<null | string>;
 
 export async function resolveComposerAuthToken(
-  getAuthToken: () => Promise<null | string>,
+  getAuthToken: ClerkTokenGetter,
 ): Promise<null | string> {
-  const browserSession = (window as Window & { Clerk?: ClerkBrowserSession }).Clerk?.session;
-  const rawToken = browserSession?.lastActiveToken?.getRawString?.();
-  if (rawToken) {
-    return rawToken;
-  }
-  const browserToken = browserSession?.getToken
-    ? await Promise.race([browserSession.getToken(), composerDelay(500).then(() => null)])
-    : null;
-  if (browserToken) {
-    return browserToken;
-  }
-  return Promise.race([getAuthToken(), composerDelay(300).then(() => null)]);
-}
-
-function composerDelay(ms: number): Promise<void> {
-  return new Promise((resolve) => window.setTimeout(resolve, ms));
+  return getAuthToken({ skipCache: true });
 }


### PR DESCRIPTION
## Summary
- request an uncached Clerk token when the home composer submits
- remove the raw `lastActiveToken` shortcut that could reuse a 60-second JWT after expiry
- let the request wait for Clerk instead of silently timing out token acquisition

## Why
Production network evidence showed home-composer thread creation sending JWTs after their `exp` timestamp. The raw browser token shortcut bypassed Clerk's normal refresh behavior, causing `Invalid or expired bearer token` before an agent run could start.

## Validation
- `pnpm turbo skills:build`
- `pnpm turbo typecheck lint build --force` (55/55 tasks)
- `pnpm architecture:check`
- `pnpm deadcode`
- `git diff --check`