### PR TITLE
fix(agent): accept complete research claims

### DIFF
--- a/packages/agent-core/src/mastra/workflows/research-provenance.ts
+++ b/packages/agent-core/src/mastra/workflows/research-provenance.ts
@@ -34,26 +34,26 @@ export const ResearchPassDraftSchema = z.strictObject({
   claims: z
     .array(
       z.strictObject({
-        claim: z.string().trim().min(1).max(800),
+        claim: z.string().trim().min(1),
         sources: z.array(SourceReferenceDraftSchema).min(1).max(3),
       }),
     )
     .min(1)
     .max(6),
-  summary: z.string().trim().min(1).max(2_000),
+  summary: z.string().trim().min(1),
 });
 
 export const ResearchSynthesisDraftSchema = z.strictObject({
   claims: z
     .array(
       z.strictObject({
-        claim: z.string().trim().min(1).max(800),
+        claim: z.string().trim().min(1),
         sourceIds: z.array(z.string().trim().min(1).max(4_096)).min(1).max(4),
       }),
     )
     .min(1)
     .max(16),
-  report: z.string().trim().min(1).max(12_000),
+  report: z.string().trim().min(1),
 });
 
 type SourceReference = z.infer<typeof SourceReferenceSchema>;


### PR DESCRIPTION
## Why

The post-#160 production trace showed a complete, bounded six-claim research pass with a valid summary. Anthropic respected the array bounds but did not enforce JSON Schema `maxLength`; Mastra post-validation rejected one 1,020-character claim against the 800-character model-facing limit.

## What changed

- Remove provider-unreliable string-length constraints from model-facing claim, summary, and report fields.
- Keep the working max-items limits for claims and source fan-out.
- Keep explicit prompt concision, synthesis token allowance, and strict Exa/Firecrawl provenance validation unchanged.

No database, migration, dependency, environment, or deployment-topology changes.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`

Production QA will repeat the complete PDF lifecycle after deployment.