### PR TITLE
fix(sandbox): support large run-code payloads

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -181,6 +181,10 @@ Each user has one durable Daytona sandbox. Projects are lexically confined to th
 folders under `/workspace`, and run leases keep the sandbox active while the agent is
 working. Project folders share the sandbox's Unix identity, so this prevents accidental
 cross-project access but is not an operating-system security boundary within one user.
+The validated `runCode` source contract remains separate from the smaller public `exec`
+argv contract: the Worker base64-chunks source into bounded, reserved request environment
+variables and pipes it to the selected interpreter over stdin. Large code therefore does
+not exceed an argv element limit or leave a temporary source file on the persistent volume.
 Sandbox lookup validates canonical ownership labels before trusting a cached Daytona
 resource ID. A missing/stale Durable Object cache therefore recovers the one canonical
 sandbox by labels, while duplicate live canonical matches fail closed. New sandboxes pin

--- a/apps/agent-worker/src/durable-objects/project-sandbox-processes.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-processes.ts
@@ -6,6 +6,7 @@ import type {
   SandboxRunCodeResult,
 } from "@cheatcode/sandbox-contracts";
 import type { SandboxConsoleSnapshot } from "@cheatcode/types/api";
+import { encodeBase64 } from "../sandbox-support";
 import { sandboxExecProcessName } from "./project-sandbox-audit";
 import { WORKSPACE_DIR } from "./project-sandbox-content-support";
 import { recordSandboxUsageBestEffort } from "./project-sandbox-metering";
@@ -55,6 +56,8 @@ import {
 import type { SandboxRuntime } from "./project-sandbox-runtime-handle";
 
 const DEFAULT_EXEC_TIMEOUT_MS = 60_000;
+const RUN_CODE_ENV_CHUNK_CHARACTERS = 24_000;
+const RUN_CODE_ENV_PREFIX = "CHEATCODE_RUN_CODE_";
 
 export interface ProjectSandboxStatus {
   healthy: boolean;
@@ -146,14 +149,11 @@ async function runCode(
   input: ProjectRunCodeInput,
 ): Promise<SandboxRunCodeResult> {
   const parsed = ProjectRunCodeInputSchema.parse(input);
-  const command =
-    parsed.language === "python"
-      ? ["python3", "-c", parsed.code]
-      : ["node", "--input-type=module", "-e", parsed.code];
-  const result = await context.coordinated.exec({
-    command,
+  const encodedChunks = chunkRunCode(encodeBase64(new TextEncoder().encode(parsed.code)));
+  const result = await executeCommand(context.runtime, {
+    command: runCodeCommand(parsed.language, encodedChunks.length),
     cwd: parsed.cwd ?? WORKSPACE_DIR,
-    env: parsed.env,
+    env: runCodeEnvironment(parsed.env, encodedChunks),
     timeoutMs: parsed.timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS,
   });
   return {
@@ -166,32 +166,77 @@ async function runCode(
 
 async function exec(runtime: ProcessRuntime, input: ProjectExecInput): Promise<SandboxExecResult> {
   const parsed = ProjectExecInputSchema.parse(input);
+  return executeCommand(runtime, {
+    command: parsed.command,
+    cwd: parsed.cwd ?? WORKSPACE_DIR,
+    env: parsed.env,
+    timeoutMs: parsed.timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS,
+  });
+}
+
+interface ExecutableCommand {
+  command: string[];
+  cwd: string;
+  env: Record<string, string> | undefined;
+  timeoutMs: number;
+}
+
+async function executeCommand(
+  runtime: ProcessRuntime,
+  input: ExecutableCommand,
+): Promise<SandboxExecResult> {
   const startedAt = Date.now();
-  const command = commandToShellString(parsed.command);
-  const cwd = parsed.cwd ?? WORKSPACE_DIR;
-  const timeoutMs = parsed.timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS;
-  const unsupportedManager = unsupportedProjectPackageManager(cwd, parsed.command);
+  const command = commandToShellString(input.command);
+  const unsupportedManager = unsupportedProjectPackageManager(input.cwd, input.command);
   if (unsupportedManager) {
     const result = packageManagerPolicyResult(command, unsupportedManager, startedAt);
-    await recordExecAudit(runtime, parsed.command, cwd, result, result.exitCode, startedAt);
+    await recordExecAudit(runtime, input.command, input.cwd, result, result.exitCode, startedAt);
     return result;
   }
   const id = await runtime.ensureSandbox();
-  const env = projectPackageEnvironment(cwd, parsed.env);
+  const env = projectPackageEnvironment(input.cwd, input.env);
   try {
     const completed = await runtime.client().execute(id, {
       command,
-      cwd,
-      timeout: timeoutSeconds(timeoutMs),
+      cwd: input.cwd,
+      timeout: timeoutSeconds(input.timeoutMs),
       ...(env === undefined ? {} : { env }),
     });
     const result = execResult(command, completed, startedAt);
-    await recordExecAudit(runtime, parsed.command, cwd, result, completed.exitCode, startedAt);
+    await recordExecAudit(runtime, input.command, input.cwd, result, completed.exitCode, startedAt);
     await recordSandboxUsageBestEffort(await runtime.meteringContext());
     return result;
   } catch (error) {
     throw runtime.toUpstreamError(error, "Sandbox command failed.");
   }
+}
+
+function chunkRunCode(encoded: string): string[] {
+  const chunks: string[] = [];
+  for (let offset = 0; offset < encoded.length; offset += RUN_CODE_ENV_CHUNK_CHARACTERS) {
+    chunks.push(encoded.slice(offset, offset + RUN_CODE_ENV_CHUNK_CHARACTERS));
+  }
+  return chunks;
+}
+
+function runCodeCommand(language: "javascript" | "python", chunkCount: number): string[] {
+  const inputs = Array.from(
+    { length: chunkCount },
+    (_, index) => `"$${RUN_CODE_ENV_PREFIX}${index}"`,
+  ).join(" ");
+  const interpreter = language === "python" ? "python3 -" : "node --input-type=module";
+  return ["sh", "-c", `printf %s ${inputs} | base64 -d | ${interpreter}`];
+}
+
+function runCodeEnvironment(
+  requested: Record<string, string> | undefined,
+  chunks: readonly string[],
+): Record<string, string> {
+  const environment = { ...requested };
+  for (const [index, chunk] of chunks.entries()) {
+    environment[`${RUN_CODE_ENV_PREFIX}${index}`] = chunk;
+  }
+  return environment;
 }
 
 function packageManagerPolicyResult(


### PR DESCRIPTION
## Why

Rich Markdown PDF generation builds a renderer script larger than the public exec argv-element limit. ProjectSandbox.runCode reused that exec path, so the validated 8,790-character renderer failed before execution with an 8,192-character Zod limit.

## What changed

- keep public exec argv limits unchanged
- transport validated run-code source as bounded base64 request-environment chunks
- pipe source to Node or Python over stdin, preserving top-level module behavior
- execute inside the existing runCode lease without writing source onto the persistent workspace volume
- document the separate runCode and exec transport contracts

## Verification

- pnpm lint
- pnpm typecheck
- pnpm turbo build --force
- pnpm deadcode
- pnpm architecture:check
- pnpm turbo skills:build
- confirmed the production renderer script is 8,790 characters and the prior production error identifies command element 3 exceeding 8,192 characters

Production research and PDF acceptance will be rerun after deployment.