### PR TITLE
fix(sandbox): run pnpm on native disk

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -152,6 +152,12 @@ webpack compilation even after the listening socket opens. A baked Python synchr
 full refresh on every process start and mirrors subsequent writes and deletions within one second,
 including shell-based edits. The local source, dependency tree, and build cache are disposable;
 wake and restart reconstruct them from the durable project without changing the Files surface.
+Direct pnpm commands use that same native-disk source as a transaction: the runtime snapshots the
+durable source, executes pnpm locally, and copies only command-produced source changes back after
+verifying that the corresponding durable paths did not change concurrently. Long-running pnpm
+processes keep the durable-to-local mirror alive for hot reload. Shell-wrapped package managers are
+rejected because they cannot participate in this synchronization boundary; npm, Yarn, and Bun stay
+disabled for project workspaces.
 
 AgentRun keeps one compact exact SQLite shape for run identity, replay parts, and
 coordination state. Dormant objects are reconciled transactionally on activation;

--- a/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
+++ b/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
@@ -1,5 +1,6 @@
 import { shellQuote } from "../sandbox-support";
-import { NEXT_RUNTIME_BIN, projectLocalSourceDir } from "./project-sandbox-package-runtime";
+import { localProjectProcessCommand } from "./project-sandbox-local-source";
+import { NEXT_RUNTIME_BIN, resolveProjectLocalRuntime } from "./project-sandbox-package-runtime";
 
 interface LocalPreviewCommandInput {
   port: number;
@@ -7,89 +8,12 @@ interface LocalPreviewCommandInput {
   workspaceSlug: string;
 }
 
-const PREVIEW_MIRROR_SYNC_SCRIPT = `
-import os
-import shutil
-import sys
-import time
-
-IGNORED_DIRS = {".expo", ".next", "node_modules"}
-LOCAL_ONLY_NAMES = IGNORED_DIRS | {"next-env.d.ts"}
-
-def remove_path(path):
-    if os.path.isdir(path) and not os.path.islink(path):
-        shutil.rmtree(path)
-    elif os.path.lexists(path):
-        os.unlink(path)
-
-def sync_link(source, target):
-    link = os.readlink(source)
-    if os.path.islink(target) and os.readlink(target) == link:
-        return
-    remove_path(target)
-    os.symlink(link, target)
-
-def sync_file(entry, target, force):
-    source_stat = entry.stat(follow_symlinks=False)
-    try:
-        target_stat = os.stat(target, follow_symlinks=False)
-    except FileNotFoundError:
-        target_stat = None
-    changed = (
-        force
-        or target_stat is None
-        or not os.path.isfile(target)
-        or source_stat.st_size != target_stat.st_size
-        or source_stat.st_mtime_ns > target_stat.st_mtime_ns
-    )
-    if changed:
-        remove_path(target)
-        shutil.copy2(entry.path, target, follow_symlinks=False)
-
-def sync_directory(source, target, force=False):
-    if os.path.lexists(target) and not os.path.isdir(target):
-        remove_path(target)
-    os.makedirs(target, exist_ok=True)
-    source_names = set()
-    for entry in os.scandir(source):
-        if entry.name in IGNORED_DIRS:
-            continue
-        source_names.add(entry.name)
-        destination = os.path.join(target, entry.name)
-        try:
-            if entry.is_symlink():
-                sync_link(entry.path, destination)
-            elif entry.is_dir(follow_symlinks=False):
-                sync_directory(entry.path, destination, force)
-            elif entry.is_file(follow_symlinks=False):
-                sync_file(entry, destination, force)
-        except FileNotFoundError:
-            continue
-    for entry in os.scandir(target):
-        if entry.name not in source_names and entry.name not in LOCAL_ONLY_NAMES:
-            remove_path(entry.path)
-
-def synchronize(source, target, force):
-    sync_directory(source, target, force)
-
-source_dir, target_dir, mode = sys.argv[1:4]
-if mode == "once":
-    synchronize(source_dir, target_dir, True)
-else:
-    while True:
-        try:
-            synchronize(source_dir, target_dir, False)
-        except OSError:
-            pass
-        time.sleep(0.75)
-`;
-
 /** Runs Next from native sandbox disk while `/workspace` remains the durable project source. */
 export function localNextPreviewCommand(input: LocalPreviewCommandInput): string[] {
-  const localSourceDir = projectLocalSourceDir(input.workspaceSlug);
-  const syncCommand = ["python3", "-c", PREVIEW_MIRROR_SYNC_SCRIPT, input.sourceDir, localSourceDir]
-    .map(shellQuote)
-    .join(" ");
+  const runtime = resolveProjectLocalRuntime(input.sourceDir);
+  if (!runtime || runtime.workspaceSlug !== input.workspaceSlug) {
+    throw new TypeError("Preview source does not match its workspace slug.");
+  }
   const nextCommand = [
     NEXT_RUNTIME_BIN,
     "dev",
@@ -101,20 +25,5 @@ export function localNextPreviewCommand(input: LocalPreviewCommandInput): string
   ]
     .map(shellQuote)
     .join(" ");
-  const command = [
-    `${syncCommand} once || exit $?`,
-    `${syncCommand} loop &`,
-    "sync_pid=$!",
-    `cd ${shellQuote(localSourceDir)} || exit $?`,
-    `${nextCommand} &`,
-    "app_pid=$!",
-    'terminate() { kill -TERM "$app_pid" "$sync_pid" 2>/dev/null || true; }',
-    "trap terminate HUP INT TERM",
-    'wait "$app_pid"',
-    "status=$?",
-    'kill "$sync_pid" 2>/dev/null || true',
-    'wait "$sync_pid" 2>/dev/null || true',
-    'exit "$status"',
-  ].join("\n");
-  return ["sh", "-lc", command];
+  return ["sh", "-lc", localProjectProcessCommand(runtime, nextCommand)];
 }

--- a/apps/agent-worker/src/durable-objects/project-sandbox-local-source.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-local-source.ts
@@ -1,0 +1,271 @@
+import { shellQuote } from "../sandbox-support";
+import type { ProjectLocalRuntime } from "./project-sandbox-package-runtime";
+
+const LOCAL_SOURCE_SYNC_SCRIPT = `
+import hashlib
+import json
+import os
+import shutil
+import sys
+import time
+
+IGNORED_DIRS = {".expo", ".next", ".turbo", "build", "coverage", "dist", "node_modules", "out"}
+LOCAL_ONLY_NAMES = IGNORED_DIRS | {"next-env.d.ts"}
+LOCK_STALE_SECONDS = 15 * 60
+
+def remove_path(path):
+    if os.path.isdir(path) and not os.path.islink(path):
+        shutil.rmtree(path)
+    elif os.path.lexists(path):
+        os.unlink(path)
+
+def sync_link(source, target):
+    link = os.readlink(source)
+    if os.path.islink(target) and os.readlink(target) == link:
+        return
+    remove_path(target)
+    os.symlink(link, target)
+
+def sync_file(source, target, force):
+    source_stat = os.stat(source, follow_symlinks=False)
+    try:
+        target_stat = os.stat(target, follow_symlinks=False)
+    except FileNotFoundError:
+        target_stat = None
+    changed = (
+        force
+        or target_stat is None
+        or not os.path.isfile(target)
+        or source_stat.st_size != target_stat.st_size
+        or source_stat.st_mtime_ns > target_stat.st_mtime_ns
+    )
+    if changed:
+        remove_path(target)
+        shutil.copyfile(source, target, follow_symlinks=False)
+
+def sync_directory(source, target, force=False):
+    if os.path.lexists(target) and not os.path.isdir(target):
+        remove_path(target)
+    os.makedirs(target, exist_ok=True)
+    source_names = set()
+    for entry in os.scandir(source):
+        if entry.name in IGNORED_DIRS:
+            continue
+        source_names.add(entry.name)
+        destination = os.path.join(target, entry.name)
+        try:
+            if entry.is_symlink():
+                sync_link(entry.path, destination)
+            elif entry.is_dir(follow_symlinks=False):
+                sync_directory(entry.path, destination, force)
+            elif entry.is_file(follow_symlinks=False):
+                sync_file(entry.path, destination, force)
+        except FileNotFoundError:
+            continue
+    for entry in os.scandir(target):
+        if entry.name not in source_names and entry.name not in LOCAL_ONLY_NAMES:
+            remove_path(entry.path)
+
+def digest(path):
+    value = hashlib.sha256()
+    with open(path, "rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            value.update(chunk)
+    return value.hexdigest()
+
+def tree_state(root):
+    state = {}
+    if not os.path.isdir(root):
+        return state
+    for current, dir_names, file_names in os.walk(root, topdown=True, followlinks=False):
+        dir_names[:] = sorted(name for name in dir_names if name not in IGNORED_DIRS)
+        relative_root = os.path.relpath(current, root)
+        for name in dir_names:
+            path = os.path.join(current, name)
+            relative = os.path.normpath(os.path.join(relative_root, name))
+            if os.path.islink(path):
+                state[relative] = ["link", os.readlink(path)]
+            else:
+                state[relative] = ["dir"]
+        for name in sorted(file_names):
+            if name in LOCAL_ONLY_NAMES:
+                continue
+            path = os.path.join(current, name)
+            relative = os.path.normpath(os.path.join(relative_root, name))
+            if os.path.islink(path):
+                state[relative] = ["link", os.readlink(path)]
+            else:
+                state[relative] = ["file", digest(path)]
+    return state
+
+def package_lock_active(lock_path):
+    try:
+        age = time.time() - os.path.getmtime(lock_path)
+    except FileNotFoundError:
+        return False
+    if age <= LOCK_STALE_SECONDS:
+        return True
+    try:
+        os.unlink(lock_path)
+    except FileNotFoundError:
+        pass
+    return False
+
+def wait_for_preview(lock_path, busy_path):
+    deadline = time.time() + 30
+    while os.path.exists(busy_path):
+        if time.time() >= deadline:
+            raise TimeoutError("local source mirror did not quiesce")
+        time.sleep(0.05)
+
+def preview_sync(source, target, mode, lock_path, busy_path):
+    force = mode == "preview-once"
+    while True:
+        if package_lock_active(lock_path):
+            if force:
+                time.sleep(0.05)
+                continue
+            time.sleep(0.25)
+            continue
+        os.makedirs(os.path.dirname(busy_path), exist_ok=True)
+        with open(busy_path, "w", encoding="utf-8"):
+            pass
+        try:
+            if package_lock_active(lock_path):
+                continue
+            sync_directory(source, target, force)
+        finally:
+            try:
+                os.unlink(busy_path)
+            except FileNotFoundError:
+                pass
+        if force:
+            return
+        time.sleep(0.75)
+
+def prepare(source, target, lock_path, busy_path, baseline_path):
+    os.makedirs(os.path.dirname(lock_path), exist_ok=True)
+    with open(lock_path, "w", encoding="utf-8") as lock:
+        lock.write(str(time.time()))
+    try:
+        wait_for_preview(lock_path, busy_path)
+        sync_directory(source, target, True)
+        with open(baseline_path, "w", encoding="utf-8") as baseline:
+            json.dump(tree_state(target), baseline, sort_keys=True, separators=(",", ":"))
+    except Exception:
+        cleanup(lock_path, baseline_path)
+        raise
+
+def copy_state(source_root, target_root, relative, state):
+    source = os.path.join(source_root, relative)
+    target = os.path.join(target_root, relative)
+    kind = state[0]
+    if kind == "dir":
+        if os.path.lexists(target) and not os.path.isdir(target):
+            remove_path(target)
+        os.makedirs(target, exist_ok=True)
+        return
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    if kind == "link":
+        sync_link(source, target)
+        return
+    if os.path.isdir(target) or os.path.islink(target):
+        remove_path(target)
+    shutil.copyfile(source, target, follow_symlinks=False)
+
+def cleanup(lock_path, baseline_path):
+    for path in (baseline_path, lock_path):
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+def commit(source, target, lock_path, baseline_path):
+    try:
+        with open(baseline_path, encoding="utf-8") as baseline_file:
+            baseline = json.load(baseline_file)
+        local = tree_state(target)
+        durable = tree_state(source)
+        changed = sorted(path for path in set(baseline) | set(local) if baseline.get(path) != local.get(path))
+        conflicts = [
+            path
+            for path in changed
+            if durable.get(path) != baseline.get(path) and durable.get(path) != local.get(path)
+        ]
+        if conflicts:
+            raise RuntimeError("durable project changed during package command: " + ", ".join(conflicts[:8]))
+        for relative in sorted((path for path in changed if path not in local), key=lambda value: value.count(os.sep), reverse=True):
+            remove_path(os.path.join(source, relative))
+        for relative in sorted((path for path in changed if path in local), key=lambda value: value.count(os.sep)):
+            copy_state(target, source, relative, local[relative])
+    finally:
+        cleanup(lock_path, baseline_path)
+
+mode, source, target, lock_path, busy_path, baseline_path = sys.argv[1:7]
+if mode in {"preview-once", "preview-loop"}:
+    preview_sync(source, target, mode, lock_path, busy_path)
+elif mode == "package-prepare":
+    prepare(source, target, lock_path, busy_path, baseline_path)
+elif mode == "package-commit":
+    commit(source, target, lock_path, baseline_path)
+elif mode == "package-abort":
+    cleanup(lock_path, baseline_path)
+else:
+    raise ValueError("unknown local source synchronization mode")
+`;
+
+function runtimeStatePaths(runtime: ProjectLocalRuntime): {
+  baselinePath: string;
+  busyPath: string;
+  lockPath: string;
+} {
+  return {
+    baselinePath: `${runtime.runtimeDir}/package-operation-baseline.json`,
+    busyPath: `${runtime.runtimeDir}/preview-sync.busy`,
+    lockPath: `${runtime.runtimeDir}/package-operation.lock`,
+  };
+}
+
+export function localSourceSyncCommand(
+  runtime: ProjectLocalRuntime,
+  mode: "package-abort" | "package-commit" | "package-prepare" | "preview-loop" | "preview-once",
+): string {
+  const { baselinePath, busyPath, lockPath } = runtimeStatePaths(runtime);
+  return [
+    "python3",
+    "-c",
+    LOCAL_SOURCE_SYNC_SCRIPT,
+    mode,
+    runtime.workspaceDir,
+    runtime.localSourceDir,
+    lockPath,
+    busyPath,
+    baselinePath,
+  ]
+    .map(shellQuote)
+    .join(" ");
+}
+
+/** Runs a long-lived package script on native disk while durable source changes keep flowing in. */
+export function localProjectProcessCommand(
+  runtime: ProjectLocalRuntime,
+  rawCommand: string,
+): string {
+  const syncOnce = localSourceSyncCommand(runtime, "preview-once");
+  const syncLoop = localSourceSyncCommand(runtime, "preview-loop");
+  return [
+    `${syncOnce} || exit $?`,
+    `${syncLoop} &`,
+    "sync_pid=$!",
+    `cd ${shellQuote(runtime.localCwd)} || exit $?`,
+    `${rawCommand} &`,
+    "app_pid=$!",
+    'terminate() { kill -TERM "$app_pid" "$sync_pid" 2>/dev/null || true; }',
+    "trap terminate HUP INT TERM",
+    'wait "$app_pid"',
+    "status=$?",
+    'kill "$sync_pid" 2>/dev/null || true',
+    'wait "$sync_pid" 2>/dev/null || true',
+    'exit "$status"',
+  ].join("\n");
+}

--- a/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
@@ -4,11 +4,12 @@ const BASE_NODE_PATH = [
   "/opt/cheatcode-doc-runtime/node_modules",
   "/opt/cheatcode-skill-runtime/node_modules",
 ];
-const WORKSPACE_PROJECT_PATH = /^\/workspace\/([a-z0-9]+(?:-[a-z0-9]+)*)(?:\/|$)/u;
-const UNSUPPORTED_PACKAGE_MANAGERS = new Set(["npm", "npx", "yarn", "yarnpkg"]);
+const WORKSPACE_PROJECT_PATH = /^\/workspace\/([a-z0-9]+(?:-[a-z0-9]+)*)(?<suffix>\/.*)?$/u;
+const PNPM_EXECUTABLES = new Set(["pnpm", "pnpx"]);
+const UNSUPPORTED_PACKAGE_MANAGERS = new Set(["bun", "bunx", "npm", "npx", "yarn", "yarnpkg"]);
 const SHELL_EXECUTABLES = new Set(["bash", "sh", "zsh"]);
 const SHELL_PACKAGE_MANAGER_COMMAND =
-  /(?:^|&&|\|\||;|\n|\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=[^\s;&|()]+)\s+)*(?:command\s+)?(?:sudo\s+)?(?:[^\s;&|()]+\/)?(npm|npx|yarn|yarnpkg)(?=\s|$)/u;
+  /(?:^|&&|\|\||;|\n|\()\s*(?:(?:[A-Za-z_][A-Za-z0-9_]*=[^\s;&|()]+)\s+)*(?:command\s+)?(?:sudo\s+)?(?:[^\s;&|()]+\/)?(bun|bunx|npm|npx|pnpm|pnpx|yarn|yarnpkg)(?=\s|$)/u;
 
 export const NEXT_RUNTIME_BIN = `${APP_RUNTIME_ROOT}/next/node_modules/.bin/next`;
 export const EXPO_RUNTIME_BIN = `${APP_RUNTIME_ROOT}/expo/node_modules/.bin/expo`;
@@ -16,10 +17,10 @@ export const NEXT_TEMPLATE_DIR = "/home/node/cheatcode-next-template";
 export const EXPO_TEMPLATE_DIR = "/home/node/cheatcode-expo-template";
 
 export function projectLocalModulesDir(workspaceSlug: string): string {
-  return `${projectLocalRuntimeDir(workspaceSlug)}/node_modules`;
+  return `${projectLocalSourceDir(workspaceSlug)}/node_modules`;
 }
 
-export function projectLocalSourceDir(workspaceSlug: string): string {
+function projectLocalSourceDir(workspaceSlug: string): string {
   return `${projectLocalRuntimeDir(workspaceSlug)}/source`;
 }
 
@@ -31,7 +32,51 @@ export function projectLocalRuntimeDir(workspaceSlug: string): string {
   return `${PROJECT_LOCAL_ROOT}/${workspaceSlug}`;
 }
 
-/** Prevents package managers that place dependency trees on persistent FUSE. */
+export interface ProjectLocalRuntime {
+  localCwd: string;
+  localSourceDir: string;
+  runtimeDir: string;
+  workspaceDir: string;
+  workspaceSlug: string;
+}
+
+/** Maps a durable project cwd to the same path inside its disposable native-disk mirror. */
+export function resolveProjectLocalRuntime(cwd: string): ProjectLocalRuntime | null {
+  const match = WORKSPACE_PROJECT_PATH.exec(cwd);
+  const workspaceSlug = match?.[1];
+  if (!workspaceSlug) return null;
+  const suffix = match.groups?.["suffix"] ?? "";
+  const runtimeDir = projectLocalRuntimeDir(workspaceSlug);
+  const localSourceDir = projectLocalSourceDir(workspaceSlug);
+  return {
+    localCwd: `${localSourceDir}${suffix}`,
+    localSourceDir,
+    runtimeDir,
+    workspaceDir: `/workspace/${workspaceSlug}`,
+    workspaceSlug,
+  };
+}
+
+/** Returns the native-disk target only for a direct pnpm argv invocation. */
+export function projectPnpmRuntime(
+  cwd: string,
+  command: readonly string[],
+): ProjectLocalRuntime | null {
+  if (!PNPM_EXECUTABLES.has(basename(command[0]))) return null;
+  return resolveProjectLocalRuntime(cwd);
+}
+
+/** Rewrites explicit durable project paths before pnpm receives its native-disk cwd. */
+export function localizeProjectPackageCommand(
+  runtime: ProjectLocalRuntime,
+  command: readonly string[],
+): string[] {
+  return command.map((argument) =>
+    argument.replaceAll(runtime.workspaceDir, runtime.localSourceDir),
+  );
+}
+
+/** Prevents package-manager forms that cannot use the transactional native-disk runtime. */
 export function unsupportedProjectPackageManager(
   cwd: string,
   command: readonly string[],
@@ -39,10 +84,31 @@ export function unsupportedProjectPackageManager(
   if (!WORKSPACE_PROJECT_PATH.test(cwd)) return null;
   const executable = basename(command[0]);
   if (UNSUPPORTED_PACKAGE_MANAGERS.has(executable)) return executable;
+  const wrappedManager = wrappedPackageManager(executable, command.slice(1));
+  if (wrappedManager) return wrappedManager;
   if (!SHELL_EXECUTABLES.has(executable)) return null;
   const commandFlag = command.findIndex((argument) => /^-[a-z]*c[a-z]*$/u.test(argument));
   const shellCommand = commandFlag < 0 ? undefined : command[commandFlag + 1];
   return shellCommand?.match(SHELL_PACKAGE_MANAGER_COMMAND)?.[1] ?? null;
+}
+
+function wrappedPackageManager(executable: string, args: readonly string[]): string | null {
+  if (executable === "corepack") {
+    return packageManagerName(args.find((argument) => !argument.startsWith("-")));
+  }
+  if (executable !== "env" && executable !== "sudo") return null;
+  const candidate = args.find(
+    (argument) =>
+      argument !== "--" && !argument.startsWith("-") && !/^[A-Za-z_][A-Za-z0-9_]*=/u.test(argument),
+  );
+  return packageManagerName(candidate);
+}
+
+function packageManagerName(value: string | undefined): string | null {
+  const executable = basename(value);
+  return PNPM_EXECUTABLES.has(executable) || UNSUPPORTED_PACKAGE_MANAGERS.has(executable)
+    ? executable
+    : null;
 }
 
 /** Keeps generated dependencies and caches off persistent object-store FUSE. */
@@ -59,8 +125,7 @@ export function projectPackageEnvironment(
   const fallbackRuntime = preferredRuntime === "expo" ? "next" : "expo";
   return {
     ...requested,
-    CHEATCODE_NEXT_DIST_DIR:
-      requestedNextDistDir ?? `../../home/node/.cheatcode/projects/${workspaceSlug}/cache/next`,
+    CHEATCODE_NEXT_DIST_DIR: requestedNextDistDir ?? `${projectLocalCacheDir(workspaceSlug)}/next`,
     NODE_PATH: [
       modulesDir,
       `${APP_RUNTIME_ROOT}/${preferredRuntime}/node_modules`,
@@ -70,7 +135,6 @@ export function projectPackageEnvironment(
     ]
       .filter(Boolean)
       .join(":"),
-    npm_config_modules_dir: modulesDir,
   };
 }
 

--- a/apps/agent-worker/src/durable-objects/project-sandbox-processes.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-processes.ts
@@ -8,9 +8,12 @@ import type {
 import type { SandboxConsoleSnapshot } from "@cheatcode/types/api";
 import { sandboxExecProcessName } from "./project-sandbox-audit";
 import { WORKSPACE_DIR } from "./project-sandbox-content-support";
+import { localProjectProcessCommand, localSourceSyncCommand } from "./project-sandbox-local-source";
 import { recordSandboxUsageBestEffort } from "./project-sandbox-metering";
 import {
+  localizeProjectPackageCommand,
   projectPackageEnvironment,
+  projectPnpmRuntime,
   unsupportedProjectPackageManager,
 } from "./project-sandbox-package-runtime";
 import { createProcessControl, type ProcessControl } from "./project-sandbox-process-control";
@@ -225,6 +228,20 @@ async function executeCommand(
   const id = await runtime.ensureSandbox();
   const env = projectPackageEnvironment(input.cwd, input.env);
   try {
+    const packageRuntime = projectPnpmRuntime(input.cwd, input.command);
+    if (packageRuntime) {
+      const result = await executeProjectPnpmCommand(
+        runtime,
+        id,
+        input,
+        packageRuntime,
+        env,
+        startedAt,
+      );
+      await recordExecAudit(runtime, input.command, input.cwd, result, result.exitCode, startedAt);
+      await recordSandboxUsageBestEffort(await runtime.meteringContext());
+      return result;
+    }
     const completed = await runtime.client().execute(id, {
       command,
       cwd: input.cwd,
@@ -238,6 +255,80 @@ async function executeCommand(
   } catch (error) {
     throw runtime.toUpstreamError(error, "Sandbox command failed.");
   }
+}
+
+async function executeProjectPnpmCommand(
+  runtime: ProcessRuntime,
+  id: string,
+  input: ExecutableCommand,
+  packageRuntime: NonNullable<ReturnType<typeof projectPnpmRuntime>>,
+  env: Record<string, string> | undefined,
+  startedAt: number,
+): Promise<SandboxExecResult> {
+  const client = runtime.client();
+  const localizedCommand = localizeProjectPackageCommand(packageRuntime, input.command);
+  const prepare = await client.execute(id, {
+    command: localSourceSyncCommand(packageRuntime, "package-prepare"),
+    cwd: WORKSPACE_DIR,
+    timeout: 60,
+  });
+  if (prepare.exitCode !== 0) {
+    return localPackageRuntimeFailure(input.command, prepare, startedAt);
+  }
+  let completed: Awaited<ReturnType<typeof client.execute>>;
+  try {
+    completed = await client.execute(id, {
+      command: commandToShellString(localizedCommand),
+      cwd: packageRuntime.localCwd,
+      timeout: timeoutSeconds(input.timeoutMs),
+      ...(env === undefined ? {} : { env }),
+    });
+  } catch (error) {
+    await abortProjectPackageCommand(client, id, packageRuntime);
+    throw error;
+  }
+  if (completed.exitCode !== 0) {
+    await abortProjectPackageCommand(client, id, packageRuntime);
+    return execResult(commandToShellString(input.command), completed, startedAt);
+  }
+  const committed = await client.execute(id, {
+    command: localSourceSyncCommand(packageRuntime, "package-commit"),
+    cwd: WORKSPACE_DIR,
+    timeout: 60,
+  });
+  if (committed.exitCode !== 0) {
+    return localPackageRuntimeFailure(input.command, committed, startedAt);
+  }
+  return execResult(commandToShellString(input.command), completed, startedAt);
+}
+
+async function abortProjectPackageCommand(
+  client: ReturnType<ProcessRuntime["client"]>,
+  id: string,
+  packageRuntime: NonNullable<ReturnType<typeof projectPnpmRuntime>>,
+): Promise<void> {
+  await client
+    .execute(id, {
+      command: localSourceSyncCommand(packageRuntime, "package-abort"),
+      cwd: WORKSPACE_DIR,
+      timeout: 10,
+    })
+    .catch(() => undefined);
+}
+
+function localPackageRuntimeFailure(
+  command: readonly string[],
+  completed: { exitCode: number; result?: string | null | undefined },
+  startedAt: number,
+): SandboxExecResult {
+  return {
+    command: commandToShellString([...command]),
+    durationMs: Date.now() - startedAt,
+    exitCode: completed.exitCode || 74,
+    stderr: completed.result ?? "Could not synchronize the sandbox-local package runtime.",
+    stdout: "",
+    success: false,
+  };
 }
 
 function codeWithWorkingDirectory(
@@ -261,12 +352,20 @@ function packageManagerPolicyResult(
     command,
     durationMs: Date.now() - startedAt,
     exitCode: 64,
-    stderr:
-      `${manager} is disabled in persistent projects because it writes dependencies to object storage. ` +
-      "Use pnpm; dependencies are installed in the sandbox-local project runtime.",
+    stderr: packageManagerPolicyMessage(manager),
     stdout: "",
     success: false,
   };
+}
+
+function packageManagerPolicyMessage(manager: string): string {
+  if (manager === "pnpm" || manager === "pnpx") {
+    return `${manager} must be passed as direct command argv so Cheatcode can synchronize its sandbox-local package runtime.`;
+  }
+  return (
+    `${manager} is disabled in persistent projects because it writes dependencies to object storage. ` +
+    "Use pnpm directly; dependencies are installed in the sandbox-local project runtime."
+  );
 }
 
 function execResult(
@@ -328,7 +427,18 @@ async function startProcess(
   const sessionId = `cc-${name}`;
   await context.control.prepareProcessSlot(id, name, parsed);
   const cwd = parsed.cwd ?? WORKSPACE_DIR;
-  const rawCommand = commandToShellString(parsed.command);
+  const serializedCommand = commandToShellString(parsed.command);
+  const packageRuntime = projectPnpmRuntime(cwd, parsed.command);
+  const rawCommand = packageRuntime
+    ? commandToShellString([
+        "sh",
+        "-lc",
+        localProjectProcessCommand(
+          packageRuntime,
+          commandToShellString(localizeProjectPackageCommand(packageRuntime, parsed.command)),
+        ),
+      ])
+    : serializedCommand;
   const policy = processPolicy(parsed);
   const provisional = processRecordFromLaunch(parsed, policy, {
     cmdId: sessionId,
@@ -346,12 +456,17 @@ async function startProcess(
 function assertSupportedProjectPackageManager(cwd: string, command: readonly string[]): void {
   const manager = unsupportedProjectPackageManager(cwd, command);
   if (!manager) return;
+  const isPnpm = manager === "pnpm" || manager === "pnpx";
   throw new APIError(
     422,
     "sandbox_command_failed",
-    `${manager} is disabled in persistent projects. Use pnpm instead.`,
+    isPnpm
+      ? `${manager} must be passed as direct command argv.`
+      : `${manager} is disabled in persistent projects. Use pnpm instead.`,
     {
-      hint: "Use pnpm so dependency trees stay in the sandbox-local project runtime.",
+      hint: isPnpm
+        ? `Call ${manager} directly so its native-disk runtime can be synchronized safely.`
+        : "Use pnpm so dependency trees stay in the sandbox-local project runtime.",
       retriable: false,
     },
   );


### PR DESCRIPTION
## Why

A restored project could fail during preparation with EPERM futime because pnpm still executed from Daytona persistent object-store FUSE. The previous npm_config_modules_dir environment value is not a supported pnpm 11 modules-directory boundary, and moving node_modules alone does not stop pnpm from touching project state.

## What changed

- execute direct project pnpm and pnpx commands from the existing native-disk source mirror
- synchronize command-produced source changes back transactionally with optimistic conflict detection
- share one lock-aware source mirror between package commands and long-running preview processes
- reject shell-wrapped package managers because they cannot participate safely in the synchronization contract
- keep dependencies, Next cache, and build output off persistent FUSE
- document the package-runtime boundary

No database migration, environment change, or Daytona snapshot rebuild is required.

## Verification

- pnpm lint
- pnpm typecheck
- pnpm turbo build --force
- pnpm deadcode
- pnpm architecture:check
- pnpm turbo skills:build
- Python synchronization script syntax check
- local transaction check: successful source commit plus concurrent-write conflict preservation
- production sandbox reproduction confirmed pnpm fails on persistent FUSE and succeeds from the native-disk mirror

Production browser acceptance will run after the protected Cloudflare deployment reaches the exact merged main SHA.