### PR TITLE
fix(artifacts): delimit sandbox metadata

### DIFF
--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -79,7 +79,9 @@ and PDF therefore preserve the same headings, prose, lists, tables, links, citat
 and ordering; only print-safe pagination and document chrome differ. The project
 workspace is resolved only after remote research succeeds;
 the PDF is then stored both in the live project files and the durable
-generated-output store. Document generators stage their bounded structured input
+generated-output store. Sandbox renderers delimit their final artifact metadata with
+an internal stdout marker so bounded library diagnostics cannot corrupt the payload.
+Document generators stage their bounded structured input
 in a hidden, project-local temporary file instead of embedding it in the sandbox
 command line, then delete that input after rendering; this keeps large reports
 within the sandbox process contract without retaining source payloads.

--- a/packages/agent-core/src/tools/docs/execute.ts
+++ b/packages/agent-core/src/tools/docs/execute.ts
@@ -46,6 +46,7 @@ const MAX_WORKSPACE_ARTIFACT_BASE64_CHARS = 2_000_000;
 const MAX_STAGED_INPUT_CHARACTERS = 1_900_000;
 const WORKSPACE_ROOT = "/workspace";
 const ARTIFACT_STAGING_DIRECTORY = ".cheatcode/artifact-inputs";
+const ARTIFACT_STDOUT_MARKER = "__CHEATCODE_ARTIFACT__";
 
 export async function executeGenerateSlides(
   input: GenerateSlidesInput,
@@ -219,7 +220,12 @@ async function writeWorkspaceArtifact(
 
 function parseSandboxArtifact(stdout: string): SandboxArtifact {
   try {
-    return SandboxArtifactSchema.parse(JSON.parse(stdout.trim()));
+    const markerIndex = stdout.lastIndexOf(ARTIFACT_STDOUT_MARKER);
+    const payload =
+      markerIndex === -1
+        ? stdout.trim()
+        : stdout.slice(markerIndex + ARTIFACT_STDOUT_MARKER.length).trim();
+    return SandboxArtifactSchema.parse(JSON.parse(payload));
   } catch (error) {
     throw new APIError(
       502,

--- a/packages/agent-core/src/tools/docs/scripts.ts
+++ b/packages/agent-core/src/tools/docs/scripts.ts
@@ -3,6 +3,8 @@ const RUNTIME_REQUIRE = [
   'const require = createRequire("/opt/cheatcode-doc-runtime/package.json");',
 ].join("\n");
 
+const ARTIFACT_STDOUT_MARKER = "__CHEATCODE_ARTIFACT__";
+
 function loadInput(inputPath: string): string {
   return [
     'const { readFile } = await import("node:fs/promises");',
@@ -13,7 +15,7 @@ function loadInput(inputPath: string): string {
 function emitArtifact(filename: string, mimeType: string): string {
   return [
     "function emit(base64) {",
-    "  process.stdout.write(JSON.stringify({",
+    `  process.stdout.write("\\n${ARTIFACT_STDOUT_MARKER}" + JSON.stringify({`,
     `    filename: ${JSON.stringify(filename)},`,
     `    mimeType: ${JSON.stringify(mimeType)},`,
     "    base64,",


### PR DESCRIPTION
## Why

After the large run-code transport fix, production PDF rendering executed successfully but artifact parsing still failed when sandbox or renderer diagnostics shared stdout with the final JSON metadata.

## What changed

- emit a reserved final-artifact marker immediately before metadata JSON
- parse only the payload after the last marker
- retain compatibility with a clean JSON-only response
- document the sandbox artifact stdout protocol

## Verification

- pnpm lint
- pnpm typecheck
- pnpm turbo build --force
- pnpm deadcode
- pnpm architecture:check
- pnpm turbo skills:build
- live Daytona diagnostic with an injected renderer log followed by marked PDF metadata
- confirmed the marker remains the final output boundary and the rendered PDF payload is valid

Production deep-research and PDF acceptance will be rerun after deployment.