### PR TITLE
fix(sandbox): keep preview cache project-relative

### DIFF
--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -587,6 +587,7 @@ async function startAppBuilderDevServer(
       cwd: workspace.dir,
       env: {
         CHEATCODE_APP_RUNTIME: "next",
+        CHEATCODE_NEXT_DIST_DIR: "../cache/next",
         CHOKIDAR_USEPOLLING: "true",
         WATCHPACK_POLLING: "1000",
       },

--- a/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
@@ -54,11 +54,13 @@ export function projectPackageEnvironment(
   if (!workspaceSlug) return requested;
   const modulesDir = projectLocalModulesDir(workspaceSlug);
   const requestedNodePath = requested?.["NODE_PATH"];
+  const requestedNextDistDir = requested?.["CHEATCODE_NEXT_DIST_DIR"];
   const preferredRuntime = requested?.["CHEATCODE_APP_RUNTIME"] === "expo" ? "expo" : "next";
   const fallbackRuntime = preferredRuntime === "expo" ? "next" : "expo";
   return {
     ...requested,
-    CHEATCODE_NEXT_DIST_DIR: `${projectLocalCacheDir(workspaceSlug)}/next`,
+    CHEATCODE_NEXT_DIST_DIR:
+      requestedNextDistDir ?? `../../home/node/.cheatcode/projects/${workspaceSlug}/cache/next`,
     NODE_PATH: [
       modulesDir,
       `${APP_RUNTIME_ROOT}/${preferredRuntime}/node_modules`,


### PR DESCRIPTION
## What changed
- set the managed local-mirror Next cache to the project-relative `../cache/next` path
- preserve the existing FUSE-workspace fallback for other sandbox processes
- allow a managed process to supply its runtime-specific cache path

## Production diagnosis
The first mirror release opened port 5179 but returned HTTP 500 because Next interpreted an absolute `distDir` as `source/home/node/...`. With this relative path, the same production sandbox source returned full HTTP 200 HTML in about four seconds. A direct `/workspace` run still fails with the expected FUSE `ENOSYS rename`, confirming the local mirror remains required.

## Validation
- live Daytona local-source HTTP 200
- focused Biome + agent-worker typecheck
- `pnpm turbo skills:build`
- `pnpm turbo typecheck lint build --force` (55/55)
- `pnpm architecture:check`
- `pnpm deadcode`
- `git diff --check`