### PR TITLE
fix(db): complete artifact intent insert acl

### DIFF
--- a/packages/db/drizzle/0000_current_schema.sql
+++ b/packages/db/drizzle/0000_current_schema.sql
@@ -3403,7 +3403,7 @@ GRANT SELECT(cleanup_not_before) ON TABLE public.v2_artifact_upload_intents TO a
 -- Name: COLUMN v2_artifact_upload_intents.quiesced_at; Type: ACL; Schema: public; Owner: -
 --
 
-GRANT SELECT(quiesced_at),UPDATE(quiesced_at) ON TABLE public.v2_artifact_upload_intents TO app_agent;
+GRANT SELECT(quiesced_at),INSERT(quiesced_at),UPDATE(quiesced_at) ON TABLE public.v2_artifact_upload_intents TO app_agent;
 GRANT SELECT(quiesced_at) ON TABLE public.v2_artifact_upload_intents TO app_webhooks;
 
 

--- a/scripts/supabase-target/index.ts
+++ b/scripts/supabase-target/index.ts
@@ -33,6 +33,7 @@ export async function assertSupabaseTarget(client: PgClient): Promise<void> {
     await validateRuntimeRoles(client),
     await validateRuntimeAcl(client),
     await validateImmutableGeneratedOutputAcl(client),
+    await validateArtifactUploadIntentAcl(client),
     await validateDataApiIsolation(client),
     await validateIntegrityConstraints(client),
     await validateIntegrityIndexes(client),
@@ -288,6 +289,20 @@ async function validateImmutableGeneratedOutputAcl(client: PgClient): Promise<st
   return row["can_update"] === false
     ? []
     : ["app_agent must not update immutable generated outputs."];
+}
+
+async function validateArtifactUploadIntentAcl(client: PgClient): Promise<string[]> {
+  const result = await client.query(
+    `select has_column_privilege(pg_catalog.to_regrole('app_agent'), 'public.v2_artifact_upload_intents', 'quiesced_at', 'INSERT') as can_insert_quiesced_at,
+            has_table_privilege(pg_catalog.to_regrole('app_agent'), 'public.v2_artifact_upload_intents', 'UPDATE') as can_update_table`,
+  );
+  const row = result.rows[0];
+  if (row?.["can_insert_quiesced_at"] !== true) {
+    return ["app_agent must insert the bounded quiesced-at default on artifact upload intents."];
+  }
+  return row["can_update_table"] === false
+    ? []
+    : ["app_agent must not have table-wide update access to artifact upload intents."];
 }
 
 function validateFunctionAcl(


### PR DESCRIPTION
## Summary

- add the missing column-level `INSERT` grant for `v2_artifact_upload_intents.quiesced_at` to the single clean baseline
- assert that exact grant in production schema validation
- assert that the agent role still has no table-wide update access

## Why

Drizzle emits the nullable `quiesced_at` column as `DEFAULT` when reserving an artifact upload. PostgreSQL therefore requires column-level insert permission even though application code omits the field. Production logs showed this exact permission failure after the preceding ownership-query corrections.

## Production application

The grant and the one-row Drizzle baseline checksum were updated atomically under the database maintenance advisory lock. The production ledger still contains exactly one migration row.

## Verification

- production contract dry-run passes
- production `app_agent` can insert `quiesced_at`
- production `app_agent` still cannot update the table broadly
- `pnpm typecheck:scripts`
- `pnpm turbo lint`
- `pnpm --filter @cheatcode/db db:generate` reports no schema changes