### PR TITLE
fix: prevent agent Workflows exhausting subrequests

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -83,6 +83,10 @@ completed step instead of losing an in-memory coroutine. Transcript publication 
 event keys and an atomic SQLite receipt, so Workflow step replay cannot duplicate visible parts.
 There is no application step, token, duration, or cost ceiling; semantic completion ends the loop,
 while per-operation timeouts and the platform Workflow limit remain operational safeguards.
+The Worker pins Cloudflare's paid-plan maximum subrequest allowance because external provider,
+Daytona, Hyperdrive, R2, and Durable Object requests share one Workflow-instance budget. That
+platform transport budget must accommodate the configured 25,000 durable steps rather than become
+an earlier, workload-dependent product limit.
 Successful deep-research tools are terminal response producers: the Workflow suppresses the model's
 pre-tool narration, publishes the tool's validated canonical Markdown directly as the assistant text,
 and completes without asking a second model turn to copy or summarize it. The same Markdown is the

--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -6,6 +6,9 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-07-15",
   "compatibility_flags": ["nodejs_compat"],
+  "limits": {
+    "subrequests": 10000000
+  },
   "version_metadata": {
     "binding": "CF_VERSION_METADATA"
   },


### PR DESCRIPTION
## Summary
- Raise the agent Worker subrequest allowance to Cloudflare's paid-plan maximum.
- Prevent normal model, Daytona, database, storage, and Durable Object traffic from terminating semantically active agent runs.
- Document why the transport budget must match the existing 25,000-step Workflow contract.

## Context
Production QA for the pomodoro-app failure proved the prior fourth-tool fix works: all four tool calls completed. The next model turn then failed four times with Cloudflare's exact `Too many subrequests by single Worker invocation` error. This PR fixes that independent deployment boundary.

No separate Linear issue or plan document exists for this production incident.

## Architecture
Cloudflare counts external fetches and Cloudflare-service calls against one Workflow-instance subrequest budget. The agent loop is intentionally completion-driven, so `apps/agent-worker/wrangler.jsonc` now pins the paid-plan maximum while the existing 25,000-step limit, operation timeouts, cancellation, and provider quotas remain the operational safeguards.

## Decisions Made
| Decision | Choice | Alternatives considered | Reasoning |
| --- | --- | --- | --- |
| Budget location | Top-level agent Worker `limits.subrequests` | Model retries or per-tool workarounds | This is the Cloudflare-owned deployment boundary named by the runtime error. |
| Budget value | Paid-plan maximum, 10,000,000 | Arbitrary lower ceilings | Agent work varies by sandbox and tool traffic; a lower value would remain a hidden product limit and subrequests are not preallocated. |
| Scope | Agent Worker only | Raise every Worker | Only the long-running agent Workflow demonstrated this workload and failure mode. |

## Edge Cases Handled
| Scenario | Handling |
| --- | --- |
| Long app-building run uses many provider and sandbox requests | The platform budget no longer terminates the run before its configured Workflow-step ceiling. |
| Other Workers receive ordinary webhook or gateway traffic | Their limits remain unchanged. |
| Runaway or abandoned run | Existing cancellation, timeouts, provider quotas, and Workflow steps remain in force. |

## How to Review
1. Review `apps/agent-worker/wrangler.jsonc` for the deployment limit.
2. Review `apps/agent-worker/README.md` for the architectural contract.

## Verification
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm turbo build --force`
- [x] `pnpm deadcode`
- [x] `pnpm architecture:check`
- [x] `pnpm turbo skills:build`
- [x] `wrangler deploy --dry-run --config apps/agent-worker/wrangler.jsonc`
- [ ] Rerun the exact failing flow on production after merge and Cloudflare deployment.