### PR TITLE
fix(web): preview image deliverables

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -11,7 +11,12 @@ partial or corrupt transcript is never rendered as a duplicate assistant message
 
 Deliverable parts contain durable output identity and presentation metadata, never an expiring
 URL. A download click calls the authenticated gateway mint endpoint, validates its bounded response,
-and follows the resulting short-lived capability directly to the streaming response.
+and follows the resulting short-lived capability directly to the streaming response. Image
+deliverables lazily exchange that same capability for a bounded in-memory blob when they approach
+the viewport, render an inline thumbnail, and reuse the blob in an accessible full-size viewer.
+No image capability or object URL is persisted. Opening an image in Files switches to the project
+workspace and asks the trusted code-server bridge to reveal the exact generated asset; an already
+visible Files panel selects a newly generated image without waking a closed sandbox.
 
 Composer uploads always land in a writable project. If none is selected, choosing the first
 valid file creates and selects a general project named from that file. Files upload sequentially

--- a/apps/web/src/components/chat/message-deliverables.tsx
+++ b/apps/web/src/components/chat/message-deliverables.tsx
@@ -1,22 +1,36 @@
 "use client";
 
 import { useAuth } from "@clerk/nextjs";
-import { useState } from "react";
+import Image from "next/image";
+import { type RefObject, useEffect, useId, useRef, useState } from "react";
 import { toast } from "sonner";
 import { formatBytes } from "@/components/chat/message-deliverable-model";
 import type { ArtifactData } from "@/components/chat/message-parts.types";
 import {
   Code,
   Download,
+  Eye,
   FileSpreadsheet,
   FileText,
+  FolderOpen,
   Image as ImageIcon,
+  Loader2,
+  ModalShell,
   Presentation,
   Video,
+  X,
 } from "@/components/ui";
-import { createOutputDownloadUrl } from "@/lib/api/outputs";
+import { createOutputDownloadUrl, loadOutputImagePreview } from "@/lib/api/outputs";
+import { useAppStore } from "@/lib/store/app-store";
+import { cn } from "@/lib/ui/cn";
 
