### PR TITLE
chore(sandbox): promote verified runtime snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-2d91bd46205d-30812852154",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-82e9c9add1b1-31304224819",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable sandbox candidate containing the browser-driver lifecycle repair and patched runtime dependency floors after its protected image pipeline passed.

## Provenance

- source main commit: `82e9c9add1b198088dee056e31feb133ffd4fe8a`
- protected snapshot workflow: [31304224819](https://github.com/cheatcode-ai/cheatcode/actions/runs/31304224819)
- candidate: `cheatcode-sandbox-viewer-bundle-82e9c9add1b1-31304224819`
- image build: passed
- Trivy configuration, vulnerability, and secret scans: passed
- immutable-image runtime smoke suite: passed
- Daytona publication and candidate verification: passed

## Change

Updates only `DAYTONA_SANDBOX_SNAPSHOT` in the agent Worker configuration. Existing sandboxes are replaced after active work drains while preserving the canonical mounted workspace volume.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `git diff --check`
