### PR TITLE
fix(auth): make social login use one redirect navigation

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -95,6 +95,10 @@ The production CSP admits the exact validated `NEXT_PUBLIC_GATEWAY_URL`; a real 
 Production build pins that value to `https://gateway.trycheatcode.com`, while optimized
 local QA can use its loopback Wrangler origin.
 Production additionally admits only Vercel's exact immutable deployment origin.
+Google and other social authentication uses Clerk's full-page redirect flow. The callback therefore
+finishes through one authoritative navigation instead of a popup attempting to replace the anonymous
+client tree after its server identity has changed. Production can keep `Cross-Origin-Opener-Policy`
+at `same-origin`; no authentication flow depends on a cross-origin opener relationship.
 
 ## Deploy
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -73,7 +73,7 @@ const nextConfig = {
       {
         headers: [
           { key: "Content-Security-Policy", value: CONTENT_SECURITY_POLICY },
-          { key: "Cross-Origin-Opener-Policy", value: "same-origin-allow-popups" },
+          { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
           { key: "Origin-Agent-Cluster", value: "?1" },
           { key: "Permissions-Policy", value: "camera=(), geolocation=(), microphone=()" },
           { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -7,6 +7,10 @@ import { clerkAuthAppearance } from "./clerk-auth-appearance";
 
 export type AuthMode = "sign-in" | "sign-up";
 
+// OAuth changes the authenticated server identity. A full-page redirect gives Clerk and Next.js
+// one authoritative navigation instead of reconciling a popup callback into an anonymous tree.
+const AUTH_OAUTH_FLOW = "redirect" as const;
+
 interface AuthModalProps {
   open: boolean;
   id?: string | undefined;
@@ -75,7 +79,7 @@ function AuthModalContent({
           appearance={clerkAuthAppearance}
           fallbackRedirectUrl={redirectPath}
           forceRedirectUrl={redirectPath}
-          oauthFlow="popup"
+          oauthFlow={AUTH_OAUTH_FLOW}
           routing="hash"
         />
       ) : (
@@ -83,7 +87,7 @@ function AuthModalContent({
           appearance={clerkAuthAppearance}
           fallbackRedirectUrl={redirectPath}
           forceRedirectUrl={redirectPath}
-          oauthFlow="popup"
+          oauthFlow={AUTH_OAUTH_FLOW}
           routing="hash"
         />
       )}


### PR DESCRIPTION
## Summary

- Replace forced popup OAuth for sign-in and sign-up with Clerk's full-page redirect flow.
- Prevent a remotely chunked popup callback from crashing the signed-out Next.js tree during session replacement.
- Restore strict `Cross-Origin-Opener-Policy: same-origin` now that authentication does not need an opener relationship.

## Root cause

Production Google OAuth reached Clerk and created the session, but the popup callback intermittently failed while loading a remote `@clerk/ui` chunk. The popup then had to reconcile the newly authenticated identity into the already-rendered anonymous application tree, producing the generic client-side exception page.

## Architecture

OAuth now performs one authoritative navigation:

`Cheatcode sign-in -> Google -> Clerk callback -> requested Cheatcode path`

The installed `@clerk/ui` version remains pinned through `ClerkProvider`; only the transport changes.

## Decisions made

| Decision | Choice | Alternative | Reasoning |
|---|---|---|---|
| OAuth transport | Full-page redirect | Forced popup | Removes popup lifecycle, opener, and cross-window identity reconciliation failure modes. |
| Opener policy | `same-origin` | `same-origin-allow-popups` | Redirect auth no longer requires cross-origin opener access, so production isolation can be strict. |
| Clerk UI version | Keep pinned | Remove `ui={ui}` | Version pinning is Clerk's documented deterministic-rendering path. |

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- Reproduced production Google sign-in with the requested Google account and captured the failing Clerk UI chunk before the change.
- Post-deploy acceptance: repeat sign-out -> Google account selection -> Clerk callback -> authenticated Cheatcode route, then inspect console and network errors.

## Scope

No database, migration, environment, API, or worker topology changes.
