### PR TITLE
fix(web): scope key tooltip to Google AI

### DIFF
--- a/apps/web/src/components/settings/provider-key-model.ts
+++ b/apps/web/src/components/settings/provider-key-model.ts
@@ -10,20 +10,17 @@ export type ProviderKeyFormValues = z.infer<typeof ProviderKeyFormSchema>;
 export type ProviderKeyEditorStatus = "deleting" | "idle" | "saving";
 export type SecretVisibility = "hidden" | "visible";
 
-export const PROVIDER_META: Record<Provider, { description: string; label: string }> = {
-  anthropic: { description: "Agent models and browser automation.", label: "Anthropic" },
-  deepseek: { description: "Optional personal key for DeepSeek models.", label: "DeepSeek" },
-  exa: { description: "Web research and source discovery.", label: "Exa" },
-  firecrawl: { description: "Web search, scraping, and extraction.", label: "Firecrawl" },
+export const PROVIDER_META: Record<Provider, { description?: string; label: string }> = {
+  anthropic: { label: "Anthropic" },
+  deepseek: { label: "DeepSeek" },
+  exa: { label: "Exa" },
+  firecrawl: { label: "Firecrawl" },
   google: {
     description: "Tools only: images, Veo video, and browser automation.",
     label: "Google AI",
   },
-  openai: { description: "Agent models and browser automation.", label: "OpenAI" },
-  openrouter: {
-    description: "Alternative routing for supported agent models.",
-    label: "OpenRouter",
-  },
+  openai: { label: "OpenAI" },
+  openrouter: { label: "OpenRouter" },
 };
 
 export function providerPanelId(provider: Provider): string {

--- a/apps/web/src/components/settings/provider-keys-list.tsx
+++ b/apps/web/src/components/settings/provider-keys-list.tsx
@@ -136,15 +136,17 @@ function ProviderKeyRowHeader({
         >
           {meta.label} API Key
         </h2>
-        <CheatcodeTooltip label={meta.description} side="top">
-          <button
-            aria-label={`About ${meta.label} API key`}
-            className="inline-flex size-6 shrink-0 cursor-help items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
-            type="button"
-          >
-            <Info aria-hidden="true" className="size-3.5" />
-          </button>
-        </CheatcodeTooltip>
+        {meta.description ? (
+          <CheatcodeTooltip label={meta.description} side="top">
+            <button
+              aria-label={`About ${meta.label} API key`}
+              className="inline-flex size-6 shrink-0 cursor-help items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50"
+              type="button"
+            >
+              <Info aria-hidden="true" className="size-3.5" />
+            </button>
+          </CheatcodeTooltip>
+        ) : null}
       </div>
       {isExpanded ? null : (
         <div className="ml-4 flex items-center gap-2">


### PR DESCRIPTION
## Summary
- keeps the tool-purpose info icon and tooltip only on the Google AI key row
- removes info icons and tooltip copy from the six other provider rows
- preserves the Google AI tooltip's hover and keyboard-focus accessibility behavior

## Decision
Google AI needs clarification because its key is tool-only despite appearing on the Models page. The other providers do not need extra row-level explanation, so their original compact labels are retained.

## Test Plan
- [x] web TypeScript check
- [x] web Biome lint
- [x] production Next.js build
- [x] repository dead-code analysis
- [ ] production browser verification after deployment
