### PR TITLE
fix(preview): version Files bridge URLs

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -199,7 +199,8 @@ enumerate the project first, so dependency trees and large generated projects ar
 start critical path. After an idle stop, a current tracked code-server session is relaunched from its
 durable command instead of repeating installation and cleanup probes. A project with no tracked
 app-preview record returns the terminal `none` state without starting Daytona or entering the
-preview wake polling loop.
+preview wake polling loop. Files URLs include the Worker release SHA so code-server's service worker
+cannot reuse a workbench document containing an older injected parent bridge after a deployment.
 
 AgentRun does not count, persist, bill, or emit model-token or model-cost data,
 and it does not apply per-run or daily dollar caps. Provider usage remains an

--- a/apps/agent-worker/src/durable-objects/project-sandbox-code-server.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-code-server.ts
@@ -10,9 +10,11 @@ export const CODE_SERVER_START_TIMEOUT_MS = 120_000;
 export function codeServerFolderUrl(
   rawUrl: string,
   folderPath: string,
+  bridgeRelease: string,
   initialFilePath?: string,
 ): string {
   const url = new URL(rawUrl);
+  url.searchParams.set("cc_bridge", bridgeRelease);
   url.searchParams.set("folder", folderPath);
   if (initialFilePath) {
     url.searchParams.set("cc_open_file", initialFilePath);

--- a/apps/agent-worker/src/durable-objects/project-sandbox-content.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-content.ts
@@ -117,6 +117,7 @@ type ContentRuntime = Pick<
   | "ensureSandbox"
   | "previewHostname"
   | "previewSecret"
+  | "releaseSha"
   | "toUpstreamError"
 >;
 
@@ -429,10 +430,11 @@ async function exposeCodeServer(
     secret: await context.runtime.previewSecret(),
     useSubdomain: true,
   });
+  const bridgeRelease = context.runtime.releaseSha();
   return {
     expiresAt: built.expiresAt,
     port: CODE_SERVER_PORT,
-    url: codeServerFolderUrl(built.url, displayFolder, parsed.initialFilePath),
+    url: codeServerFolderUrl(built.url, displayFolder, bridgeRelease, parsed.initialFilePath),
     workspacePath: parsed.workspacePath,
   };
 }

--- a/apps/agent-worker/src/durable-objects/project-sandbox-runtime-handle.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-runtime-handle.ts
@@ -94,6 +94,7 @@ export interface SandboxRuntime {
   readonly ownerUserId: () => string;
   readonly previewHostname: () => string;
   readonly previewSecret: () => Promise<string>;
+  readonly releaseSha: () => string;
   readonly registerOwner: (userId: string, sandboxName?: string) => Promise<void>;
   readonly restartSandboxForWorkspaceRecovery: (sandboxId: string) => Promise<void>;
   readonly sandboxName: () => string;
@@ -162,6 +163,7 @@ function runtimeHandle(state: RuntimeState): SandboxRuntime {
     previewHostname: () =>
       previewHostnameForWorker(state.env.CHEATCODE_ENVIRONMENT, state.env.PREVIEW_HOSTNAME),
     previewSecret: () => previewSecret(state),
+    releaseSha: () => state.env.CHEATCODE_RELEASE_SHA ?? "development",
     registerOwner: (userId, sandboxName) => state.identity.registerOwner(userId, sandboxName),
     restartSandboxForWorkspaceRecovery: (sandboxId) =>
       restartSandboxForWorkspaceRecovery(state, sandboxId),


### PR DESCRIPTION
## What changed

- add the deployed Worker release SHA to every code-server Files URL
- expose the validated release identity through the sandbox runtime
- document why the release-specific cache key is required

## Why

The preview proxy already marks workbench HTML `private, no-store`, but code-server's registered service worker can retain an older workbench document. That leaves an old injected parent bridge active after a Worker deployment. A release-specific URL guarantees the current bridge is loaded without disabling code-server's useful static caching.

## Verification

- `pnpm turbo typecheck lint build` (55/55 tasks)
- production iframe reproduced the stale bridge while a cache-busted production workbench loaded the current bridge
- final product-level production verification will run after deployment