### PR TITLE
chore(sandbox): promote verified runtime snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-82e9c9add1b1-31304224819",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-bccf2a8fc9b6-31308258885",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable Daytona runtime that contains the root-owned project source synchronizer required by the native-disk package and preview boundary.

## Snapshot provenance

- source commit: `bccf2a8fc9b603c670fd6bc43dd15d17a5221beb`
- build workflow: `31308258885`
- candidate: `cheatcode-sandbox-viewer-bundle-bccf2a8fc9b6-31308258885`
- image build, configuration/vulnerability/secret scans, runtime smoke tests, publication, and provider verification: passed

## Architecture effects

The Agent Worker will replace stale canonical sandbox containers on the next workspace operation while retaining each project's existing persistent-volume subpath.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `git diff --check`

All repository gates ran with Node 24.18.0 and pnpm 11.15.0.