-export function DeliverablesBlock({ items }: { items: readonly ArtifactData[] }) {
+interface DeliverablesBlockProps {
+  items: readonly ArtifactData[];
+  threadId: string;
+}
+
+export function DeliverablesBlock({ items, threadId }: DeliverablesBlockProps) {
+  useAutoOpenLatestImage(items, threadId);
   return (
     <div
       className="cc-fade-in rounded-[14px] border border-thread-border bg-[var(--thread-code-bg)] p-3"
@@ -25,25 +39,303 @@ export function DeliverablesBlock({ items }: { items: readonly ArtifactData[] })
       <div className="mb-2 text-[10px] text-thread-text-muted uppercase tracking-[0.18em]">
         Deliverables
       </div>
-      <div className="space-y-1.5">
+      <div className="space-y-2">
         {items.map((item) => (
-          <DeliverableChip data={item} key={item.outputId} />
+          <DeliverableCard data={item} key={item.outputId} threadId={threadId} />
         ))}
       </div>
     </div>
   );
 }
 
-function DeliverableChip({ data }: { data: ArtifactData }) {
+function DeliverableCard({ data, threadId }: { data: ArtifactData; threadId: string }) {
   const { getToken } = useAuth();
-  const [isPreparing, setIsPreparing] = useState(false);
+  const download = useDeliverableDownload(data, getToken);
+  if (isImageArtifact(data)) {
+    return (
+      <ImageDeliverableCard
+        data={data}
+        download={download}
+        getToken={getToken}
+        threadId={threadId}
+      />
+    );
+  }
+  return <FileDeliverableCard data={data} download={download} />;
+}
+
+function FileDeliverableCard({
+  data,
+  download,
+}: {
+  data: ArtifactData;
+  download: DeliverableDownload;
+}) {
   const Icon = deliverableIcon(data.kind, data.mimeType);
-  const label = data.filename;
-  const meta = `${data.kind} · ${formatBytes(data.sizeBytes)}`;
-  const download = async (): Promise<void> => {
-    if (isPreparing) {
-      return;
-    }
+  return (
+    <div className="flex items-center gap-2.5 rounded-[10px] border border-border bg-background px-2.5 py-2">
+      <Icon aria-hidden="true" className="h-4 w-4 shrink-0 text-fg-secondary" />
+      <DeliverableMetadata data={data} />
+      <DownloadButton download={download} filename={data.filename} />
+    </div>
+  );
+}
+
+function ImageDeliverableCard({
+  data,
+  download,
+  getToken,
+  threadId,
+}: {
+  data: ArtifactData;
+  download: DeliverableDownload;
+  getToken: () => Promise<null | string>;
+  threadId: string;
+}) {
+  const [isViewerOpen, setViewerOpen] = useState(false);
+  const preview = useLazyImagePreview(data, getToken);
+  const openInFiles = useOpenImageInFiles(data, threadId, () => setViewerOpen(false));
+  return (
+    <div className="overflow-hidden rounded-[12px] border border-border bg-background">
+      <ImageThumbnail data={data} onOpen={() => setViewerOpen(true)} preview={preview} />
+      <div className="flex flex-wrap items-center gap-2 px-2.5 py-2.5">
+        <ImageIcon aria-hidden="true" className="h-4 w-4 shrink-0 text-fg-secondary" />
+        <DeliverableMetadata data={data} />
+        <button
+          className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full px-2 text-[12px] text-fg-secondary transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={openInFiles}
+          type="button"
+        >
+          <FolderOpen aria-hidden="true" className="h-3.5 w-3.5" />
+          Open in Files
+        </button>
+        <DownloadButton download={download} filename={data.filename} />
+      </div>
+      <ImageViewer
+        data={data}
+        download={download}
+        onClose={() => setViewerOpen(false)}
+        onOpenInFiles={openInFiles}
+        open={isViewerOpen}
+        previewUrl={preview.url}
+      />
+    </div>
+  );
+}
+
+interface ImagePreview {
+  hostRef: RefObject<HTMLDivElement | null>;
+  message: string | null;
+  status: "error" | "idle" | "loading" | "ready";
+  url: string | null;
+}
+
+function ImageThumbnail({
+  data,
+  onOpen,
+  preview,
+}: {
+  data: ArtifactData;
+  onOpen: () => void;
+  preview: ImagePreview;
+}) {
+  return (
+    <div
+      className="relative aspect-[4/3] w-full overflow-hidden bg-secondary"
+      ref={preview.hostRef}
+    >
+      {preview.url ? (
+        <button
+          aria-label={`View ${data.filename}`}
+          className="group relative h-full w-full cursor-zoom-in focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+          onClick={onOpen}
+          type="button"
+        >
+          <Image
+            alt=""
+            className="object-contain transition-transform duration-200 ease-out group-hover:scale-[1.01] motion-reduce:transition-none"
+            fill
+            sizes="(max-width: 767px) 100vw, 520px"
+            src={preview.url}
+            unoptimized
+          />
+          <span className="absolute right-2 bottom-2 inline-flex h-8 items-center gap-1.5 rounded-full bg-black/70 px-2.5 font-medium text-[11px] text-white backdrop-blur-sm">
+            <Eye aria-hidden="true" className="h-3.5 w-3.5" />
+            View
+          </span>
+        </button>
+      ) : (
+        <ImagePreviewPlaceholder message={preview.message} status={preview.status} />
+      )}
+    </div>
+  );
+}
+
+function ImagePreviewPlaceholder({ message, status }: Pick<ImagePreview, "message" | "status">) {
+  const isLoading = status === "idle" || status === "loading";
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "flex h-full w-full flex-col items-center justify-center gap-2 p-5 text-center text-[12px] text-fg-secondary",
+        isLoading && "motion-safe:animate-pulse",
+      )}
+    >
+      {isLoading ? (
+        <Loader2 aria-hidden="true" className="h-5 w-5 animate-spin motion-reduce:animate-none" />
+      ) : (
+        <ImageIcon aria-hidden="true" className="h-5 w-5" />
+      )}
+      <span>{isLoading ? "Preparing preview…" : (message ?? "Preview unavailable")}</span>
+    </div>
+  );
+}
+
+function ImageViewer({
+  data,
+  download,
+  onClose,
+  onOpenInFiles,
+  open,
+  previewUrl,
+}: {
+  data: ArtifactData;
+  download: DeliverableDownload;
+  onClose: () => void;
+  onOpenInFiles: () => void;
+  open: boolean;
+  previewUrl: string | null;
+}) {
+  const titleId = useId();
+  return (
+    <ModalShell
+      className="h-[min(92dvh,960px)] max-w-[min(96vw,1280px)] overflow-hidden rounded-[18px]"
+      labelledBy={titleId}
+      onClose={onClose}
+      open={open}
+    >
+      <div className="flex h-full min-h-0 flex-col bg-background">
+        <ImageViewerHeader
+          data={data}
+          download={download}
+          onClose={onClose}
+          onOpenInFiles={onOpenInFiles}
+          titleId={titleId}
+        />
+        <div className="relative min-h-0 flex-1 bg-secondary/60">
+          {previewUrl ? (
+            <Image
+              alt={imageAlt(data.filename)}
+              className="object-contain"
+              fill
+              sizes="96vw"
+              src={previewUrl}
+              unoptimized
+            />
+          ) : null}
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+function ImageViewerHeader({
+  data,
+  download,
+  onClose,
+  onOpenInFiles,
+  titleId,
+}: {
+  data: ArtifactData;
+  download: DeliverableDownload;
+  onClose: () => void;
+  onOpenInFiles: () => void;
+  titleId: string;
+}) {
+  return (
+    <div className="flex min-h-14 items-center gap-2 border-border border-b px-3 sm:px-4">
+      <h2 className="min-w-0 flex-1 truncate font-medium text-[13px]" id={titleId}>
+        {data.filename}
+      </h2>
+      <button
+        className="inline-flex h-9 shrink-0 items-center gap-1.5 rounded-full px-2.5 text-[12px] text-fg-secondary hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={onOpenInFiles}
+        type="button"
+      >
+        <FolderOpen aria-hidden="true" className="h-4 w-4" />
+        <span className="hidden sm:inline">Open in Files</span>
+      </button>
+      <DownloadButton download={download} filename={data.filename} prominent />
+      <button
+        aria-label="Close image viewer"
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-fg-secondary hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={onClose}
+        type="button"
+      >
+        <X aria-hidden="true" className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+interface DeliverableDownload {
+  isPreparing: boolean;
+  start: () => Promise<void>;
+}
+
+function DownloadButton({
+  download,
+  filename,
+  prominent = false,
+}: {
+  download: DeliverableDownload;
+  filename: string;
+  prominent?: boolean;
+}) {
+  return (
+    <button
+      aria-busy={download.isPreparing || undefined}
+      aria-label={download.isPreparing ? `Preparing ${filename}` : `Download ${filename}`}
+      className={cn(
+        "inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full px-2 text-[12px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-wait disabled:opacity-60",
+        prominent
+          ? "bg-foreground px-3 text-background hover:opacity-85"
+          : "text-fg-secondary hover:bg-secondary hover:text-foreground",
+      )}
+      disabled={download.isPreparing}
+      onClick={() => void download.start()}
+      type="button"
+    >
+      {download.isPreparing ? (
+        <Loader2 aria-hidden="true" className="h-3.5 w-3.5 animate-spin" />
+      ) : (
+        <Download aria-hidden="true" className="h-3.5 w-3.5" />
+      )}
+      <span className={cn(prominent && "hidden sm:inline")}>
+        {download.isPreparing ? "preparing…" : "download"}
+      </span>
+    </button>
+  );
+}
+
+function DeliverableMetadata({ data }: { data: ArtifactData }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="truncate text-[13px] text-foreground">{data.filename}</div>
+      <div className="text-[11px] text-placeholder">
+        {data.kind} · {formatBytes(data.sizeBytes)}
+      </div>
+    </div>
+  );
+}
+
+function useDeliverableDownload(
+  data: ArtifactData,
+  getToken: () => Promise<null | string>,
+): DeliverableDownload {
+  const [isPreparing, setIsPreparing] = useState(false);
+  const start = async (): Promise<void> => {
+    if (isPreparing) return;
     setIsPreparing(true);
     try {
       const capability = await createOutputDownloadUrl(getToken, data.outputId);
@@ -54,25 +346,115 @@ function DeliverableChip({ data }: { data: ArtifactData }) {
       setIsPreparing(false);
     }
   };
-  return (
-    <div className="flex items-center gap-2.5 rounded-[10px] border border-border bg-background px-2.5 py-2">
-      <Icon aria-hidden="true" className="h-4 w-4 shrink-0 text-fg-secondary" />
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-[13px] text-foreground">{label}</div>
-        <div className="text-[11px] text-placeholder">{meta}</div>
-      </div>
-      <button
-        aria-label={isPreparing ? `Preparing ${label}` : `Download ${label}`}
-        className="inline-flex shrink-0 items-center gap-1.5 text-[12px] text-fg-secondary transition-colors hover:text-foreground disabled:cursor-wait disabled:opacity-60"
-        disabled={isPreparing}
-        onClick={() => void download()}
-        type="button"
-      >
-        <Download aria-hidden="true" className="h-3.5 w-3.5" />
-        {isPreparing ? "preparing…" : "download"}
-      </button>
-    </div>
-  );
+  return { isPreparing, start };
+}
+
+function useLazyImagePreview(
+  data: ArtifactData,
+  getToken: () => Promise<null | string>,
+): ImagePreview {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const isNearViewport = useNearViewport(hostRef);
+  const [preview, setPreview] = useState<Omit<ImagePreview, "hostRef">>({
+    message: null,
+    status: "idle",
+    url: null,
+  });
+  useEffect(() => {
+    if (!isNearViewport) return;
+    const controller = new AbortController();
+    let objectUrl: string | null = null;
+    setPreview({ message: null, status: "loading", url: null });
+    void loadOutputImagePreview(getToken, data.outputId, data.sizeBytes, controller.signal)
+      .then((blob) => {
+        objectUrl = URL.createObjectURL(blob);
+        setPreview({ message: null, status: "ready", url: objectUrl });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setPreview({
+          message: error instanceof Error ? error.message : "Preview unavailable",
+          status: "error",
+          url: null,
+        });
+      });
+    return () => {
+      controller.abort();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [data.outputId, data.sizeBytes, getToken, isNearViewport]);
+  return { ...preview, hostRef };
+}
+
+function useNearViewport(ref: RefObject<HTMLElement | null>): boolean {
+  const [isNear, setNear] = useState(false);
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || typeof IntersectionObserver === "undefined") {
+      setNear(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+        setNear(true);
+        observer.disconnect();
+      },
+      { rootMargin: "320px" },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+  return isNear;
+}
+
+function useOpenImageInFiles(data: ArtifactData, threadId: string, afterOpen: () => void) {
+  const requestFileOpen = useAppStore((state) => state.requestFileOpen);
+  const setActivePreviewTab = useAppStore((state) => state.setActivePreviewTab);
+  const setPreviewPanelOpen = useAppStore((state) => state.setPreviewPanelOpen);
+  return () => {
+    const path = imageWorkspacePath(data);
+    if (!path) {
+      toast.error("This image does not have a safe workspace path.");
+      return;
+    }
+    requestFileOpen(threadId, path);
+    setActivePreviewTab("files");
+    setPreviewPanelOpen(true);
+    afterOpen();
+  };
+}
+
+function useAutoOpenLatestImage(items: readonly ArtifactData[], threadId: string): void {
+  const activePreviewTab = useAppStore((state) => state.activePreviewTab);
+  const previewPanelOpen = useAppStore((state) => state.previewPanelOpen);
+  const requestFileOpen = useAppStore((state) => state.requestFileOpen);
+  const latestImage = items.findLast(isImageArtifact);
+  const latestImagePath = latestImage ? imageWorkspacePath(latestImage) : null;
+  useEffect(() => {
+    if (!previewPanelOpen || activePreviewTab !== "files" || !latestImagePath) return;
+    requestFileOpen(threadId, latestImagePath);
+  }, [activePreviewTab, latestImagePath, previewPanelOpen, requestFileOpen, threadId]);
+}
+
+function imageWorkspacePath(data: ArtifactData): string | null {
+  if (!isImageArtifact(data) || /[/\\]/u.test(data.filename) || data.filename.includes("..")) {
+    return null;
+  }
+  return `.cheatcode/assets/images/${data.filename}`;
+}
+
+function imageAlt(filename: string): string {
+  const readable = filename
+    .replace(/\.[^.]+$/u, "")
+    .replace(/[-_]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return readable ? `Generated image: ${readable}` : "Generated image";
+}
+
+function isImageArtifact(data: ArtifactData): boolean {
+  return data.kind === "image" || data.mimeType.startsWith("image/");
 }
 
 function deliverableIcon(kind: ArtifactData["kind"], mimeType: string) {

--- a/apps/web/src/components/chat/message-parts.tsx
+++ b/apps/web/src/components/chat/message-parts.tsx
@@ -64,7 +64,9 @@ export function MessageParts({
           />
         ),
       )}
-      {deliverables.length > 0 ? <DeliverablesBlock items={deliverables} /> : null}
+      {deliverables.length > 0 ? (
+        <DeliverablesBlock items={deliverables} threadId={threadId} />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/preview/sandbox-ide-tab.tsx
+++ b/apps/web/src/components/preview/sandbox-ide-tab.tsx
@@ -13,6 +13,7 @@ import { CheatcodeLoader } from "@/components/ui/cheatcode-loader";
 import { CheatcodeTooltip } from "@/components/ui/cheatcode-tooltip";
 import { RecoveryCard } from "@/components/ui/recovery-card";
 import { openComputerIde, openSandboxIde } from "@/lib/api/sandbox";
+import { type FilesOpenRequest, useAppStore } from "@/lib/store/app-store";
 import { cn } from "@/lib/ui/cn";
 
 const PREVIEW_SESSION_REFRESH_MS = 8 * 60 * 1000;
@@ -206,6 +207,8 @@ function SandboxIdeFrame({
 
 function useCodeServerBridge(iframeUrl: string | null, threadId: string | null) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const clearFilesOpenRequest = useAppStore((state) => state.clearFilesOpenRequest);
+  const filesOpenRequest = useAppStore((state) => state.filesOpenRequest);
   const [readyIframeUrl, setReadyIframeUrl] = useState<string | null>(null);
   const [timedOutIframeUrl, setTimedOutIframeUrl] = useState<string | null>(null);
   const [sidebarVisible, setSidebarVisible] = useState(true);
@@ -216,6 +219,7 @@ function useCodeServerBridge(iframeUrl: string | null, threadId: string | null) 
         iframeOrigin,
         iframeUrl,
         iframeRef,
+        clearFilesOpenRequest,
         setReadyIframeUrl,
         setSidebarVisible,
         setTimedOutIframeUrl,
@@ -224,7 +228,7 @@ function useCodeServerBridge(iframeUrl: string | null, threadId: string | null) 
     };
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [iframeOrigin, iframeUrl, threadId]);
+  }, [clearFilesOpenRequest, iframeOrigin, iframeUrl, threadId]);
   const isReady = iframeUrl !== null && readyIframeUrl === iframeUrl;
   const requestReadyState = () => requestCodeServerState(iframeOrigin, iframeRef);
   useCodeServerHandshake({
@@ -234,6 +238,7 @@ function useCodeServerBridge(iframeUrl: string | null, threadId: string | null) 
     isReady,
     setTimedOutIframeUrl,
   });
+  useRequestedFileOpen({ filesOpenRequest, iframeOrigin, iframeRef, isReady, threadId });
   const toggleSidebar = () => {
     if (!iframeOrigin) return;
     iframeRef.current?.contentWindow?.postMessage(
@@ -249,6 +254,27 @@ function useCodeServerBridge(iframeUrl: string | null, threadId: string | null) 
     sidebarVisible,
     toggleSidebar,
   };
+}
+
+function useRequestedFileOpen(input: {
+  filesOpenRequest: FilesOpenRequest | null;
+  iframeOrigin: string | null;
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+  isReady: boolean;
+  threadId: string | null;
+}): void {
+  const { filesOpenRequest, iframeOrigin, iframeRef, isReady, threadId } = input;
+  useEffect(() => {
+    if (!isReady || !iframeOrigin || filesOpenRequest?.threadId !== threadId) return;
+    iframeRef.current?.contentWindow?.postMessage(
+      {
+        path: filesOpenRequest.path,
+        requestId: filesOpenRequest.requestId,
+        type: "CHEATCODE_OPEN_FILE",
+      },
+      iframeOrigin,
+    );
+  }, [filesOpenRequest, iframeOrigin, iframeRef, isReady, threadId]);
 }
 
 function useCodeServerHandshake(input: {
@@ -292,6 +318,7 @@ function requestCodeServerState(
 function handleCodeServerMessage(
   event: MessageEvent,
   input: {
+    clearFilesOpenRequest: (requestId: string) => void;
     iframeOrigin: string | null;
     iframeUrl: string | null;
     iframeRef: RefObject<HTMLIFrameElement | null>;
@@ -305,6 +332,9 @@ function handleCodeServerMessage(
   if (!iframeOrigin || !isTrustedCodeServerMessage(event, iframeOrigin, input.iframeRef)) return;
   if (event.data.type === "CHEATCODE_SIDEBAR_STATE") {
     input.setSidebarVisible(event.data.visible === true);
+  }
+  if (event.data.type === "CHEATCODE_FILE_OPENED") {
+    input.clearFilesOpenRequest(event.data.requestId);
   }
   if (event.data.type === "CHEATCODE_CODE_SERVER_READY") {
     input.setReadyIframeUrl(input.iframeUrl);
@@ -332,6 +362,7 @@ function isTrustedCodeServerMessage(
 
 type CodeServerMessage =
   | { readonly type: "CHEATCODE_CODE_SERVER_READY" }
+  | { readonly requestId: string; readonly type: "CHEATCODE_FILE_OPENED" }
   | { readonly type: "CHEATCODE_SIDEBAR_STATE"; readonly visible: boolean };
 
 function isCodeServerMessage(value: unknown): value is CodeServerMessage {
@@ -340,6 +371,9 @@ function isCodeServerMessage(value: unknown): value is CodeServerMessage {
   }
   if (value.type === "CHEATCODE_CODE_SERVER_READY") {
     return true;
+  }
+  if (value.type === "CHEATCODE_FILE_OPENED") {
+    return "requestId" in value && typeof value.requestId === "string";
   }
   return (
     value.type === "CHEATCODE_SIDEBAR_STATE" &&

--- a/apps/web/src/lib/api/outputs.ts
+++ b/apps/web/src/lib/api/outputs.ts
@@ -8,8 +8,11 @@ import {
 import {
   API_RESPONSE_LIMIT_BYTES,
   authorizedFetch,
+  readBoundedBlobResponse,
   readBoundedJsonResponse,
 } from "@/lib/api/authorized-fetch";
+
+const OUTPUT_IMAGE_PREVIEW_MAX_BYTES = 20 * 1024 * 1024;
 
 export async function createOutputDownloadUrl(
   getToken: () => Promise<null | string>,
@@ -25,4 +28,28 @@ export async function createOutputDownloadUrl(
   return OutputDownloadUrlResponseSchema.parse(
     await readBoundedJsonResponse(response, API_RESPONSE_LIMIT_BYTES.metadata),
   );
+}
+
+export async function loadOutputImagePreview(
+  getToken: () => Promise<null | string>,
+  outputId: string,
+  sizeBytes: number,
+  signal: AbortSignal,
+): Promise<Blob> {
+  if (sizeBytes <= 0 || sizeBytes > OUTPUT_IMAGE_PREVIEW_MAX_BYTES) {
+    throw new Error("This image is too large to preview here. Download it to view the original.");
+  }
+  const capability = await createOutputDownloadUrl(getToken, outputId, signal);
+  const response = await fetch(capability.downloadUrl, {
+    referrerPolicy: "no-referrer",
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Image preview returned HTTP ${response.status}`);
+  }
+  const blob = await readBoundedBlobResponse(response, sizeBytes);
+  if (blob.size === 0 || !blob.type.startsWith("image/")) {
+    throw new Error("The generated output is not a displayable image.");
+  }
+  return blob;
 }

--- a/apps/web/src/lib/store/app-store.ts
+++ b/apps/web/src/lib/store/app-store.ts
@@ -21,6 +21,12 @@ interface StreamReconnect {
   fromSeq: number;
 }
 
+export interface FilesOpenRequest {
+  path: string;
+  requestId: string;
+  threadId: string;
+}
+
 const PREVIEW_PATH_HISTORY_MAX = 50;
 
 interface AppStoreState {
@@ -35,6 +41,7 @@ interface AppStoreState {
   consoleTruncated: boolean;
   draftByThread: Record<string, string>;
   expoUrl: string | null;
+  filesOpenRequest: FilesOpenRequest | null;
   previewDevice: PreviewDevice;
   previewPanelOpen: boolean;
   previewPath: string;
@@ -56,11 +63,13 @@ interface AppStoreActions {
   ) => void;
   bumpPreviewReloadToken: () => void;
   clearDraft: (threadId: string) => void;
+  clearFilesOpenRequest: (requestId: string) => void;
   goBackPreviewPath: () => void;
   navigatePreviewPath: (path: string) => void;
   resetConsole: () => void;
   resetIdentityState: () => void;
   resetPreviewNavigation: () => void;
+  requestFileOpen: (threadId: string, path: string) => void;
   setActivePreviewTab: (tab: PreviewTab) => void;
   setAgentModelId: (modelId: AgentModelId) => void;
   setAppPreviewStatus: (status: AppPreviewState) => void;
@@ -126,6 +135,7 @@ function initialAppStoreState(): AppStoreState {
     consoleTruncated: false,
     draftByThread: {},
     expoUrl: null,
+    filesOpenRequest: null,
     previewDevice: "desktop",
     previewPanelOpen: false,
     previewPath: "/",
@@ -186,6 +196,18 @@ function createPreviewActions(set: AppStoreSet) {
     goBackPreviewPath: () => set(goBackPreviewPath),
     navigatePreviewPath: (path: string) => set((state) => navigatePreviewPath(state, path)),
     resetPreviewNavigation: () => set({ previewPath: "/", previewPathHistory: [] }),
+    clearFilesOpenRequest: (requestId: string) =>
+      set((state) =>
+        state.filesOpenRequest?.requestId === requestId ? { filesOpenRequest: null } : {},
+      ),
+    requestFileOpen: (threadId: string, path: string) =>
+      set({
+        filesOpenRequest: {
+          path,
+          requestId: crypto.randomUUID(),
+          threadId,
+        },
+      }),
     setActivePreviewTab: (activePreviewTab: PreviewTab) => set({ activePreviewTab }),
     setAppPreviewStatus: (appPreviewStatus: AppPreviewState) => set({ appPreviewStatus }),
     setExpoUrl: (expoUrl: string | null) => set({ expoUrl }),
@@ -267,6 +289,7 @@ function identityScopedInitialState(): Pick<
   | "draftByThread"
   | "appPreviewStatus"
   | "expoUrl"
+  | "filesOpenRequest"
   | "previewPanelOpen"
   | "previewPath"
   | "previewPathHistory"
@@ -285,6 +308,7 @@ function identityScopedInitialState(): Pick<
     consoleTruncated: false,
     draftByThread: {},
     expoUrl: null,
+    filesOpenRequest: null,
     previewPanelOpen: false,
     previewPath: "/",
     previewPathHistory: [],

--- a/packages/preview-bridge/README.md
+++ b/packages/preview-bridge/README.md
@@ -3,7 +3,9 @@
 Shared code-server parent-frame integration used by both the production preview
 proxy and the local agent-worker preview path. The proxy supplies an exact,
 trusted application origin and injects the bridge only into bounded,
-signature-checked code-server workbench HTML.
+signature-checked code-server workbench HTML. The bridge reports readiness and sidebar state,
+accepts bounded relative workspace-file reveal requests from that exact parent origin, expands the
+corresponding Explorer path, opens the file, and acknowledges the request back to the parent.
 
 ## Public exports
 

--- a/packages/preview-bridge/src/index.ts
+++ b/packages/preview-bridge/src/index.ts
@@ -233,6 +233,67 @@ break;
 }catch(_err){}
 }
 
+var activeFileOpenRequest=null;
+function requestedFileParts(rawPath){
+if(typeof rawPath!=="string"||rawPath.length<1||rawPath.length>1000||rawPath.charAt(0)==="/"||rawPath.indexOf("\\")!==-1)return null;
+var parts=rawPath.split("/");
+for(var i=0;i<parts.length;i++){
+if(!parts[i]||parts[i]==="."||parts[i]==="..")return null;
+}
+return parts;
+}
+
+function treeItemName(row){
+var label=row&&row.querySelector(".label-name");
+return ((label&&label.textContent)||"").trim();
+}
+
+function treeItemLevel(row){
+var value=row&&row.getAttribute("aria-level");
+return value&&/^\d+$/.test(value)?Number(value):null;
+}
+
+function findVisibleTreeItem(name,expectedLevel){
+var rows=document.querySelectorAll(".part.sidebar [role='treeitem']");
+for(var i=0;i<rows.length;i++){
+if(!visible(rows[i])||treeItemName(rows[i])!==name)continue;
+var level=treeItemLevel(rows[i]);
+if(expectedLevel===null||level===null||level===expectedLevel)return rows[i];
+}
+return null;
+}
+
+function reportFileOpened(requestId){
+try{window.parent.postMessage({requestId:requestId,type:"CHEATCODE_FILE_OPENED"},cheatcodeParentOrigin)}catch(_err){}
+}
+
+function openRequestedFileStep(parts,index,expectedLevel,requestId,attempt){
+if(!activeFileOpenRequest||activeFileOpenRequest.requestId!==requestId||attempt>80)return;
+var row=findVisibleTreeItem(parts[index],expectedLevel);
+if(!row){setTimeout(function(){openRequestedFileStep(parts,index,expectedLevel,requestId,attempt+1)},100);return;}
+var level=treeItemLevel(row);
+if(index<parts.length-1){
+if(row.getAttribute("aria-expanded")!=="true"){
+var twistie=row.querySelector(".monaco-tl-twistie")||row;
+dispatchClick(twistie);
+}
+setTimeout(function(){openRequestedFileStep(parts,index+1,level===null?null:level+1,requestId,attempt+1)},120);
+return;
+}
+var target=row.querySelector(".label-name,.monaco-icon-label,.monaco-tl-contents")||row;
+dispatchClick(target);
+setTimeout(function(){dispatchClick(target);reportFileOpened(requestId)},250);
+activeFileOpenRequest=null;
+}
+
+function openWorkspaceFile(path,requestId){
+var parts=requestedFileParts(path);
+if(!parts||typeof requestId!=="string"||requestId.length<1||requestId.length>100)return;
+activeFileOpenRequest={requestId:requestId};
+applySidebarState(false);
+openRequestedFileStep(parts,0,null,requestId,0);
+}
+
 function closeAllEditors(){
 var tabs=document.querySelectorAll(".tab");
 if(!tabs.length)return true;
@@ -340,6 +401,7 @@ var requestedSidebar=document.querySelector(".part.sidebar");
 if(requestedSidebar)reportSidebarState(requestedSidebar);
 }
 if(message.type==="CHEATCODE_CLOSE_ALL_EDITORS")closeAllEditors();
+if(message.type==="CHEATCODE_OPEN_FILE")openWorkspaceFile(message.path,message.requestId);
 if(message.type==="CHEATCODE_RESET_WORKSPACE_VIEW"){workspaceResetRequested=true;resetWorkspaceView();}
 if(message.type==="CHEATCODE_TOGGLE_SIDEBAR")toggleSidebar();
 if(message.type==="CHEATCODE_SET_SIDEBAR_COLLAPSED")applySidebarState(message.collapsed===true);


### PR DESCRIPTION
## Summary
- Render generated image outputs directly in the deliverables card and an accessible full-size viewer.
- Keep preview fetches lazy, signed, bounded to 20 MiB, and isolated from sandbox startup.
- Open generated images directly in the Files editor instead of selecting their parent directory.

## Architecture
The web app exchanges the existing short-lived download capability for an authenticated image blob. Object URLs stay browser-local and are revoked on cleanup. File-open requests are transient UI state sent to the trusted Code Server frame and acknowledged by the injected preview bridge.

## Decisions
| Decision | Choice | Reasoning |
|---|---|---|
| Preview transport | Existing signed output URL | Preserves the R2 boundary and does not expose credentials |
| Loading | Intersection-observer lazy loading | Avoids fetching off-screen images or waking the sandbox |
| Files handoff | Exact relative workspace path with frame acknowledgement | Opens the file users selected and rejects traversal paths |
| Viewer | Existing modal primitive | Preserves focus, Escape handling, and screen-reader semantics |

## Edge cases
- Images over 20 MiB remain downloadable but are not loaded inline.
- Empty or non-image responses show a recoverable preview error.
- Unsafe filenames cannot be sent to the sandbox editor.
- Requests are scoped to the active thread and exact trusted iframe origin.

## Checks
- [x] `pnpm turbo typecheck`
- [x] `pnpm turbo lint`
- [x] `pnpm turbo build`
- [ ] Production image deliverable QA after deployment