### PR TITLE
fix(db): scope artifact upload row lock

### DIFF
--- a/packages/db/src/artifact-upload-intents.ts
+++ b/packages/db/src/artifact-upload-intents.ts
@@ -289,7 +289,7 @@ function lockActiveUploadOwnership(
         isNull(users.deletionFence),
       ),
     )
-    .for("update")
+    .for("update", { of: agentRuns })
     .limit(1)
     .then((rows) => rows[0]);
 }


### PR DESCRIPTION
## Summary

- lock only the active `v2_agent_runs` row while validating artifact-upload ownership
- keep project, thread, and user joins read-only under their least-privilege grants
- preserve the transaction fence against a concurrent run completion

## Why

PostgreSQL applies an unqualified `FOR UPDATE` to every relation in a joined query. The agent role intentionally cannot update projects, so generated media reached persistence and then failed before its upload intent could be committed. `FOR UPDATE OF v2_agent_runs` matches the intended concurrency boundary and the clean baseline ACLs.

## Verification

- `pnpm exec biome check packages/db/src/artifact-upload-intents.ts`
- `pnpm turbo lint`
- `pnpm turbo typecheck --filter=@cheatcode/db --filter=@cheatcode/agent-worker`
- `pnpm turbo build --filter=@cheatcode/agent-worker`
- `pnpm db:migrate -- --dry-run`