### PR TITLE
fix(web): mint preview access after generation

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -27,10 +27,10 @@ live iframe mounted so application state is preserved during ordinary use.
 Fresh app-builder projects keep the animated Cheatcode mark visible while the internal starter
 scaffold boots and the model generates the requested app. The persisted `app-preview-status`
 stream part reveals the iframe only when generated content is ready, and an iframe-load guard keeps
-the same mark in place until the final document has loaded. While that mark is visible, the hidden
-session exchange remains mounted so the one-minute URL handoff becomes a renewable ten-minute
-host cookie before long-running builds finish. Existing project edits remain visible and continue
-hot-reloading normally.
+the same mark in place until the final document has loaded. Preview wake and capability minting stay
+paused during fresh scaffold generation; readiness acquires a new one-minute handoff immediately
+before the iframe mounts and exchanges it for the renewable ten-minute host cookie. Existing project
+edits remain visible and continue hot-reloading normally.
 
 ## Public exports
 

--- a/apps/web/src/components/preview/preview-side-panel.tsx
+++ b/apps/web/src/components/preview/preview-side-panel.tsx
@@ -70,13 +70,17 @@ function usePreviewPanelController(
   const { getToken } = useAuth();
   const store = usePreviewPanelStore();
   const isMobile = project?.mode === "app-builder-mobile" || store.expoUrl !== null;
+  const isRunActive = activeRunId !== null;
+  const isFreshPreviewBuilding = store.appPreviewStatus === "building" && isRunActive;
   // The authenticated wake endpoint is the only source of preview capabilities. Opening any
   // project Computer panel asks it for a fresh handoff; projects without a dev server fall back to
-  // Files. Daytona idle-stops are revived through the same path.
+  // Files. Fresh scaffolds wait until generated content is ready so their one-minute handoff is
+  // minted immediately before the iframe mounts. Daytona idle-stops are revived through the same
+  // path.
   const previewLive = useEnsurePreviewLive(
     threadId,
     getToken,
-    store.previewPanelOpen && project !== null,
+    store.previewPanelOpen && project !== null && !isFreshPreviewBuilding,
     store.sandboxStatus,
   );
   useFirstPreviewTelemetry(getToken, store.previewPanelOpen, store.previewUrl);
@@ -86,7 +90,7 @@ function usePreviewPanelController(
     store.setActivePreviewTab("app");
     store.setPreviewPanelOpen(true);
   }, [browserTakeover.session, store.setActivePreviewTab, store.setPreviewPanelOpen]);
-  return { ...store, browserTakeover, isMobile, isRunActive: activeRunId !== null, previewLive };
+  return { ...store, browserTakeover, isMobile, isRunActive, previewLive };
 }
 
 function usePreviewPanelStore() {
@@ -328,6 +332,8 @@ function AppTab({
   const iframeUrl =
     useStablePreviewSource(requestedIframeUrl) ?? requestedIframeUrl ?? "about:blank";
   const frameDevice: PreviewDevice = isMobile ? "phone" : device;
+  const isGeneratedPreviewPending = appPreviewStatus === "building" && isRunActive;
+  const isReadyPreviewPending = appPreviewStatus === "ready" && previewUrl === null;
   if (
     previewPhase === "live" &&
     !previewUrl &&
@@ -346,7 +352,8 @@ function AppTab({
       <AppTabContent
         frameDevice={frameDevice}
         iframeUrl={iframeUrl}
-        isGeneratedPreviewPending={appPreviewStatus === "building" && isRunActive}
+        isGeneratedPreviewPending={isGeneratedPreviewPending}
+        isReadyPreviewPending={isReadyPreviewPending}
         previewPhase={previewPhase}
         previewRetry={previewRetry}
         previewUrl={previewUrl}
@@ -387,6 +394,7 @@ function AppTabContent({
   frameDevice,
   iframeUrl,
   isGeneratedPreviewPending,
+  isReadyPreviewPending,
   previewPhase,
   previewRetry,
   previewUrl,
@@ -395,25 +403,27 @@ function AppTabContent({
   frameDevice: PreviewDevice;
   iframeUrl: string;
   isGeneratedPreviewPending: boolean;
+  isReadyPreviewPending: boolean;
   previewPhase: PreviewLivePhase;
   previewRetry: () => Promise<void>;
   previewUrl: string | null;
   requestedIframeUrl: string | null;
 }) {
-  if (previewPhase === "booting" || isGeneratedPreviewPending) {
+  if (
+    previewPhase === "booting" ||
+    isGeneratedPreviewPending ||
+    (isReadyPreviewPending && previewPhase !== "error")
+  ) {
     return (
-      <>
-        <PreviewSessionRefresh previewUrl={requestedIframeUrl} />
-        <PreviewDeviceFrame
-          device={frameDevice}
-          content={
-            <CheatcodeLoader
-              className="h-full min-h-[420px] min-w-0 flex-1 bg-bg-secondary"
-              label={isGeneratedPreviewPending ? "Building preview…" : "Starting preview…"}
-            />
-          }
-        />
-      </>
+      <PreviewDeviceFrame
+        device={frameDevice}
+        content={
+          <CheatcodeLoader
+            className="h-full min-h-[420px] min-w-0 flex-1 bg-bg-secondary"
+            label={isGeneratedPreviewPending ? "Building preview…" : "Starting preview…"}
+          />
+        }
+      />
     );
   }
   if (previewPhase === "error") {


### PR DESCRIPTION
## Summary

- pause preview wake and capability minting while a fresh app scaffold is hidden behind the branded loader
- acquire a new preview handoff only after generated content reports ready
- keep the loader visible through that wake so the iframe never mounts with an expired credential

## Decision

A 60-second URL handoff must not be minted during a multi-minute generation step. Even if a hidden iframe exchanges it for a cookie, later mounting the visible iframe with the expired query credential fails because explicit query authorization correctly takes precedence. Deferring capability creation removes the race and also avoids unnecessary preview wake traffic while content cannot be shown.

## Verification

- `pnpm --filter @cheatcode/web typecheck`
- `pnpm --filter @cheatcode/web lint`
- `pnpm turbo typecheck lint build` (55/55 tasks)
- production reproduction crossed 60 seconds with the loader intact and confirmed the prior hidden-exchange approach still failed at iframe mount, directly validating this design change