### PR TITLE
refactor(agent): isolate Google tool credentials

### DIFF
--- a/apps/agent-worker/src/durable-objects/agent-run-mastra-stream.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-mastra-stream.ts
@@ -113,7 +113,6 @@ async function prepareMastraContext(options: MastraStreamOptions): Promise<Prepa
     composioConfigured: Boolean(toolCredentials.composioApiKey),
     exaConfigured: Boolean(toolCredentials.exaApiKey),
     firecrawlConfigured: Boolean(toolCredentials.firecrawlApiKey),
-    googleMediaConfigured: Boolean(toolCredentials.googleMediaApiKey),
   });
   return { ...userSkillContext, toolCredentials };
 }
@@ -217,10 +216,7 @@ function agentRequestContext(
     exaApiKey: toolCredentials.exaApiKey,
     firecrawlApiKey: toolCredentials.firecrawlApiKey,
     globalMemory: input.globalMemory,
-    googleApiKey:
-      credential.transportProvider === "google"
-        ? credential.apiKey
-        : toolCredentials.googleMediaApiKey,
+    googleToolApiKeyResolver: toolCredentials.googleToolApiKeyResolver,
     llmProvider: credential.transportProvider,
     modelId: credential.transportModelId,
     openaiApiKey: credential.transportProvider === "openai" ? credential.apiKey : undefined,

--- a/apps/agent-worker/src/durable-objects/agent-tool-credentials.ts
+++ b/apps/agent-worker/src/durable-objects/agent-tool-credentials.ts
@@ -3,14 +3,12 @@ import type { AgentRunEnv } from "./agent-run-env";
 import type { StartRunInput } from "./agent-run-schemas";
 import type { ComposioRuntimeCredentials } from "./composio-provider";
 import { resolveComposioRuntimeCredentials } from "./composio-provider";
-import type { MediaCredentials } from "./media-provider";
-import { resolveMediaCredentials } from "./media-provider";
+import { createGoogleToolApiKeyResolver, type GoogleToolApiKeyResolver } from "./media-provider";
 import type { ResearchCredentials } from "./research-provider";
 import { resolveResearchCredentials } from "./research-provider";
 
 export type AgentToolCredentials = ComposioRuntimeCredentials &
-  MediaCredentials &
-  ResearchCredentials;
+  ResearchCredentials & { googleToolApiKeyResolver: GoogleToolApiKeyResolver };
 
 export async function resolveAgentToolCredentials(input: {
   env: AgentRunEnv;
@@ -26,11 +24,15 @@ export async function resolveAgentToolCredentials(input: {
     input.run,
     input.logger,
   );
-  input.setRunStage("Resolving media providers.");
-  const mediaCredentials = await resolveMediaCredentials(input.env, input.run, input.logger);
+  input.setRunStage("Preparing Google tool access.");
+  const googleToolApiKeyResolver = createGoogleToolApiKeyResolver(
+    input.env,
+    input.run,
+    input.logger,
+  );
   return {
     ...composioCredentials,
-    ...mediaCredentials,
     ...researchCredentials,
+    googleToolApiKeyResolver,
   };
 }

--- a/apps/agent-worker/src/durable-objects/llm-provider.ts
+++ b/apps/agent-worker/src/durable-objects/llm-provider.ts
@@ -161,7 +161,7 @@ function resolveModelRequest(model: LogicalModelId): RequestedModel {
   } catch (error) {
     throw new APIError(400, "request_body_invalid", "Unsupported model selection.", {
       details: { message: error instanceof Error ? error.message : "Unknown model error" },
-      hint: "Use a supported Anthropic, Google Gemini, OpenAI, DeepSeek, or OpenRouter model id.",
+      hint: "Use a supported Anthropic, OpenAI, DeepSeek, or OpenRouter model id.",
       retriable: false,
     });
   }
@@ -300,9 +300,6 @@ function providerLabel(provider: LlmProvider): string {
   }
   if (provider === "openai") {
     return "OpenAI";
-  }
-  if (provider === "google") {
-    return "Google Gemini";
   }
   if (provider === "deepseek") {
     return "DeepSeek";

--- a/apps/agent-worker/src/durable-objects/media-provider.ts
+++ b/apps/agent-worker/src/durable-objects/media-provider.ts
@@ -10,32 +10,42 @@ interface MediaProviderEnv {
   HYPERDRIVE: Hyperdrive;
 }
 
-interface MediaProviderInput {
+interface GoogleToolProviderInput {
   userId: string;
 }
 
-export interface MediaCredentials {
-  googleMediaApiKey?: string | undefined;
+export type GoogleToolApiKeyResolver = () => Promise<string | undefined>;
+
+export function createGoogleToolApiKeyResolver(
+  env: MediaProviderEnv,
+  input: GoogleToolProviderInput,
+  logger: ReturnType<typeof createLogger>,
+): GoogleToolApiKeyResolver {
+  let resolution: Promise<string | undefined> | undefined;
+  return () => {
+    resolution ??= resolveGoogleToolApiKey(env, input, logger);
+    return resolution;
+  };
 }
 
-export async function resolveMediaCredentials(
+async function resolveGoogleToolApiKey(
   env: MediaProviderEnv,
-  input: MediaProviderInput,
+  input: GoogleToolProviderInput,
   logger: ReturnType<typeof createLogger>,
-): Promise<MediaCredentials> {
+): Promise<string | undefined> {
   return withUserDb(
     env,
     toUserId(input.userId),
     async ({ transaction }) => {
       const googleMediaApiKey = await transaction((db) => getProviderKey(db, "google"));
-      logger.info("byok_media_provider_key_checked", { google: Boolean(googleMediaApiKey) });
-      return googleMediaApiKey ? { googleMediaApiKey } : {};
+      logger.info("byok_google_tool_key_checked", { configured: Boolean(googleMediaApiKey) });
+      return googleMediaApiKey ?? undefined;
     },
     (dbHandle) =>
       closeDatabaseBestEffort({
         dbHandle,
         logger,
-        operation: "resolve_media_credentials",
+        operation: "resolve_google_tool_key",
       }),
   );
 }

--- a/apps/web/src/components/settings/models-panel-model.ts
+++ b/apps/web/src/components/settings/models-panel-model.ts
@@ -28,7 +28,6 @@ export const SETTINGS_KEY_PROVIDERS = [
 export const MODEL_KEY_PROVIDERS = new Set<Provider>([
   "anthropic",
   "deepseek",
-  "google",
   "openai",
   "openrouter",
 ]);
@@ -44,7 +43,7 @@ const PROVIDER_LABELS = {
   deepseek: "DeepSeek",
   exa: "Exa",
   firecrawl: "Firecrawl",
-  google: "Gemini",
+  google: "Google AI",
   openai: "OpenAI",
   openrouter: "OpenRouter",
 } satisfies Record<Provider, string>;

--- a/apps/web/src/components/settings/provider-key-model.ts
+++ b/apps/web/src/components/settings/provider-key-model.ts
@@ -10,14 +10,20 @@ export type ProviderKeyFormValues = z.infer<typeof ProviderKeyFormSchema>;
 export type ProviderKeyEditorStatus = "deleting" | "idle" | "saving";
 export type SecretVisibility = "hidden" | "visible";
 
-export const PROVIDER_META: Record<Provider, { label: string }> = {
-  anthropic: { label: "Anthropic" },
-  deepseek: { label: "DeepSeek" },
-  exa: { label: "Exa" },
-  firecrawl: { label: "Firecrawl" },
-  google: { label: "Gemini" },
-  openai: { label: "OpenAI" },
-  openrouter: { label: "OpenRouter" },
+export const PROVIDER_META: Record<Provider, { description: string; label: string }> = {
+  anthropic: { description: "Agent models and browser automation.", label: "Anthropic" },
+  deepseek: { description: "Optional personal key for DeepSeek models.", label: "DeepSeek" },
+  exa: { description: "Web research and source discovery.", label: "Exa" },
+  firecrawl: { description: "Web search, scraping, and extraction.", label: "Firecrawl" },
+  google: {
+    description: "Tools only: images, Veo video, and browser automation.",
+    label: "Google AI",
+  },
+  openai: { description: "Agent models and browser automation.", label: "OpenAI" },
+  openrouter: {
+    description: "Alternative routing for supported agent models.",
+    label: "OpenRouter",
+  },
 };
 
 export function providerPanelId(provider: Provider): string {

--- a/apps/web/src/components/settings/provider-keys-list.tsx
+++ b/apps/web/src/components/settings/provider-keys-list.tsx
@@ -1,6 +1,8 @@
 import type { Provider, ProviderKeySummary } from "@cheatcode/types/api";
 import type { FormEventHandler } from "react";
 import type { FieldError, UseFormRegister, UseFormWatch } from "react-hook-form";
+import { Info } from "@/components/ui";
+import { CheatcodeTooltip } from "@/components/ui/cheatcode-tooltip";
 import { cn } from "@/lib/ui/cn";
 import { ProviderKeyEditor } from "./provider-key-editor";
 import {
@@ -124,11 +126,26 @@ function ProviderKeyRowHeader({
   provider: Provider;
   summary: ProviderKeySummary | undefined;
 }) {
+  const meta = PROVIDER_META[provider];
   return (
     <div className="flex min-h-8 items-center justify-between">
-      <h2 className="truncate font-medium text-[14px] text-foreground" id={providerTabId(provider)}>
-        {PROVIDER_META[provider].label} API Key
-      </h2>
+      <div className="flex min-w-0 items-center gap-1.5">
+        <h2
+          className="min-w-0 truncate font-medium text-[14px] text-foreground"
+          id={providerTabId(provider)}
+        >
+          {meta.label} API Key
+        </h2>
+        <CheatcodeTooltip label={meta.description} side="top">
+          <button
+            aria-label={`About ${meta.label} API key`}
+            className="inline-flex size-6 shrink-0 cursor-help items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+            type="button"
+          >
+            <Info aria-hidden="true" className="size-3.5" />
+          </button>
+        </CheatcodeTooltip>
+      </div>
       {isExpanded ? null : (
         <div className="ml-4 flex items-center gap-2">
           <button

--- a/apps/web/src/components/ui/icons.ts
+++ b/apps/web/src/components/ui/icons.ts
@@ -26,6 +26,7 @@ export {
   Globe,
   Image,
   Inbox,
+  Info,
   LifeBuoy,
   Link,
   Loader2,

--- a/apps/web/src/components/ui/index.ts
+++ b/apps/web/src/components/ui/index.ts
@@ -27,6 +27,7 @@ export {
   Globe,
   Image,
   Inbox,
+  Info,
   LifeBuoy,
   Link,
   Loader2,

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -21,8 +21,8 @@ Sandbox and artifact capabilities cross tool-domain boundaries only through
 Single-consumer data, document, and media implementations live under
 `src/tools/`. Data tools profile and normalize bounded tabular inputs and render
 deterministic SVG/Recharts output. Document tools generate sandbox-side PPTX,
-DOCX, XLSX, and PDF source against `/opt/cheatcode-doc-runtime`. Media tools use
-the active request's Google BYOK key for image/video work. All three receive
+DOCX, XLSX, and PDF source against `/opt/cheatcode-doc-runtime`. Media and Google-backed
+browser tools resolve the user's Google AI BYOK key lazily when invoked. All three receive
 sandbox and R2 artifact capabilities through request-scoped contracts; they do
 not read environment variables, persist credentials, or log keys.
 
@@ -52,9 +52,9 @@ pnpm --filter @cheatcode/agent-core typecheck
 Provider keys are supplied through BYOK runtime context, not module scope.
 `resolveRequestedLlmTransport` returns an `LlmTransportSelection`: its provider and bare
 model ID are SDK transport inputs, never the durable product model attribution.
-Google model selections use `google/<Gemini model id>`, for example
-`google/gemini-2.5-flash`. OpenRouter model selections use
-`openrouter/<OpenRouter model id>`, for example `openrouter/openrouter/auto`.
+OpenRouter model selections use `openrouter/<OpenRouter model id>`, for example
+`openrouter/openrouter/auto`. Google AI keys are tool credentials for image/video
+generation and browser automation; `google/<model id>` is not an agent-model route.
 
 Mastra storage is intentionally execution-only and in-memory. AgentRun Durable
 Objects and Postgres own durable run and transcript state. Workflows that receive

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@ai-sdk/anthropic": "catalog:",
     "@ai-sdk/deepseek": "catalog:",
-    "@ai-sdk/google": "catalog:",
     "@ai-sdk/openai": "catalog:",
     "@cheatcode/composio": "workspace:*",
     "@cheatcode/observability": "workspace:*",

--- a/packages/agent-core/src/mastra/agents/general.ts
+++ b/packages/agent-core/src/mastra/agents/general.ts
@@ -1,6 +1,5 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createDeepSeek } from "@ai-sdk/deepseek";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import { APIError } from "@cheatcode/observability";
 import { Agent } from "@mastra/core/agent";
@@ -12,10 +11,8 @@ import {
   DEEPSEEK_API_KEY_CONTEXT_KEY,
   DEFAULT_ANTHROPIC_MODEL_ID,
   DEFAULT_DEEPSEEK_MODEL_ID,
-  DEFAULT_GOOGLE_MODEL_ID,
   DEFAULT_OPENAI_MODEL_ID,
   DEFAULT_OPENROUTER_MODEL_ID,
-  GOOGLE_API_KEY_CONTEXT_KEY,
   LLM_MODEL_ID_CONTEXT_KEY,
   LLM_PROVIDER_CONTEXT_KEY,
   type LlmProvider,
@@ -49,17 +46,6 @@ function createOpenAiByokModel(
     throw new Error("OpenAI BYOK key is required.");
   }
   return createOpenAI({ apiKey: trimmed, fetch: boundedProviderFetch }).responses(modelId);
-}
-
-function createGoogleByokModel(
-  apiKey: string,
-  modelId = DEFAULT_GOOGLE_MODEL_ID,
-): MastraModelConfig {
-  const trimmed = apiKey.trim();
-  if (trimmed.length === 0) {
-    throw new Error("Google BYOK key is required.");
-  }
-  return createGoogleGenerativeAI({ apiKey: trimmed, fetch: boundedProviderFetch })(modelId);
 }
 
 function createOpenRouterByokModel(
@@ -107,9 +93,6 @@ export function resolveRequestedLlmTransport(model: string): LlmTransportSelecti
   if (requested.startsWith("openai/")) {
     return requestedModel("openai", requested.slice("openai/".length));
   }
-  if (requested.startsWith("google/")) {
-    return requestedModel("google", requested.slice("google/".length));
-  }
   if (requested.startsWith("openrouter/")) {
     return requestedModel("openrouter", requested.slice("openrouter/".length));
   }
@@ -147,11 +130,6 @@ function resolveGeneralModel({
         requiredProviderKey(requestContext, OPENROUTER_API_KEY_CONTEXT_KEY, "OpenRouter", provider),
         requestedModelId(modelId, DEFAULT_OPENROUTER_MODEL_ID),
       );
-    case "google":
-      return createGoogleByokModel(
-        requiredProviderKey(requestContext, GOOGLE_API_KEY_CONTEXT_KEY, "Google Gemini", provider),
-        requestedModelId(modelId, DEFAULT_GOOGLE_MODEL_ID),
-      );
     case "deepseek":
       return createDeepSeekModel(
         requiredProviderKey(requestContext, DEEPSEEK_API_KEY_CONTEXT_KEY, "DeepSeek", provider),
@@ -166,7 +144,7 @@ function resolveGeneralModel({
 }
 
 function resolveLlmProvider(value: unknown): LlmProvider {
-  if (value === "google" || value === "openai" || value === "openrouter" || value === "deepseek") {
+  if (value === "openai" || value === "openrouter" || value === "deepseek") {
     return value;
   }
   return "anthropic";

--- a/packages/agent-core/src/mastra/context.ts
+++ b/packages/agent-core/src/mastra/context.ts
@@ -11,7 +11,7 @@ export const CONTEXT = {
   exaApiKey: "exaApiKey",
   firecrawlApiKey: "firecrawlApiKey",
   globalMemory: "globalMemory",
-  googleApiKey: "googleApiKey",
+  googleToolApiKeyResolver: "googleToolApiKeyResolver",
   llmModelId: "llmModelId",
   llmProvider: "llmProvider",
   openaiApiKey: "openaiApiKey",

--- a/packages/agent-core/src/mastra/llm-context.ts
+++ b/packages/agent-core/src/mastra/llm-context.ts
@@ -5,7 +5,6 @@ import {
 } from "@cheatcode/types";
 
 export const ANTHROPIC_API_KEY_CONTEXT_KEY = "anthropicApiKey";
-export const GOOGLE_API_KEY_CONTEXT_KEY = "googleApiKey";
 export const OPENAI_API_KEY_CONTEXT_KEY = "openaiApiKey";
 export const OPENROUTER_API_KEY_CONTEXT_KEY = "openrouterApiKey";
 export const DEEPSEEK_API_KEY_CONTEXT_KEY = "deepseekApiKey";
@@ -23,7 +22,7 @@ export const DEFAULT_DEEPSEEK_MODEL_ID = providerLocalModelId(
   "deepseek/",
 );
 
-export type LlmProvider = "anthropic" | "google" | "openai" | "openrouter" | "deepseek";
+export type LlmProvider = "anthropic" | "openai" | "openrouter" | "deepseek";
 
 /** Provider-local selection used only to construct the outbound SDK transport. */
 export interface LlmTransportSelection {

--- a/packages/agent-core/src/mastra/tool-defs/browser-runtime.ts
+++ b/packages/agent-core/src/mastra/tool-defs/browser-runtime.ts
@@ -7,37 +7,35 @@ import {
   DEFAULT_GOOGLE_MODEL_ID,
   DEFAULT_OPENAI_MODEL_ID,
 } from "../llm-context";
+import { resolveGoogleToolApiKey } from "./request-context";
 
-const BROWSER_PROVIDER_CONFIG: Record<
-  BrowserProvider,
+type DirectBrowserProvider = Exclude<BrowserProvider, "google">;
+
+const DIRECT_BROWSER_PROVIDER_CONFIG: Record<
+  DirectBrowserProvider,
   { apiKeyContext: string; defaultModelId: string }
 > = {
   anthropic: {
     apiKeyContext: CONTEXT.anthropicApiKey,
     defaultModelId: DEFAULT_ANTHROPIC_MODEL_ID,
   },
-  google: {
-    apiKeyContext: CONTEXT.googleApiKey,
-    defaultModelId: DEFAULT_GOOGLE_MODEL_ID,
-  },
   openai: {
     apiKeyContext: CONTEXT.openaiApiKey,
     defaultModelId: DEFAULT_OPENAI_MODEL_ID,
   },
 };
-const BROWSER_PROVIDER_FALLBACK_ORDER: readonly BrowserProvider[] = [
+const DIRECT_BROWSER_PROVIDER_FALLBACK_ORDER: readonly DirectBrowserProvider[] = [
   "anthropic",
   "openai",
-  "google",
 ];
 
 export interface RequestContextReader {
   get(key: string): unknown;
 }
 
-export function browserRuntimeFromRequestContext(
+export async function browserRuntimeFromRequestContext(
   requestContext: RequestContextReader,
-): BrowserRuntimeContext {
+): Promise<BrowserRuntimeContext> {
   const runtimeContext = CodeRuntimeContextSchema.parse(requestContext.get(CONTEXT.codeRuntime));
   const runId = requestContext.get(CONTEXT.browserRunId);
   if (typeof runId !== "string" || runId.length === 0) {
@@ -52,17 +50,17 @@ export function browserRuntimeFromRequestContext(
   }
   return {
     ...(runtimeContext.artifacts ? { artifacts: runtimeContext.artifacts } : {}),
-    credential: browserCredentialFromRequestContext(requestContext),
+    credential: await browserCredentialFromRequestContext(requestContext),
     runId,
     sandbox: runtimeContext.sandbox,
   };
 }
 
-function browserCredentialFromRequestContext(requestContext: RequestContextReader) {
+async function browserCredentialFromRequestContext(requestContext: RequestContextReader) {
   const requestedProvider = requestContext.get(CONTEXT.llmProvider);
   const modelId = requestContext.get(CONTEXT.llmModelId);
-  if (isBrowserProvider(requestedProvider)) {
-    const config = BROWSER_PROVIDER_CONFIG[requestedProvider];
+  if (isDirectBrowserProvider(requestedProvider)) {
+    const config = DIRECT_BROWSER_PROVIDER_CONFIG[requestedProvider];
     return providerCredential(
       requestedProvider,
       requestContext.get(config.apiKeyContext),
@@ -73,21 +71,25 @@ function browserCredentialFromRequestContext(requestContext: RequestContextReade
   return fallbackBrowserCredential(requestContext);
 }
 
-function fallbackBrowserCredential(requestContext: RequestContextReader) {
+async function fallbackBrowserCredential(requestContext: RequestContextReader) {
   // Fallback for non-vision providers (for example, an included DeepSeek or OpenRouter run): browser
   // tools need a vision/CUA key, so prefer any the user has. The platform DeepSeek key is
   // never read here, so it can never reach the sandbox as a browser credential.
-  for (const provider of BROWSER_PROVIDER_FALLBACK_ORDER) {
-    const config = BROWSER_PROVIDER_CONFIG[provider];
+  for (const provider of DIRECT_BROWSER_PROVIDER_FALLBACK_ORDER) {
+    const config = DIRECT_BROWSER_PROVIDER_CONFIG[provider];
     const apiKey = requestContext.get(config.apiKeyContext);
     if (typeof apiKey === "string" && apiKey.trim().length > 0) {
       return providerCredential(provider, apiKey, undefined, config.defaultModelId);
     }
   }
+  const googleApiKey = await resolveGoogleToolApiKey(requestContext);
+  if (googleApiKey) {
+    return providerCredential("google", googleApiKey, undefined, DEFAULT_GOOGLE_MODEL_ID);
+  }
   throw new APIError(
     400,
     "byok_key_missing",
-    "Browser automation needs an Anthropic, OpenAI, or Google API key.",
+    "Browser automation needs an Anthropic, OpenAI, or Google AI API key.",
     {
       hint: "Add one in Settings → Models. The included DeepSeek model does not power browser tools.",
       retriable: false,
@@ -95,8 +97,8 @@ function fallbackBrowserCredential(requestContext: RequestContextReader) {
   );
 }
 
-function isBrowserProvider(value: unknown): value is BrowserProvider {
-  return value === "anthropic" || value === "google" || value === "openai";
+function isDirectBrowserProvider(value: unknown): value is DirectBrowserProvider {
+  return value === "anthropic" || value === "openai";
 }
 
 function providerCredential(
@@ -130,7 +132,7 @@ function browserProviderLabel(provider: BrowserProvider): string {
     return "Anthropic";
   }
   if (provider === "google") {
-    return "Google Gemini";
+    return "Google AI";
   }
   return "OpenAI";
 }

--- a/packages/agent-core/src/mastra/tool-defs/media-tools.ts
+++ b/packages/agent-core/src/mastra/tool-defs/media-tools.ts
@@ -4,10 +4,10 @@ import {
   GenerateOrEditMediaInputSchema,
   GenerateOrEditMediaOutputSchema,
 } from "../../tools/media/schemas";
-import { CONTEXT } from "../context";
+import { resolveGoogleToolApiKey } from "./request-context";
 import { requestContextFromToolContext, workspaceRuntimeFromContext } from "./tool-runtime-context";
 
-/** Generates or edits image/video artifacts with the user's request-scoped Google key. */
+/** Generates or edits media after lazily resolving the user's Google AI tool key. */
 export const mastraGenerateOrEditMedia = createTool({
   id: "generate_or_edit_media",
   description:
@@ -16,11 +16,11 @@ export const mastraGenerateOrEditMedia = createTool({
   outputSchema: GenerateOrEditMediaOutputSchema,
   execute: async (input, context) => {
     const requestContext = requestContextFromToolContext(context);
-    const googleApiKey = requestContext.get(CONTEXT.googleApiKey);
+    const googleApiKey = await resolveGoogleToolApiKey(requestContext);
     return executeGenerateOrEditMedia(
       GenerateOrEditMediaInputSchema.parse(input),
       await workspaceRuntimeFromContext(context),
-      typeof googleApiKey === "string" ? googleApiKey : "",
+      googleApiKey ?? "",
     );
   },
 });

--- a/packages/agent-core/src/mastra/tool-defs/request-context.ts
+++ b/packages/agent-core/src/mastra/tool-defs/request-context.ts
@@ -6,6 +6,8 @@ import { CONTEXT, type ContextKey } from "../context";
 import type { LlmProvider } from "../llm-context";
 import type { UserSkillCreator, UserSkillLoader, UserSkillRuntime } from "../user-skill-runtime";
 
+type GoogleToolApiKeyResolver = () => Promise<string | undefined>;
+
 interface CodeRequestContextOptions {
   agentDisplayName?: string | undefined;
   anthropicApiKey?: string | undefined;
@@ -17,7 +19,7 @@ interface CodeRequestContextOptions {
   exaApiKey?: string | undefined;
   firecrawlApiKey?: string | undefined;
   globalMemory?: string | undefined;
-  googleApiKey?: string | undefined;
+  googleToolApiKeyResolver?: GoogleToolApiKeyResolver | undefined;
   llmProvider?: LlmProvider | undefined;
   modelId?: string | undefined;
   openaiApiKey?: string | undefined;
@@ -61,7 +63,7 @@ function contextEntries(
     [CONTEXT.composioQuotaMeter, options.composioQuotaMeter],
     [CONTEXT.composioUserId, options.composioUserId],
     [CONTEXT.openaiApiKey, options.openaiApiKey],
-    [CONTEXT.googleApiKey, options.googleApiKey],
+    [CONTEXT.googleToolApiKeyResolver, options.googleToolApiKeyResolver],
     [CONTEXT.openrouterApiKey, options.openrouterApiKey],
     [CONTEXT.deepseekApiKey, options.deepseekApiKey],
     [CONTEXT.exaApiKey, options.exaApiKey],
@@ -71,6 +73,17 @@ function contextEntries(
     [CONTEXT.userSkillCreator, options.userSkillCreator],
     [CONTEXT.userSkillLoader, options.userSkillLoader],
   ];
+}
+
+export async function resolveGoogleToolApiKey(requestContext: {
+  get(key: string): unknown;
+}): Promise<string | undefined> {
+  const candidate = requestContext.get(CONTEXT.googleToolApiKeyResolver);
+  if (typeof candidate !== "function") {
+    return undefined;
+  }
+  const apiKey = await (candidate as GoogleToolApiKeyResolver)();
+  return typeof apiKey === "string" && apiKey.trim().length > 0 ? apiKey.trim() : undefined;
 }
 
 function setOptionalContextValue(

--- a/packages/agent-core/src/tools/media/execute.ts
+++ b/packages/agent-core/src/tools/media/execute.ts
@@ -356,8 +356,8 @@ function extensionForMimeType(mimeType: string): string {
 function requiredApiKey(value: string): string {
   const key = value.trim();
   if (!key) {
-    throw new APIError(400, "byok_key_missing", "Add a Google API key to generate media.", {
-      hint: "Open Models and configure your Google API key.",
+    throw new APIError(400, "byok_key_missing", "Add a Google AI API key to generate media.", {
+      hint: "Open Models and configure your Google AI API key.",
       retriable: false,
     });
   }

--- a/packages/byok/src/provider-validation.ts
+++ b/packages/byok/src/provider-validation.ts
@@ -56,7 +56,7 @@ const PROVIDER_VALIDATORS = {
   },
   google: {
     invalidStatuses: [400, 401, 403],
-    label: "Google Gemini",
+    label: "Google AI",
     method: "GET",
     schema: z
       .object({

--- a/packages/types/src/models.ts
+++ b/packages/types/src/models.ts
@@ -7,7 +7,7 @@ export const LogicalModelIdSchema = z
   .min(1)
   .max(200)
   .regex(
-    /^(?:anthropic|deepseek|google|openai|openrouter)\/\S+$/,
+    /^(?:anthropic|deepseek|openai|openrouter)\/\S+$/,
     "Use a supported provider-prefixed model id without whitespace.",
   )
   .brand<"LogicalModelId">();
@@ -38,9 +38,9 @@ const RAW_CATALOG_MODEL_ID_VALUES = [
  * The single source of truth for the agent model catalog shown in the picker.
  *
  * Curated to the live Models list: Claude Sonnet 4.6, Claude Opus 4.8,
- * GPT-5.4 Thinking, GPT-5.4 Mini, and the included DeepSeek V4 Pro model. Gemini 2.5
- * Flash and the standalone OpenRouter-Auto row stay reachable as provider-prefixed
- * request ids routed through OpenRouter, but are not drawn in the picker.
+ * GPT-5.4 Thinking, GPT-5.4 Mini, and the included DeepSeek V4 Pro model. The standalone
+ * OpenRouter-Auto row stays reachable as a provider-prefixed request id but is not
+ * drawn in the picker. Google AI keys are tool-only and never select the chat model.
  *
  * Catalog order doubles as the resolution priority: the production default is first,
  * and Opus 4.8 is preferred over the GPT-5.4 entries when that default is disabled.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ catalogs:
     '@ai-sdk/deepseek':
       specifier: 2.0.39
       version: 2.0.39
-    '@ai-sdk/google':
-      specifier: 3.0.82
-      version: 3.0.82
     '@ai-sdk/openai':
       specifier: 3.0.71
       version: 3.0.71
@@ -583,9 +580,6 @@ importers:
       '@ai-sdk/deepseek':
         specifier: 'catalog:'
         version: 2.0.39(zod@4.4.3)
-      '@ai-sdk/google':
-        specifier: 'catalog:'
-        version: 3.0.82(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: 'catalog:'
         version: 3.0.71(zod@4.4.3)
@@ -892,12 +886,6 @@ packages:
 
   '@ai-sdk/gateway@3.0.131':
     resolution: {integrity: sha512-CnjOZdywQaUnCyZ0N5wVNm7Sm63+NeHDVZQJKFX2IDq+t03SLwiiuoi3ILTLPlM+YSOhkQ/pvIDoR4qa98Zp5A==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/google@3.0.82':
-    resolution: {integrity: sha512-md+M92ZJuPIMU2p4v1rGLpJJWTmTh/vpJPkMnQbEdcLaPTZxRaroIKSnmL/9UGJV0BORJlHNDJegkcnhVpTmDA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6778,12 +6766,6 @@ snapshots:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       '@vercel/oidc': 3.2.0
-      zod: 4.4.3
-
-  '@ai-sdk/google@3.0.82(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/openai@3.0.71(zod@4.4.3)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,7 +79,6 @@ peerDependencyRules:
 catalog:
   '@ai-sdk/anthropic': 3.0.84
   '@ai-sdk/deepseek': 2.0.39
-  '@ai-sdk/google': 3.0.82
   '@ai-sdk/openai': 3.0.71
   '@ai-sdk/react': 3.0.207
   # 2.5.3-2.5.4 panic in the type-aware module resolver (biomejs/biome#10885).

--- a/skills/product-self-knowledge/SKILL.md
+++ b/skills/product-self-knowledge/SKILL.md
@@ -49,7 +49,7 @@ The visible model catalog is:
 | GPT-5.4 Mini | OpenAI | Fast utility option |
 | DeepSeek V4 Pro | DeepSeek | Included platform route |
 
-Cheatcode accepts provider-prefixed OpenRouter and Google model IDs even though those providers are not shown as separate catalog rows. BYOK keys are configured in Models and are decrypted only for the active request. Supported provider key families are Anthropic, OpenAI, Google, OpenRouter, DeepSeek, Exa, and Firecrawl. BYOK key counts are not limited by subscription-plan slots.
+Cheatcode accepts provider-prefixed OpenRouter model IDs even though OpenRouter is not shown as a separate catalog row. Google AI keys are tool-only credentials for image/video generation and browser automation; agent runs reject `google/<model-id>` selections. BYOK keys are configured in Models and decrypted only for the active request or tool invocation. Supported provider key families are Anthropic, OpenAI, Google AI, OpenRouter, DeepSeek, Exa, and Firecrawl. BYOK key counts are not limited by subscription-plan slots.
 
 ## Plans
 


### PR DESCRIPTION
## Summary
- removes unsupported Gemini chat-model routing and the unused `@ai-sdk/google` dependency
- keeps Google AI as a tool credential for image generation, Veo video, and browser automation
- resolves the Google key lazily only when a Google-backed tool actually runs
- labels the setting as Google AI and explains every provider key through an accessible info tooltip

## Architecture
Agent model selection now accepts only Anthropic, OpenAI, DeepSeek, and OpenRouter routes. The AgentRun stores a request-scoped Google-key resolver; media and browser tool boundaries invoke it on demand, and its promise is cached only for that active run.

## Decisions Made
| Decision | Choice | Reasoning |
|---|---|---|
| Google model support | Remove the hidden chat route | Gemini is not in the supported agent catalog and the setting exists for tools |
| Credential resolution | Lazy request-scoped resolver | Avoids decrypting or passing a Google key during runs that never use Google-backed tools |
| Settings copy | Info icon and tooltip | Keeps the list compact while making each key's purpose accessible on hover and focus |

## Edge Cases Handled
| Scenario | Handling |
|---|---|
| Media tool runs without a Google key | Returns the existing actionable BYOK error using the Google AI label |
| Browser runs on DeepSeek/OpenRouter | Prefers configured Anthropic/OpenAI credentials, then lazily resolves Google AI |
| Repeated Google tool calls in one run | Shares one in-flight key-resolution promise without module-scope caching |
| Client submits `google/<model>` | Rejected by the shared logical model schema |

## Test Plan
- [x] `pnpm turbo typecheck lint build` (55/55 tasks successful)
- [x] staged Biome validation and commitlint hooks
- [ ] verify the Google AI row and provider tooltips on production after deployment
- [ ] verify the production Worker release after the Cloudflare workflow
