### PR TITLE
fix(web): prevent composer project pill overlap

### DIFF
--- a/apps/web/src/components/composer/project-picker-parts.tsx
+++ b/apps/web/src/components/composer/project-picker-parts.tsx
@@ -44,7 +44,7 @@ export function ProjectPickerTrigger({
         aria-haspopup="menu"
         aria-label="Choose project"
         className={cn(
-          "group/button relative isolate inline-flex h-8 min-w-0 shrink-0 cursor-pointer select-none items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full bg-background px-2.5 font-medium text-secondary-foreground text-sm transition duration-200 hover:bg-accent/70 hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50 max-[340px]:max-w-[92px] max-[340px]:gap-1 max-[340px]:px-2 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+          "group/button relative isolate inline-flex h-8 w-full min-w-0 cursor-pointer select-none items-center justify-center gap-1.5 overflow-hidden whitespace-nowrap rounded-full bg-background px-2.5 font-medium text-secondary-foreground text-sm transition duration-200 hover:bg-accent/70 hover:text-accent-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-1 active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50 max-[340px]:max-w-[92px] max-[340px]:gap-1 max-[340px]:px-2 [&_svg]:pointer-events-none [&_svg]:shrink-0",
           compact ? "max-w-[160px]" : "max-w-[220px]",
         )}
         data-variant={variant}
@@ -55,7 +55,7 @@ export function ProjectPickerTrigger({
         type="button"
       >
         <ProjectFolderIcon className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="min-w-0 max-w-full truncate font-medium text-xs">
+        <span className="min-w-0 flex-1 truncate font-medium text-xs">
           {selectedProject?.name ?? "Choose project"}
         </span>
       </button>

--- a/apps/web/src/components/composer/project-picker.tsx
+++ b/apps/web/src/components/composer/project-picker.tsx
@@ -25,7 +25,7 @@ export function ProjectPicker({
 }) {
   const controller = useProjectPickerController({ onSelect, selectedProject });
   return (
-    <div className="relative min-w-0" ref={controller.meta.menuRef}>
+    <div className="relative min-w-0 max-w-full" ref={controller.meta.menuRef}>
       <ProjectPickerTrigger
         compact={compact}
         controller={controller}


### PR DESCRIPTION
## Summary
- constrain the project picker to the width allocated by the composer toolbar
- truncate only the long project name while retaining the folder icon and full tooltip label
- prevent the project control from drawing over the model selector in compact chat layouts

## What's Included

### Composer project picker
- make the trigger fill, but never exceed, its shrinkable wrapper
- let the text label consume and truncate within the remaining space
- cap the picker root at the available width

## Decision
The picker wrapper already receives the correct available width from the toolbar. The trigger was the faulty boundary because `shrink-0` forced a 160 px child into a 132 px allocation. The fix preserves the existing toolbar composition and corrects the child sizing contract instead of adding viewport-specific offsets.

## Edge Cases Handled
- long project names truncate without hiding the folder icon
- the model selector remains fully visible in the compact Computer-panel layout
- the full project name remains available through the existing tooltip

## How to Review
1. Review `project-picker-parts.tsx` for the trigger and label sizing change.
2. Review `project-picker.tsx` for the root width containment.

## Verification
- [x] `pnpm turbo typecheck lint build` — 55/55 tasks passed
- [x] reproduced the production overlap at −15.8 px
- [x] verified a 12 px gap after applying the exact class change in the live DOM
- [x] verified the trigger matches its 132.2 px allocated width
- [x] verified the long name truncates and the tooltip exposes the full value
