### PR TITLE
fix(agent): bound research output size

### DIFF
--- a/packages/agent-core/src/mastra/workflows/deep-research-workflow.ts
+++ b/packages/agent-core/src/mastra/workflows/deep-research-workflow.ts
@@ -168,9 +168,10 @@ function createSynthesisStep(id: string, config: ResearchWorkflowPrompts) {
     execute: async ({ abortSignal, inputData, mastra, requestContext }) => {
       const agent = mastra.getAgent("general");
       const sources = mergeResearchSources(inputData);
-      const response = await agent.generate(config.synthesisPrompt(inputData), {
+      const response = await agent.generate(researchSynthesisPrompt(config, inputData), {
         activeTools: [],
         abortSignal,
+        modelSettings: { maxOutputTokens: 8_192 },
         providerOptions: RESEARCH_PROVIDER_OPTIONS,
         requestContext,
         structuredOutput: { schema: ResearchSynthesisDraftSchema },
@@ -289,9 +290,21 @@ function researchPassPrompt(
     config.queryPrompt(query),
     "Use only the provider evidence below. For Exa citations, copy providerResultId and URL exactly. For Firecrawl citations, copy the URL exactly.",
     "Set providerResultId to an empty string for every Firecrawl citation.",
+    "Return 4-6 distinct, synthesis-ready claims, no more than 3 sources per claim, and a concise summary. Prioritize the strongest guidance instead of exhaustively restating the evidence.",
     "Do not cite sourceId directly and do not add sources that are absent from this evidence pack.",
     "",
     JSON.stringify(evidence, null, 2),
+  ].join("\n");
+}
+
+function researchSynthesisPrompt(
+  config: ResearchWorkflowPrompts,
+  findings: z.output<typeof ResearchFindingSchema>[],
+): string {
+  return [
+    config.synthesisPrompt(findings),
+    "Consolidate overlapping evidence into at most 16 distinct claims with no more than 4 source IDs per claim.",
+    "Keep the report focused and complete within 2,000 words while retaining actionable findings and citations.",
   ].join("\n");
 }
 

--- a/packages/agent-core/src/mastra/workflows/research-provenance.ts
+++ b/packages/agent-core/src/mastra/workflows/research-provenance.ts
@@ -31,23 +31,29 @@ const SourceReferenceDraftSchema = z.strictObject({
 });
 
 export const ResearchPassDraftSchema = z.strictObject({
-  claims: z.array(
-    z.strictObject({
-      claim: z.string().trim().min(1),
-      sources: z.array(SourceReferenceDraftSchema).min(1),
-    }),
-  ),
-  summary: z.string().trim().min(1),
+  claims: z
+    .array(
+      z.strictObject({
+        claim: z.string().trim().min(1).max(800),
+        sources: z.array(SourceReferenceDraftSchema).min(1).max(3),
+      }),
+    )
+    .min(1)
+    .max(6),
+  summary: z.string().trim().min(1).max(2_000),
 });
 
 export const ResearchSynthesisDraftSchema = z.strictObject({
-  claims: z.array(
-    z.strictObject({
-      claim: z.string().trim().min(1),
-      sourceIds: z.array(z.string().trim().min(1).max(4_096)).min(1),
-    }),
-  ),
-  report: z.string().trim().min(1),
+  claims: z
+    .array(
+      z.strictObject({
+        claim: z.string().trim().min(1).max(800),
+        sourceIds: z.array(z.string().trim().min(1).max(4_096)).min(1).max(4),
+      }),
+    )
+    .min(1)
+    .max(16),
+  report: z.string().trim().min(1).max(12_000),
 });
 
 type SourceReference = z.infer<typeof SourceReferenceSchema>;


### PR DESCRIPTION
## Why

The production trace after PR #159 proved that Anthropic native structured output was active, but query passes generated 11-23 exhaustive claims and exhausted the response budget before emitting required fields. Responses were valid JSON prefixes cut off mid-claim or before `summary`.

## What changed

- Bound each query pass to 1-6 concise claims and 1-3 exact provider citations per claim.
- Prompt the model to produce 4-6 synthesis-ready claims instead of restating the whole evidence pack.
- Bound synthesis to 16 consolidated claims and 4 source IDs per claim.
- Give the final synthesis an explicit 8,192-token allowance while keeping the report below 2,000 words.
- Keep all strict Exa/Firecrawl provenance validation in place.

No database, migration, dependency, environment, or deployment-topology changes.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`

After deployment, production QA will repeat natural-language and explicit-tool research flows and validate PDF generation, viewing, download, refresh persistence, and `/` file recall.