### PR TITLE
fix(db): avoid unreadable run timestamp

### DIFF
--- a/packages/db/src/artifact-upload-intents.ts
+++ b/packages/db/src/artifact-upload-intents.ts
@@ -282,7 +282,6 @@ function lockActiveUploadOwnership(
         eq(projects.id, input.projectId),
         eq(threads.activeRunId, input.agentRunId),
         inArray(agentRuns.status, ["pending", "running"]),
-        isNull(agentRuns.finishedAt),
         isNull(threads.deletedAt),
         isNull(projects.deletedAt),
         isNull(users.deletedAt),


### PR DESCRIPTION
## Summary

- stop reading `v2_agent_runs.finished_at` from the active artifact-upload ownership query
- rely on the baseline check constraint that already makes active status and a null terminal timestamp equivalent
- retain the narrow `FOR UPDATE OF v2_agent_runs` concurrency fence without broadening the agent role

## Why

Production Postgres logs showed every media attempt failing with `permission denied for table v2_agent_runs`. The agent role intentionally has update-only access to `finished_at`; the redundant read violated that least-privilege contract. Granting more access would weaken the clean baseline for no additional invariant.

## Verification

- exact production-role ownership query succeeds after removing the timestamp predicate
- the former query reproduces `permission denied for table v2_agent_runs`
- `pnpm turbo lint`
- `pnpm turbo typecheck --filter=@cheatcode/db --filter=@cheatcode/agent-worker`
- `pnpm turbo build --filter=@cheatcode/agent-worker`
- `pnpm db:migrate -- --dry-run`