### PR TITLE
fix(preview): resolve compact explorer paths

### DIFF
--- a/packages/preview-bridge/src/index.ts
+++ b/packages/preview-bridge/src/index.ts
@@ -258,6 +258,8 @@ return parts;
 }
 
 function treeItemName(row){
+var ariaLabel=row&&row.getAttribute("aria-label");
+if(ariaLabel)return ariaLabel.split(", compact,")[0].trim();
 var label=row&&row.querySelector(".label-name");
 return ((label&&label.textContent)||"").trim();
 }


### PR DESCRIPTION
## What changed

- resolve code-server compact-folder segments from their accessible labels
- preserve exact level matching while expanding nested workspace paths

## Why

The Files explorer compacts `.cheatcode/assets/images` into one visual row. The bridge previously read the first descendant label, so a fully collapsed generated-image path could not reach the final file.

## Verification

- `pnpm turbo typecheck lint build`
- production DOM reproduction from a fully collapsed `.cheatcode/assets/images` tree matched all four levels and opened the 1024×1024 image editor
- final product-level production verification will run after deployment