### PR TITLE
fix(agent): stage large research PDF inputs

### DIFF
--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -75,7 +75,10 @@ Successful top-level deep-research and fan-out tools deterministically package
 that validated report, its claim-to-source map, and its source list as a PDF
 artifact. The project workspace is resolved only after remote research succeeds;
 the PDF is then stored both in the live project files and the durable
-generated-output store.
+generated-output store. Document generators stage their bounded structured input
+in a hidden, project-local temporary file instead of embedding it in the sandbox
+command line, then delete that input after rendering; this keeps large reports
+within the sandbox process contract without retaining source payloads.
 
 Composio REST tool discovery and execution responses are byte-bounded before
 parsing, then projected into bounded, valid JSON before entering model context.

--- a/packages/agent-core/src/mastra/context.ts
+++ b/packages/agent-core/src/mastra/context.ts
@@ -20,6 +20,7 @@ export const CONTEXT = {
   promptTaskMessage: "promptTaskMessage",
   promptWorkspaceDir: "promptWorkspaceDir",
   researchEvidenceCollector: "researchEvidenceCollector",
+  researchWorkflowAttempted: "researchWorkflowAttempted",
   researchWorkflowActive: "researchWorkflowActive",
   runIntent: "runIntent",
   userSkillCreator: "userSkillCreator",

--- a/packages/agent-core/src/mastra/tool-defs/research-tools.ts
+++ b/packages/agent-core/src/mastra/tool-defs/research-tools.ts
@@ -79,6 +79,10 @@ async function runResearchWorkflow({
   if (researchWorkflowIsActive(requestContext)) {
     throw new Error("Nested research workflows are not allowed.");
   }
+  if (researchWorkflowWasAttempted(requestContext)) {
+    throw new Error("A research workflow was already attempted for this request.");
+  }
+  markResearchWorkflowAttempted(requestContext);
   const workflow = mastraFromToolContext(context).getWorkflow(workflowName);
   const run = await workflow.createRun();
   const cancellation = bindToolCancellation(context, run);
@@ -142,6 +146,14 @@ function requestContextFromUnknownToolContext(context: ToolExecutionContext): un
 
 function researchWorkflowIsActive(requestContext: unknown): boolean {
   return mutableRequestContext(requestContext)?.get(CONTEXT.researchWorkflowActive) === true;
+}
+
+function researchWorkflowWasAttempted(requestContext: unknown): boolean {
+  return mutableRequestContext(requestContext)?.get(CONTEXT.researchWorkflowAttempted) === true;
+}
+
+function markResearchWorkflowAttempted(requestContext: unknown): void {
+  mutableRequestContext(requestContext)?.set(CONTEXT.researchWorkflowAttempted, true);
 }
 
 function markResearchWorkflowActive(requestContext: unknown): () => void {

--- a/packages/agent-core/src/tools/docs/execute.ts
+++ b/packages/agent-core/src/tools/docs/execute.ts
@@ -32,7 +32,9 @@ const SandboxArtifactSchema = z.strictObject({
 type SandboxArtifact = z.infer<typeof SandboxArtifactSchema>;
 
 const MAX_WORKSPACE_ARTIFACT_BASE64_CHARS = 2_000_000;
+const MAX_STAGED_INPUT_CHARACTERS = 1_900_000;
 const WORKSPACE_ROOT = "/workspace";
+const ARTIFACT_STAGING_DIRECTORY = ".cheatcode/artifact-inputs";
 
 export async function executeGenerateSlides(
   input: GenerateSlidesInput,
@@ -40,10 +42,8 @@ export async function executeGenerateSlides(
 ): Promise<GenerateSlidesOutput> {
   const parsed = GenerateSlidesInputSchema.parse(input);
   const filename = normalizeFilename(parsed.filename ?? parsed.title, "pptx");
-  const artifact = await runArtifactScript(
-    buildSlidesScript(parsed, filename),
-    runtimeContext,
-    "slide",
+  const artifact = await runArtifactScript(parsed, runtimeContext, "slide", (inputPath) =>
+    buildSlidesScript(inputPath, filename),
   );
   return GenerateSlidesOutputSchema.parse({
     ...artifact,
@@ -58,10 +58,8 @@ export async function executeGenerateDocx(
 ): Promise<GenerateDocxOutput> {
   const parsed = GenerateDocumentInputSchema.parse(input);
   const filename = normalizeFilename(parsed.filename ?? parsed.title, "docx");
-  const artifact = await runArtifactScript(
-    buildDocxScript(parsed, filename),
-    runtimeContext,
-    "docx",
+  const artifact = await runArtifactScript(parsed, runtimeContext, "docx", (inputPath) =>
+    buildDocxScript(inputPath, filename),
   );
   return GenerateDocxOutputSchema.parse({
     ...artifact,
@@ -76,7 +74,9 @@ export async function executeGeneratePdf(
 ): Promise<GeneratePdfOutput> {
   const parsed = GenerateDocumentInputSchema.parse(input);
   const filename = normalizeFilename(parsed.filename ?? parsed.title, "pdf");
-  const artifact = await runArtifactScript(buildPdfScript(parsed, filename), runtimeContext, "pdf");
+  const artifact = await runArtifactScript(parsed, runtimeContext, "pdf", (inputPath) =>
+    buildPdfScript(inputPath, filename),
+  );
   return GeneratePdfOutputSchema.parse({
     ...artifact,
     kind: "pdf",
@@ -90,10 +90,8 @@ export async function executeGenerateXlsx(
 ): Promise<GenerateXlsxOutput> {
   const parsed = GenerateSpreadsheetInputSchema.parse(input);
   const filename = normalizeFilename(parsed.filename ?? parsed.title, "xlsx");
-  const artifact = await runArtifactScript(
-    buildXlsxScript(parsed, filename),
-    runtimeContext,
-    "xlsx",
+  const artifact = await runArtifactScript(parsed, runtimeContext, "xlsx", (inputPath) =>
+    buildXlsxScript(inputPath, filename),
   );
   return GenerateXlsxOutputSchema.parse({
     ...artifact,
@@ -103,9 +101,10 @@ export async function executeGenerateXlsx(
 }
 
 async function runArtifactScript(
-  code: string,
+  input: unknown,
   runtimeContext: CodeRuntimeContext,
   kind: ArtifactKind,
+  buildScript: (inputPath: string) => string,
 ): Promise<ArtifactUploadResult> {
   if (!runtimeContext.artifacts) {
     throw new APIError(500, "internal_service_error", "Artifact storage is unavailable", {
@@ -113,29 +112,53 @@ async function runArtifactScript(
     });
   }
 
-  const result = await runtimeContext.sandbox.runCode({
-    code,
-    cwd: runtimeContext.workspaceDir ?? WORKSPACE_ROOT,
-    language: "javascript",
-  });
-  if (!result.success) {
-    throw new APIError(502, "upstream_sandbox_failed", "Document generation failed", {
-      details: {
-        stderrBytes: result.stderr.length,
-        stdoutBytes: result.stdout.length,
-      },
+  const staging = stagedArtifactInput(input, runtimeContext.workspaceDir ?? WORKSPACE_ROOT);
+  try {
+    await runtimeContext.sandbox.writeFile({ content: staging.content, path: staging.path });
+    const result = await runtimeContext.sandbox.runCode({
+      code: buildScript(staging.path),
+      cwd: runtimeContext.workspaceDir ?? WORKSPACE_ROOT,
+      language: "javascript",
+    });
+    if (!result.success) {
+      throw new APIError(502, "upstream_sandbox_failed", "Document generation failed", {
+        details: {
+          inputCharacters: staging.content.length,
+          stderrBytes: result.stderr.length,
+          stdoutBytes: result.stdout.length,
+        },
+        retriable: false,
+      });
+    }
+
+    const generated = parseSandboxArtifact(result.stdout);
+    await writeWorkspaceArtifact(runtimeContext, generated);
+    return await runtimeContext.artifacts.put({
+      contentType: generated.mimeType,
+      data: base64ToBytes(generated.base64),
+      filename: generated.filename,
+      kind,
+    });
+  } finally {
+    await runtimeContext.sandbox.deleteFile({ path: staging.path }).catch(() => undefined);
+  }
+}
+
+function stagedArtifactInput(
+  input: unknown,
+  workspaceDir: string,
+): { content: string; path: string } {
+  const content = JSON.stringify(input);
+  if (content.length > MAX_STAGED_INPUT_CHARACTERS) {
+    throw new APIError(422, "tool_validation_failed", "Document input is too large", {
+      details: { inputCharacters: content.length },
       retriable: false,
     });
   }
-
-  const generated = parseSandboxArtifact(result.stdout);
-  await writeWorkspaceArtifact(runtimeContext, generated);
-  return runtimeContext.artifacts.put({
-    contentType: generated.mimeType,
-    data: base64ToBytes(generated.base64),
-    filename: generated.filename,
-    kind,
-  });
+  return {
+    content,
+    path: `${workspaceDir}/${ARTIFACT_STAGING_DIRECTORY}/${crypto.randomUUID()}.json`,
+  };
 }
 
 async function writeWorkspaceArtifact(

--- a/packages/agent-core/src/tools/docs/scripts.ts
+++ b/packages/agent-core/src/tools/docs/scripts.ts
@@ -1,16 +1,13 @@
-import type {
-  GenerateDocumentInput,
-  GenerateSlidesInput,
-  GenerateSpreadsheetInput,
-} from "./schemas";
-
 const RUNTIME_REQUIRE = [
   'import { createRequire } from "node:module";',
   'const require = createRequire("/opt/cheatcode-doc-runtime/package.json");',
 ].join("\n");
 
-function assignment(name: string, value: unknown): string {
-  return `const ${name} = ${JSON.stringify(value)};`;
+function loadInput(inputPath: string): string {
+  return [
+    'const { readFile } = await import("node:fs/promises");',
+    `const input = JSON.parse(await readFile(${JSON.stringify(inputPath)}, "utf8"));`,
+  ].join("\n");
 }
 
 function emitArtifact(filename: string, mimeType: string): string {
@@ -25,10 +22,10 @@ function emitArtifact(filename: string, mimeType: string): string {
   ].join("\n");
 }
 
-export function buildSlidesScript(input: GenerateSlidesInput, filename: string): string {
+export function buildSlidesScript(inputPath: string, filename: string): string {
   return [
     RUNTIME_REQUIRE,
-    assignment("input", input),
+    loadInput(inputPath),
     emitArtifact(
       filename,
       "application/vnd.openxmlformats-officedocument.presentationml.presentation",
@@ -62,10 +59,10 @@ export function buildSlidesScript(input: GenerateSlidesInput, filename: string):
   ].join("\n");
 }
 
-export function buildDocxScript(input: GenerateDocumentInput, filename: string): string {
+export function buildDocxScript(inputPath: string, filename: string): string {
   return [
     RUNTIME_REQUIRE,
-    assignment("input", input),
+    loadInput(inputPath),
     emitArtifact(
       filename,
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -93,10 +90,10 @@ export function buildDocxScript(input: GenerateDocumentInput, filename: string):
   ].join("\n");
 }
 
-export function buildXlsxScript(input: GenerateSpreadsheetInput, filename: string): string {
+export function buildXlsxScript(inputPath: string, filename: string): string {
   return [
     RUNTIME_REQUIRE,
-    assignment("input", input),
+    loadInput(inputPath),
     emitArtifact(filename, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
     'const ExcelJS = require("exceljs");',
     "const workbook = new ExcelJS.Workbook();",
@@ -119,10 +116,10 @@ export function buildXlsxScript(input: GenerateSpreadsheetInput, filename: strin
   ].join("\n");
 }
 
-export function buildPdfScript(input: GenerateDocumentInput, filename: string): string {
+export function buildPdfScript(inputPath: string, filename: string): string {
   return [
     RUNTIME_REQUIRE,
-    assignment("input", input),
+    loadInput(inputPath),
     emitArtifact(filename, "application/pdf"),
     'const ReactModule = await import(require.resolve("react"));',
     "const React = ReactModule.default ?? ReactModule;",


### PR DESCRIPTION
## Why

Research reports can serialize beyond the sandbox's 100,000-character command limit. The document generators embedded all structured input directly in the `node -e` command, so a completed research workflow failed only when packaging its automatic PDF deliverable. The agent then attempted the expensive research workflow again.

## What changed

- stage bounded document input in a unique hidden project-local JSON file
- render from that file with a small fixed sandbox program
- delete the staged input in a `finally` block
- retain the existing project-file and R2 deliverable behavior
- enforce one research workflow attempt per outer agent request at runtime
- document the temporary-input boundary

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- production-sized regression shape: 102,279 staged characters, 1,729-character sandbox program, exact JSON round-trip, workspace PDF write, artifact upload, and temporary-file cleanup
- pre-fix production smoke test confirmed small PDFs render, persist, and appear as deliverables

The local Node runtime reports the repository's existing version warning (26.4.0 locally vs 24.18.0 pinned); all checks still pass.
