### PR TITLE
fix(agent): allow research structured output

### DIFF
--- a/packages/agent-core/src/mastra/workflows/deep-research-workflow.ts
+++ b/packages/agent-core/src/mastra/workflows/deep-research-workflow.ts
@@ -141,10 +141,10 @@ function createQueryStep(id: string, config: ResearchWorkflowPrompts) {
         abortSignal,
       );
       const response = await agent.generate(researchPassPrompt(config, inputData.query, evidence), {
+        activeTools: [],
         abortSignal,
         requestContext: research.requestContext,
         structuredOutput: { schema: ResearchPassDraftSchema },
-        toolChoice: "none",
       });
       return validateResearchPass(
         parseResearchPassDraft(response.object),
@@ -165,10 +165,10 @@ function createSynthesisStep(id: string, config: ResearchWorkflowPrompts) {
       const agent = mastra.getAgent("general");
       const sources = mergeResearchSources(inputData);
       const response = await agent.generate(config.synthesisPrompt(inputData), {
+        activeTools: [],
         abortSignal,
         requestContext,
         structuredOutput: { schema: ResearchSynthesisDraftSchema },
-        toolChoice: "none",
       });
       const draft = parseResearchSynthesisDraft(response.object);
       return ResearchReportSchema.parse({


### PR DESCRIPTION
## Why

Production acceptance on the bounded research workflow exposed a second, distinct failure. Both Exa and Firecrawl credentials were present and the provider evidence calls completed, but concurrent Claude Sonnet 5 research passes returned `{}` and failed `ResearchPassDraftSchema` validation.

The live Worker trace showed `STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED` for missing `claims` and `summary`. `toolChoice: "none"` disabled not only Cheatcode's agent tools but also the Anthropic/AI SDK internal structured-output mechanism.

## What changed

- expose an empty `activeTools` set to each research/synthesis pass
- stop forcing `toolChoice: "none"`, allowing the provider's schema-output channel to operate

This remains a tool-free nested agent pass: no Cheatcode tool can be called. Only the model provider's internal structured-output transport remains available.

## Architecture and migration effects

- no database, environment, dependency, or migration changes
- no change to provider evidence collection, citation validation, PDF packaging, or persistence

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`

Production diagnosis evidence:

- exact deployed parent SHA: `4b2d3f311522794725681114c1aade155317aa05`
- natural-language and explicit single-call reproductions
- both provider keys reported configured
- no Cloudflare subrequest exhaustion or workflow retry storm
- exact error: `STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED`, value `{}`

Production acceptance will be repeated against the exact merged SHA after deployment.
