### PR TITLE
fix(web): preserve preview session during builds

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -27,8 +27,10 @@ live iframe mounted so application state is preserved during ordinary use.
 Fresh app-builder projects keep the animated Cheatcode mark visible while the internal starter
 scaffold boots and the model generates the requested app. The persisted `app-preview-status`
 stream part reveals the iframe only when generated content is ready, and an iframe-load guard keeps
-the same mark in place until the final document has loaded. Existing project edits remain visible
-and continue hot-reloading normally.
+the same mark in place until the final document has loaded. While that mark is visible, the hidden
+session exchange remains mounted so the one-minute URL handoff becomes a renewable ten-minute
+host cookie before long-running builds finish. Existing project edits remain visible and continue
+hot-reloading normally.
 
 ## Public exports
 

--- a/apps/web/src/components/preview/preview-side-panel.tsx
+++ b/apps/web/src/components/preview/preview-side-panel.tsx
@@ -402,15 +402,18 @@ function AppTabContent({
 }) {
   if (previewPhase === "booting" || isGeneratedPreviewPending) {
     return (
-      <PreviewDeviceFrame
-        device={frameDevice}
-        content={
-          <CheatcodeLoader
-            className="h-full min-h-[420px] min-w-0 flex-1 bg-bg-secondary"
-            label={isGeneratedPreviewPending ? "Building preview…" : "Starting preview…"}
-          />
-        }
-      />
+      <>
+        <PreviewSessionRefresh previewUrl={requestedIframeUrl} />
+        <PreviewDeviceFrame
+          device={frameDevice}
+          content={
+            <CheatcodeLoader
+              className="h-full min-h-[420px] min-w-0 flex-1 bg-bg-secondary"
+              label={isGeneratedPreviewPending ? "Building preview…" : "Starting preview…"}
+            />
+          }
+        />
+      </>
     );
   }
   if (previewPhase === "error") {


### PR DESCRIPTION
## Summary

- keep the hidden preview-session exchange mounted while the branded build loader covers the starter scaffold
- exchange the one-minute preview URL handoff for the renewable host cookie before long-running app builds finish
- document the loader/session boundary

## Decision

The preview iframe must stay unmounted until generated content is ready, but authorization cannot wait that long because URL handoffs expire after 60 seconds. The existing hidden session-refresh iframe now runs behind the loader, preserving the security boundary without exposing starter content.

## Verification

- `pnpm turbo skills:build`
- `pnpm turbo typecheck lint build` (55/55 tasks)
- production reproduction confirmed the branded loader stayed visible while the original handoff expired, which this change directly prevents by performing the documented cookie exchange during that state