### PR TITLE
fix(preview): hide starter scaffold during generation

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -115,6 +115,10 @@ matched imperative such as “build a website” or “create a mobile app” al
 app-builder path before model execution. That high-confidence fallback materializes the project,
 scaffolds its canonical workspace, and registers the managed preview even when the selected model
 would otherwise attempt generic shell work and finish without a Computer target.
+The starter page is an internal server-readiness target, not user-facing generated content. A
+fresh template run emits the typed `app-preview-status` transition from `building` to `ready` only
+after model execution (and the mobile preview restart, when applicable), so the web client can keep
+the branded loading surface over the scaffold without relying on timers or iframe inspection.
 The canonical app source remains on the durable `/workspace` volume. Managed Next.js previews
 compile from a sandbox-local one-way mirror because Daytona's object-store FUSE mount can stall
 webpack compilation even after the listening socket opens. A baked Python synchronizer performs a

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -148,11 +148,14 @@ interface RunAppBuilderOptions {
   setRunStage: (stage: string) => void;
 }
 
+interface AppBuilderSetup {
+  agentContextNote?: string;
+  waitsForGeneratedPreview: boolean;
+}
+
 type WorkspaceOptions = RunAppBuilderOptions & { workspace: AppBuilderWorkspace };
 
-export async function runAppBuilder(
-  options: RunAppBuilderOptions,
-): Promise<{ agentContextNote?: string }> {
+export async function runAppBuilder(options: RunAppBuilderOptions): Promise<AppBuilderSetup> {
   const { input, logger, sandbox } = options;
   throwIfRunCanceled(options.abortSignal);
   const workspace = await resolveAppWorkspace(sandbox, input, logger);
@@ -166,20 +169,35 @@ export async function runAppBuilder(
   // follow-up run. See D7 — the marker, not the template-shape check, is the
   // one-shot guarantee.
   if (await hasImportedAppWorkspace(sandbox, workspace.dir)) {
-    return restoreImportedWorkspace(workspaceOptions);
+    return {
+      ...(await restoreImportedWorkspace(workspaceOptions)),
+      waitsForGeneratedPreview: false,
+    };
   }
   const shouldBootstrap = !(await hasExistingAppBuilderWorkspace(sandbox, workspace.dir));
   if (shouldBootstrap && input.importRepoUrl) {
-    return importRepoWorkspace({ ...workspaceOptions, repoUrl: input.importRepoUrl });
+    return {
+      ...(await importRepoWorkspace({ ...workspaceOptions, repoUrl: input.importRepoUrl })),
+      waitsForGeneratedPreview: false,
+    };
   }
-  return runTemplateAppBuilder({ ...workspaceOptions, shouldBootstrap });
+  return {
+    ...(await runTemplateAppBuilder({ ...workspaceOptions, shouldBootstrap })),
+    waitsForGeneratedPreview: shouldBootstrap,
+  };
 }
 
 async function runTemplateAppBuilder(
   options: WorkspaceOptions & { shouldBootstrap: boolean },
 ): Promise<{ agentContextNote: string }> {
-  const { sandbox, workspace } = options;
+  const { append, sandbox, shouldBootstrap, workspace } = options;
   throwIfRunCanceled(options.abortSignal);
+  if (shouldBootstrap) {
+    await append({
+      type: "data-app-preview-status",
+      data: { v: 1, status: "building" },
+    });
+  }
   await prepareTemplateWorkspace(options);
   throwIfRunCanceled(options.abortSignal);
   await clearBuildCache(sandbox, workspace.dir, workspace.mobile);

--- a/apps/agent-worker/src/durable-objects/agent-run-path.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-path.ts
@@ -53,7 +53,7 @@ async function executeAppBuilderPath(
   if (options.isCanceled()) {
     return "completed";
   }
-  const { agentContextNote } = await runAppBuilder(options);
+  const { agentContextNote, waitsForGeneratedPreview } = await runAppBuilder(options);
   if (options.isCanceled()) {
     return "completed";
   }
@@ -69,6 +69,12 @@ async function executeAppBuilderPath(
     return "completed";
   }
   await restartMobilePreviewIfNeeded(options);
+  if (waitsForGeneratedPreview) {
+    await options.append({
+      type: "data-app-preview-status",
+      data: { v: 1, status: "ready" },
+    });
+  }
   return "continue";
 }
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -24,6 +24,11 @@ does not create or wake Daytona merely because the user opens it.
 Computer preview wakeups rotate the preview session and reload the visible iframe
 once after an actual sandbox/process recovery. Silent capability rotation keeps the
 live iframe mounted so application state is preserved during ordinary use.
+Fresh app-builder projects keep the animated Cheatcode mark visible while the internal starter
+scaffold boots and the model generates the requested app. The persisted `app-preview-status`
+stream part reveals the iframe only when generated content is ready, and an iframe-load guard keeps
+the same mark in place until the final document has loaded. Existing project edits remain visible
+and continue hot-reloading normally.
 
 ## Public exports
 

--- a/apps/web/src/components/chat/chat-panel-controller.ts
+++ b/apps/web/src/components/chat/chat-panel-controller.ts
@@ -67,6 +67,7 @@ function useChatPanelRuntime(input: ChatPanelProps) {
   const surfaceApplier = useWorkspaceSurfaceApplier({
     projectId: input.project?.id ?? null,
     setActivePreviewTab: store.setActivePreviewTab,
+    setAppPreviewStatus: store.setAppPreviewStatus,
     setPreviewPanelOpen: store.setPreviewPanelOpen,
     setSandboxStatus: store.setSandboxStatus,
     threadId: input.threadId,
@@ -250,6 +251,7 @@ function useChatPanelStore(threadId: string) {
     resetConsole: useAppStore((state) => state.resetConsole),
     resetPreviewNavigation: useAppStore((state) => state.resetPreviewNavigation),
     setActivePreviewTab: useAppStore((state) => state.setActivePreviewTab),
+    setAppPreviewStatus: useAppStore((state) => state.setAppPreviewStatus),
     setDraft: useAppStore((state) => state.setDraft),
     setExpoUrl: useAppStore((state) => state.setExpoUrl),
     setPreviewPanelOpen: useAppStore((state) => state.setPreviewPanelOpen),
@@ -455,6 +457,7 @@ function useChatPanelEffects(
     resetConsole: store.resetConsole,
     resetPreviewNavigation: store.resetPreviewNavigation,
     setActivePreviewTab: store.setActivePreviewTab,
+    setAppPreviewStatus: store.setAppPreviewStatus,
     setExpoUrl: store.setExpoUrl,
     setPreviewPanelOpen: store.setPreviewPanelOpen,
     setPreviewUrl: store.setPreviewUrl,

--- a/apps/web/src/components/chat/message-timeline.ts
+++ b/apps/web/src/components/chat/message-timeline.ts
@@ -40,6 +40,7 @@ export function buildMessageTimeline(
 
 export function isHiddenTranscriptPart(part: MessagePart): boolean {
   return (
+    part.type === "data-app-preview-status" ||
     part.type === "data-artifact" ||
     part.type === "data-sandbox-status" ||
     /* retained for historical transcripts */

--- a/apps/web/src/components/chat/use-sandbox-surface-sync.ts
+++ b/apps/web/src/components/chat/use-sandbox-surface-sync.ts
@@ -14,8 +14,14 @@ type SandboxStatusData = Extract<
   { type: "data-sandbox-status" }
 >["data"];
 
+type AppPreviewStatusData = Extract<
+  CheatcodeUIMessage["parts"][number],
+  { type: "data-app-preview-status" }
+>["data"];
+
 export interface SandboxStatusActions {
   setActivePreviewTab: (tab: PreviewTab) => void;
+  setAppPreviewStatus: (status: AppPreviewStatusData["status"] | "idle") => void;
   setPreviewPanelOpen: (open: boolean) => void;
   setSandboxStatus: (status: SandboxState) => void;
 }
@@ -33,6 +39,7 @@ interface SandboxSurfaceSyncInput extends SandboxStatusActions {
 }
 
 export type SurfaceCommand =
+  | { kind: "preview-status"; status: AppPreviewStatusData["status"] }
   | { kind: "status"; status: SandboxStatusData["status"] }
   | { kind: "open-browser-preview"; toolCallId: string };
 
@@ -53,6 +60,7 @@ interface SurfaceCommandState {
 
 interface HydratedSurfaceCommands {
   browser: SurfaceCommand | null;
+  preview: SurfaceCommand | null;
   status: SurfaceCommand | null;
 }
 
@@ -67,10 +75,16 @@ export function useWorkspaceSurfaceApplier(
   const actions = useMemo(
     () => ({
       setActivePreviewTab: input.setActivePreviewTab,
+      setAppPreviewStatus: input.setAppPreviewStatus,
       setPreviewPanelOpen: input.setPreviewPanelOpen,
       setSandboxStatus: input.setSandboxStatus,
     }),
-    [input.setActivePreviewTab, input.setPreviewPanelOpen, input.setSandboxStatus],
+    [
+      input.setActivePreviewTab,
+      input.setAppPreviewStatus,
+      input.setPreviewPanelOpen,
+      input.setSandboxStatus,
+    ],
   );
   const apply = useCallback(
     (command: SurfaceCommand) =>
@@ -91,14 +105,21 @@ export function useSandboxSurfaceSync(input: SandboxSurfaceSyncInput): void {
   const actions = useMemo(
     () => ({
       setActivePreviewTab: input.setActivePreviewTab,
+      setAppPreviewStatus: input.setAppPreviewStatus,
       setPreviewPanelOpen: input.setPreviewPanelOpen,
       setSandboxStatus: input.setSandboxStatus,
     }),
-    [input.setActivePreviewTab, input.setPreviewPanelOpen, input.setSandboxStatus],
+    [
+      input.setActivePreviewTab,
+      input.setAppPreviewStatus,
+      input.setPreviewPanelOpen,
+      input.setSandboxStatus,
+    ],
   );
 
   useResetSandboxSurface(input);
   useHydratedSurfaceCommand(commands.status, input.surfaceApplier);
+  useHydratedSurfaceCommand(commands.preview, input.surfaceApplier);
   useProjectFilesDefault(input.project, status, actions, defaultedProjectFilesRef);
   useHydratedSurfaceCommand(commands.browser, input.surfaceApplier);
   useCompletionPreview(input.chatStatus, previousStatusRef);
@@ -111,6 +132,10 @@ export function workspaceSurfaceEffect(part: unknown): SurfaceCommand | null {
   if (part["type"] === "data-sandbox-status") {
     const parsed = CHEATCODE_DATA_SCHEMAS["sandbox-status"].safeParse(part["data"]);
     return parsed.success ? { kind: "status", status: parsed.data.status } : null;
+  }
+  if (part["type"] === "data-app-preview-status") {
+    const parsed = CHEATCODE_DATA_SCHEMAS["app-preview-status"].safeParse(part["data"]);
+    return parsed.success ? { kind: "preview-status", status: parsed.data.status } : null;
   }
   if (part["type"] !== "data-tool") {
     return null;
@@ -126,6 +151,7 @@ function useResetSandboxSurface(input: SandboxSurfaceSyncInput): void {
     input.surfaceApplier.reset();
     input.resetConsole();
     input.resetPreviewNavigation();
+    input.setAppPreviewStatus("idle");
     input.setPreviewUrl(null);
     input.setExpoUrl(null);
     input.setPreviewPanelOpen(false);
@@ -134,6 +160,7 @@ function useResetSandboxSurface(input: SandboxSurfaceSyncInput): void {
     input.resetConsole,
     input.resetPreviewNavigation,
     input.setExpoUrl,
+    input.setAppPreviewStatus,
     input.setPreviewPanelOpen,
     input.setPreviewUrl,
     input.setSandboxStatus,
@@ -186,8 +213,7 @@ function useCompletionPreview(
 }
 
 function hydratedSurfaceCommands(messages: readonly CheatcodeUIMessage[]): HydratedSurfaceCommands {
-  let browser: SurfaceCommand | null = null;
-  let status: SurfaceCommand | null = null;
+  const commands: HydratedSurfaceCommands = { browser: null, preview: null, status: null };
   for (let messageIndex = 0; messageIndex < messages.length; messageIndex += 1) {
     const message = messages[messageIndex];
     if (!message) {
@@ -199,15 +225,23 @@ function hydratedSurfaceCommands(messages: readonly CheatcodeUIMessage[]): Hydra
       if (!part) {
         continue;
       }
-      const command = workspaceSurfaceEffect(part);
-      if (command?.kind === "status") {
-        status = command;
-      } else if (command?.kind === "open-browser-preview") {
-        browser = command;
-      }
+      recordHydratedSurfaceCommand(commands, workspaceSurfaceEffect(part));
     }
   }
-  return { browser, status };
+  return commands;
+}
+
+function recordHydratedSurfaceCommand(
+  commands: HydratedSurfaceCommands,
+  command: SurfaceCommand | null,
+): void {
+  if (command?.kind === "status") {
+    commands.status = command;
+  } else if (command?.kind === "preview-status") {
+    commands.preview = command;
+  } else if (command?.kind === "open-browser-preview") {
+    commands.browser = command;
+  }
 }
 
 function applyWorkspaceSurfaceCommand(
@@ -219,6 +253,12 @@ function applyWorkspaceSurfaceCommand(
   if (command.kind === "status") {
     if (useAppStore.getState().sandboxStatus !== command.status) {
       actions.setSandboxStatus(command.status);
+    }
+    return;
+  }
+  if (command.kind === "preview-status") {
+    if (useAppStore.getState().appPreviewStatus !== command.status) {
+      actions.setAppPreviewStatus(command.status);
     }
     return;
   }

--- a/apps/web/src/components/preview/preview-side-panel.tsx
+++ b/apps/web/src/components/preview/preview-side-panel.tsx
@@ -2,7 +2,7 @@
 
 import type { ProjectSummary } from "@cheatcode/types/api";
 import { useAuth } from "@clerk/nextjs";
-import { Activity, type ReactNode, useEffect } from "react";
+import { Activity, type ReactNode, useEffect, useState } from "react";
 import { BrowserTakeoverSurface } from "@/components/preview/browser-takeover-surface";
 import { ExpoDevicePanel } from "@/components/preview/expo-device-panel";
 import {
@@ -86,12 +86,13 @@ function usePreviewPanelController(
     store.setActivePreviewTab("app");
     store.setPreviewPanelOpen(true);
   }, [browserTakeover.session, store.setActivePreviewTab, store.setPreviewPanelOpen]);
-  return { ...store, browserTakeover, isMobile, previewLive };
+  return { ...store, browserTakeover, isMobile, isRunActive: activeRunId !== null, previewLive };
 }
 
 function usePreviewPanelStore() {
   return {
     activePreviewTab: useAppStore((state) => normalizeComputerTab(state.activePreviewTab)),
+    appPreviewStatus: useAppStore((state) => state.appPreviewStatus),
     expoUrl: useAppStore((state) => state.expoUrl),
     previewDevice: useAppStore((state) => state.previewDevice),
     previewPanelOpen: useAppStore((state) => state.previewPanelOpen),
@@ -220,11 +221,13 @@ function panelBodyProps(
 ): PanelBodyProps {
   return {
     activePreviewTab: controller.activePreviewTab,
+    appPreviewStatus: controller.appPreviewStatus,
     computerOpen: controller.previewPanelOpen,
     device: controller.previewDevice,
     expoUrl: controller.expoUrl,
     hasProject: project !== null,
     isMobile: controller.isMobile,
+    isRunActive: controller.isRunActive,
     previewPhase: controller.previewLive.phase,
     previewRetry: controller.previewLive.retry,
     previewReloadToken: controller.previewReloadToken,
@@ -237,11 +240,13 @@ function panelBodyProps(
 
 interface PanelBodyProps {
   activePreviewTab: PreviewTab;
+  appPreviewStatus: ReturnType<typeof useAppStore.getState>["appPreviewStatus"];
   computerOpen: boolean;
   device: PreviewDevice;
   expoUrl: string | null;
   hasProject: boolean;
   isMobile: boolean;
+  isRunActive: boolean;
   previewPhase: PreviewLivePhase;
   previewRetry: () => Promise<void>;
   previewReloadToken: number;
@@ -253,11 +258,13 @@ interface PanelBodyProps {
 
 function PanelBody({
   activePreviewTab,
+  appPreviewStatus,
   computerOpen,
   device,
   expoUrl,
   hasProject,
   isMobile,
+  isRunActive,
   previewPhase,
   previewRetry,
   previewReloadToken,
@@ -276,7 +283,9 @@ function PanelBody({
             device={device}
             expoUrl={expoUrl}
             hasProject={hasProject}
+            appPreviewStatus={appPreviewStatus}
             isMobile={isMobile}
+            isRunActive={isRunActive}
             previewPhase={previewPhase}
             previewRetry={previewRetry}
             previewReloadToken={previewReloadToken}
@@ -302,10 +311,12 @@ type AppTabProps = Omit<
 >;
 
 function AppTab({
+  appPreviewStatus,
   device,
   expoUrl,
   hasProject,
   isMobile,
+  isRunActive,
   previewPhase,
   previewRetry,
   previewReloadToken,
@@ -335,6 +346,7 @@ function AppTab({
       <AppTabContent
         frameDevice={frameDevice}
         iframeUrl={iframeUrl}
+        isGeneratedPreviewPending={appPreviewStatus === "building" && isRunActive}
         previewPhase={previewPhase}
         previewRetry={previewRetry}
         previewUrl={previewUrl}
@@ -374,6 +386,7 @@ function AppTabLayout({
 function AppTabContent({
   frameDevice,
   iframeUrl,
+  isGeneratedPreviewPending,
   previewPhase,
   previewRetry,
   previewUrl,
@@ -381,19 +394,20 @@ function AppTabContent({
 }: {
   frameDevice: PreviewDevice;
   iframeUrl: string;
+  isGeneratedPreviewPending: boolean;
   previewPhase: PreviewLivePhase;
   previewRetry: () => Promise<void>;
   previewUrl: string | null;
   requestedIframeUrl: string | null;
 }) {
-  if (previewPhase === "booting") {
+  if (previewPhase === "booting" || isGeneratedPreviewPending) {
     return (
       <PreviewDeviceFrame
         device={frameDevice}
         content={
           <CheatcodeLoader
             className="h-full min-h-[420px] min-w-0 flex-1 bg-bg-secondary"
-            label="Starting preview…"
+            label={isGeneratedPreviewPending ? "Building preview…" : "Starting preview…"}
           />
         }
       />
@@ -426,17 +440,30 @@ function PreviewDeviceFrame({ content, device }: { content: ReactNode; device: P
 }
 
 function BrowserPreviewIframe({ iframeUrl }: { iframeUrl: string }) {
+  const [isLoaded, setIsLoaded] = useState(false);
   return (
-    <iframe
-      className="min-h-0 min-w-0 flex-1 border-0 bg-background"
-      key={iframeUrl}
-      allow={APP_PREVIEW_IFRAME_ALLOW}
-      allowFullScreen
-      referrerPolicy="origin"
-      sandbox={APP_PREVIEW_IFRAME_SANDBOX}
-      src={iframeUrl}
-      title="Browser preview"
-    />
+    <div className="relative flex min-h-0 min-w-0 flex-1 bg-background">
+      {!isLoaded ? (
+        <CheatcodeLoader
+          className="absolute inset-0 z-10 bg-bg-secondary"
+          label="Loading preview…"
+        />
+      ) : null}
+      <iframe
+        className={cn(
+          "min-h-0 min-w-0 flex-1 border-0 bg-background transition-opacity duration-150 motion-reduce:transition-none",
+          isLoaded ? "opacity-100" : "opacity-0",
+        )}
+        key={iframeUrl}
+        allow={APP_PREVIEW_IFRAME_ALLOW}
+        allowFullScreen
+        onLoad={() => setIsLoaded(true)}
+        referrerPolicy="origin"
+        sandbox={APP_PREVIEW_IFRAME_SANDBOX}
+        src={iframeUrl}
+        title="Browser preview"
+      />
+    </div>
   );
 }
 

--- a/apps/web/src/lib/store/app-store.ts
+++ b/apps/web/src/lib/store/app-store.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SandboxState } from "@cheatcode/types";
+import type { AppPreviewState, SandboxState } from "@cheatcode/types";
 import type { SandboxConsoleProcess } from "@cheatcode/types/api";
 import { create, type StateCreator } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
@@ -26,6 +26,7 @@ const PREVIEW_PATH_HISTORY_MAX = 50;
 interface AppStoreState {
   activePreviewTab: PreviewTab;
   agentModelId: AgentModelId;
+  appPreviewStatus: AppPreviewState;
   connectionState: ConnectionState;
   consoleCursor: ConsoleCursor;
   consoleLines: ConsoleLine[];
@@ -62,6 +63,7 @@ interface AppStoreActions {
   resetPreviewNavigation: () => void;
   setActivePreviewTab: (tab: PreviewTab) => void;
   setAgentModelId: (modelId: AgentModelId) => void;
+  setAppPreviewStatus: (status: AppPreviewState) => void;
   setConnectionState: (state: ConnectionState) => void;
   setConsoleStripOpen: (open: boolean) => void;
   setDraft: (threadId: string, value: string) => void;
@@ -115,6 +117,7 @@ function initialAppStoreState(): AppStoreState {
   return {
     activePreviewTab: "app",
     agentModelId: DEFAULT_AGENT_MODEL_ID,
+    appPreviewStatus: "idle",
     connectionState: "online",
     consoleCursor: { stderr: 0, stdout: 0 },
     consoleLines: [],
@@ -184,6 +187,7 @@ function createPreviewActions(set: AppStoreSet) {
     navigatePreviewPath: (path: string) => set((state) => navigatePreviewPath(state, path)),
     resetPreviewNavigation: () => set({ previewPath: "/", previewPathHistory: [] }),
     setActivePreviewTab: (activePreviewTab: PreviewTab) => set({ activePreviewTab }),
+    setAppPreviewStatus: (appPreviewStatus: AppPreviewState) => set({ appPreviewStatus }),
     setExpoUrl: (expoUrl: string | null) => set({ expoUrl }),
     setPreviewDevice: (previewDevice: PreviewDevice) => set({ previewDevice }),
     setPreviewPanelOpen: (previewPanelOpen: boolean) => set({ previewPanelOpen }),
@@ -261,6 +265,7 @@ function identityScopedInitialState(): Pick<
   | "consoleStripOpen"
   | "consoleTruncated"
   | "draftByThread"
+  | "appPreviewStatus"
   | "expoUrl"
   | "previewPanelOpen"
   | "previewPath"
@@ -272,6 +277,7 @@ function identityScopedInitialState(): Pick<
   | "streamReconnect"
 > {
   return {
+    appPreviewStatus: "idle",
     consoleCursor: { stderr: 0, stdout: 0 },
     consoleLines: [],
     consoleProcess: null,

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -26,7 +26,8 @@ capability discovery contracts, error codes, and UI message types.
   used by API, runtime-port, and code-tool schemas
 - `skill-runtime.ts`: canonical skill-runtime capability scopes and schema
 - `ui-message.ts`: the exact AI SDK UI message data-part contract persisted in
-  Postgres and replayed to the web client
+  Postgres and replayed to the web client, including the app-preview content-readiness transition
+  that keeps internal scaffolds out of the user-facing Browser surface
 
 The `./api` subpath also exports the canonical user-message character budget, project-file
 upload/batch/namespace limits and schemas, and finalized project-archive byte

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -77,6 +77,7 @@ export {
   TRANSCRIPT_SEGMENT_MAX_PARTS_BYTES,
 } from "./transcript-segments";
 export type {
+  AppPreviewState,
   CheatcodeUIMessage,
   ModelFallbackData,
   SandboxState,

--- a/packages/types/src/ui-message.ts
+++ b/packages/types/src/ui-message.ts
@@ -6,6 +6,7 @@ import { type LogicalModelId, LogicalModelIdSchema } from "./models";
 
 const TaskStatusSchema = z.enum(["pending", "running", "completed", "failed"]);
 const SandboxStreamStatusSchema = z.enum(["starting", "ready", "failed"]);
+const AppPreviewStreamStatusSchema = z.enum(["building", "ready"]);
 
 /**
  * Informational model-transition part. Replaces the silent text-delta fallback
@@ -41,6 +42,11 @@ const TaskStatusDataSchema = z.strictObject({
 const SandboxStatusDataSchema = z.strictObject({
   v: z.literal(1),
   status: SandboxStreamStatusSchema,
+});
+
+const AppPreviewStatusDataSchema = z.strictObject({
+  v: z.literal(1),
+  status: AppPreviewStreamStatusSchema,
 });
 
 const ProjectCreatedDataSchema = z.strictObject({
@@ -103,6 +109,7 @@ const SeqDataSchema = z.strictObject({
 });
 
 export const CHEATCODE_DATA_SCHEMAS = {
+  "app-preview-status": AppPreviewStatusDataSchema,
   artifact: ArtifactDataSchema,
   error: ErrorDataSchema,
   "model-fallback": ModelFallbackDataSchema,
@@ -133,6 +140,7 @@ function dataMessagePartSchema<Name extends keyof typeof CHEATCODE_DATA_SCHEMAS>
 /** Exact V2 message-part contract persisted in Postgres and replayed to the web client. */
 export const MessagePartSchema = z.discriminatedUnion("type", [
   TextMessagePartSchema,
+  dataMessagePartSchema("app-preview-status"),
   dataMessagePartSchema("artifact"),
   dataMessagePartSchema("error"),
   dataMessagePartSchema("model-fallback"),
@@ -147,6 +155,7 @@ export const MessagePartSchema = z.discriminatedUnion("type", [
 ]);
 
 export type ModelFallbackData = z.infer<typeof ModelFallbackDataSchema>;
+export type AppPreviewState = "idle" | z.infer<typeof AppPreviewStreamStatusSchema>;
 export type SandboxState = "cold" | z.infer<typeof SandboxStreamStatusSchema>;
 
 type CheatcodeDataParts = {


### PR DESCRIPTION
## Summary
- Keep the animated Cheatcode mark visible while a fresh app-builder scaffold boots and the model generates the requested app.
- Persist an explicit `building` → `ready` preview-content transition instead of treating an open port as finished content.
- Keep the same loader over a newly mounted iframe until its document has actually loaded.

## Linear
Not linked — direct production UX fix requested during preview reliability QA.

## Plan
No repository plan document; the implementation plan and acceptance evidence are in the task transcript.

## What's Included

### Typed readiness contract
- Adds `data-app-preview-status` to the persisted/replayed UI-message contract.
- Emits `building` only for freshly scaffolded template projects and `ready` after successful model execution.

### Browser presentation
- Hydrates and applies readiness transitions through the existing workspace surface controller.
- Hides internal readiness events from the transcript.
- Shows the branded loader during generation and until the final iframe load event.
- Leaves follow-up edits on existing projects visible for normal hot reload.

### Documentation
- Documents the internal scaffold boundary and user-facing readiness behavior in the owning package READMEs.

## Architecture
The agent Worker owns content readiness because it knows whether a workspace was freshly scaffolded and when model generation completed. The typed stream part is persisted with the run, replayed after refresh, and projected into memory-only web UI state. The web client never inspects cross-origin iframe contents or guesses with a timer.

## Decisions Made
| Decision | Choice | Alternatives Considered | Reasoning |
|---|---|---|---|
| Readiness owner | Agent Worker emits typed state | Timer; iframe text inspection | Deterministic, replayable, and cross-origin safe |
| Scaffold lifecycle | Keep it internal | Remove starter project | A valid project is still needed to boot and verify the managed server |
| Existing projects | Keep iframe visible | Hide on every run | Preserves live iteration and avoids regressing follow-up edits |
| Initial iframe load | Branded overlay until `load` | Immediate reveal | Prevents a white/partial document flash after generation |

## Edge Cases Handled
| Scenario | Handling |
|---|---|
| Historical transcript without the new part | Defaults to existing preview behavior |
| Follow-up run in an existing project | Does not enter the fresh-scaffold loading state |
| Page refresh during generation | Persisted `building` state restores the loader |
| Reduced-motion preference | Existing Cheatcode loader disables animation |

## How to Review
1. Start with `packages/types/src/ui-message.ts` and `agent-run-app-builder.ts` for the contract.
2. Check `use-sandbox-surface-sync.ts` for live and hydrated event projection.
3. Review `preview-side-panel.tsx` for the presentation transition.

## Test Plan
- [x] `pnpm turbo skills:build`
- [x] `pnpm turbo typecheck lint build --force` — 55/55 tasks
- [x] `pnpm architecture:check` — 849 modules / 1761 dependencies
- [x] `pnpm deadcode`
- [x] `git diff --check`
- [ ] Verify a fresh production app-builder run never exposes “Sandbox preview is live.”
- [ ] Verify the final generated app replaces the animated mark and remains live on refresh.
