### PR TITLE
fix(sandbox): run previews from local mirror

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -115,6 +115,12 @@ matched imperative such as “build a website” or “create a mobile app” al
 app-builder path before model execution. That high-confidence fallback materializes the project,
 scaffolds its canonical workspace, and registers the managed preview even when the selected model
 would otherwise attempt generic shell work and finish without a Computer target.
+The canonical app source remains on the durable `/workspace` volume. Managed Next.js previews
+compile from a sandbox-local one-way mirror because Daytona's object-store FUSE mount can stall
+webpack compilation even after the listening socket opens. A baked Python synchronizer performs a
+full refresh on every process start and mirrors subsequent writes and deletions within one second,
+including shell-based edits. The local source, dependency tree, and build cache are disposable;
+wake and restart reconstruct them from the durable project without changing the Files surface.
 
 AgentRun keeps one compact exact SQLite shape for run identity, replay parts, and
 coordination state. Dormant objects are reconciled transactionally on activation;

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -21,10 +21,10 @@ import {
   writeAppBuilderFiles,
   writeExpoRuntimeFiles,
 } from "./agent-run-app-builder-scaffold";
+import { localNextPreviewCommand } from "./app-builder-local-preview";
 import {
   EXPO_RUNTIME_BIN,
   EXPO_TEMPLATE_DIR,
-  NEXT_RUNTIME_BIN,
   NEXT_TEMPLATE_DIR,
   projectLocalCacheDir,
   projectLocalModulesDir,
@@ -579,15 +579,11 @@ async function startAppBuilderDevServer(
 ): Promise<void> {
   await executeStartDevServer(
     {
-      command: [
-        NEXT_RUNTIME_BIN,
-        "dev",
-        "--webpack",
-        "--hostname",
-        "0.0.0.0",
-        "--port",
-        String(workspace.port),
-      ],
+      command: localNextPreviewCommand({
+        port: workspace.port,
+        sourceDir: workspace.dir,
+        workspaceSlug: workspace.slug,
+      }),
       cwd: workspace.dir,
       env: {
         CHEATCODE_APP_RUNTIME: "next",

--- a/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
+++ b/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
@@ -1,0 +1,120 @@
+import { shellQuote } from "../sandbox-support";
+import { NEXT_RUNTIME_BIN, projectLocalSourceDir } from "./project-sandbox-package-runtime";
+
+interface LocalPreviewCommandInput {
+  port: number;
+  sourceDir: string;
+  workspaceSlug: string;
+}
+
+const PREVIEW_MIRROR_SYNC_SCRIPT = `
+import os
+import shutil
+import sys
+import time
+
+IGNORED_DIRS = {".expo", ".next", "node_modules"}
+LOCAL_ONLY_NAMES = IGNORED_DIRS | {"next-env.d.ts"}
+
+def remove_path(path):
+    if os.path.isdir(path) and not os.path.islink(path):
+        shutil.rmtree(path)
+    elif os.path.lexists(path):
+        os.unlink(path)
+
+def sync_link(source, target):
+    link = os.readlink(source)
+    if os.path.islink(target) and os.readlink(target) == link:
+        return
+    remove_path(target)
+    os.symlink(link, target)
+
+def sync_file(entry, target, force):
+    source_stat = entry.stat(follow_symlinks=False)
+    try:
+        target_stat = os.stat(target, follow_symlinks=False)
+    except FileNotFoundError:
+        target_stat = None
+    changed = (
+        force
+        or target_stat is None
+        or not os.path.isfile(target)
+        or source_stat.st_size != target_stat.st_size
+        or source_stat.st_mtime_ns > target_stat.st_mtime_ns
+    )
+    if changed:
+        remove_path(target)
+        shutil.copy2(entry.path, target, follow_symlinks=False)
+
+def sync_directory(source, target, force=False):
+    if os.path.lexists(target) and not os.path.isdir(target):
+        remove_path(target)
+    os.makedirs(target, exist_ok=True)
+    source_names = set()
+    for entry in os.scandir(source):
+        if entry.name in IGNORED_DIRS:
+            continue
+        source_names.add(entry.name)
+        destination = os.path.join(target, entry.name)
+        try:
+            if entry.is_symlink():
+                sync_link(entry.path, destination)
+            elif entry.is_dir(follow_symlinks=False):
+                sync_directory(entry.path, destination, force)
+            elif entry.is_file(follow_symlinks=False):
+                sync_file(entry, destination, force)
+        except FileNotFoundError:
+            continue
+    for entry in os.scandir(target):
+        if entry.name not in source_names and entry.name not in LOCAL_ONLY_NAMES:
+            remove_path(entry.path)
+
+def synchronize(source, target, force):
+    sync_directory(source, target, force)
+
+source_dir, target_dir, mode = sys.argv[1:4]
+if mode == "once":
+    synchronize(source_dir, target_dir, True)
+else:
+    while True:
+        try:
+            synchronize(source_dir, target_dir, False)
+        except OSError:
+            pass
+        time.sleep(0.75)
+`;
+
+/** Runs Next from native sandbox disk while `/workspace` remains the durable project source. */
+export function localNextPreviewCommand(input: LocalPreviewCommandInput): string[] {
+  const localSourceDir = projectLocalSourceDir(input.workspaceSlug);
+  const syncCommand = ["python3", "-c", PREVIEW_MIRROR_SYNC_SCRIPT, input.sourceDir, localSourceDir]
+    .map(shellQuote)
+    .join(" ");
+  const nextCommand = [
+    NEXT_RUNTIME_BIN,
+    "dev",
+    "--webpack",
+    "--hostname",
+    "0.0.0.0",
+    "--port",
+    String(input.port),
+  ]
+    .map(shellQuote)
+    .join(" ");
+  const command = [
+    `${syncCommand} once || exit $?`,
+    `${syncCommand} loop &`,
+    "sync_pid=$!",
+    `cd ${shellQuote(localSourceDir)} || exit $?`,
+    `${nextCommand} &`,
+    "app_pid=$!",
+    'terminate() { kill -TERM "$app_pid" "$sync_pid" 2>/dev/null || true; }',
+    "trap terminate HUP INT TERM",
+    'wait "$app_pid"',
+    "status=$?",
+    'kill "$sync_pid" 2>/dev/null || true',
+    'wait "$sync_pid" 2>/dev/null || true',
+    'exit "$status"',
+  ].join("\n");
+  return ["sh", "-lc", command];
+}

--- a/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
@@ -19,6 +19,10 @@ export function projectLocalModulesDir(workspaceSlug: string): string {
   return `${projectLocalRuntimeDir(workspaceSlug)}/node_modules`;
 }
 
+export function projectLocalSourceDir(workspaceSlug: string): string {
+  return `${projectLocalRuntimeDir(workspaceSlug)}/source`;
+}
+
 export function projectLocalCacheDir(workspaceSlug: string): string {
   return `${projectLocalRuntimeDir(workspaceSlug)}/cache`;
 }
@@ -54,7 +58,7 @@ export function projectPackageEnvironment(
   const fallbackRuntime = preferredRuntime === "expo" ? "next" : "expo";
   return {
     ...requested,
-    CHEATCODE_NEXT_DIST_DIR: `../../home/node/.cheatcode/projects/${workspaceSlug}/cache/next`,
+    CHEATCODE_NEXT_DIST_DIR: `${projectLocalCacheDir(workspaceSlug)}/next`,
     NODE_PATH: [
       modulesDir,
       `${APP_RUNTIME_ROOT}/${preferredRuntime}/node_modules`,


### PR DESCRIPTION
## What changed
- keep `/workspace` as the durable canonical project source
- run managed Next.js previews from a synchronized sandbox-local mirror
- rebuild the mirror on every start/wake and propagate live writes/deletions within one second
- keep Next build output on sandbox-local disk with an absolute dist path

## Why
Daytona `/workspace` is object-store FUSE. Production diagnosis proved the same Next app stalled compiling `/` from that mount while an identical local-disk copy returned HTTP 200.

## Validation
- `pnpm turbo skills:build`
- `pnpm turbo typecheck lint build --force` (55/55 tasks)
- `pnpm architecture:check`
- `pnpm deadcode`
- `git diff --check`