### PR TITLE
fix(agent): isolate analytics from workflow correctness

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -268,8 +268,12 @@ as every segment's logical timestamp. PostgreSQL publishes a run only when its u
 segment exists; retries compare each segment's JSONB, final marker, timestamp, and tenant
 identity. Oversized structured parts use lossless bounded fragment envelopes rather than
 truncation, and there is no transcript-length, step, token, or cost ceiling.
-Checkpointed tool steps emit `step_started`, `step_completed`, `tool_invoked`, and
-`skill_invoked` events independently of the live stream. If the last stream subscriber disconnects while a run is still
+Checkpointed tool steps emit one `tool_invoked` completion event and, when applicable, one
+`skill_invoked` event independently of the live stream. Model resolution is emitted on the initial
+selection and on a real fallback change, rather than once per model turn. The Workflow transcript
+and Cloudflare step history remain the source of truth for detailed step lifecycle debugging, while
+bounded Analytics Engine events cover product outcomes without coupling telemetry limits to run
+correctness. If the last stream subscriber disconnects while a run is still
 running, AgentRun emits `run_abandoned` for the funnel trail.
 
 Project deletion first fences project/thread mutations, refuses an active run, records a

--- a/apps/agent-worker/src/durable-objects/agent-run-workflow-runtime.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-workflow-runtime.ts
@@ -7,7 +7,6 @@ import {
 import {
   createLogger,
   emitErrorEvent,
-  emitUserEvent,
   readBoundedResponseJson,
   safeErrorTelemetry,
 } from "@cheatcode/observability";
@@ -423,12 +422,6 @@ async function generateWithCredential(input: {
     messages: input.messages,
     requestContext,
     runId: input.input.runId,
-  });
-  emitUserEvent(input.env, {
-    eventName: "run_model_resolved",
-    logicalModelId: input.primary.logicalModelId,
-    runId: input.input.runId,
-    userId: input.input.userId,
   });
   return WorkflowModelStepResultSchema.parse({
     input: input.input,

--- a/apps/agent-worker/src/durable-objects/agent-run-workflow.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-workflow.ts
@@ -294,7 +294,7 @@ async function executeToolWorkflowSteps(input: {
   const results: WorkflowToolStepResult[] = [];
   for (const [toolIndex, toolCall] of input.model.step.toolCalls.entries()) {
     const toolStepIndex = input.firstToolStepIndex + toolIndex;
-    await publishToolStart({ ...input, toolCall, toolIndex, toolStepIndex });
+    await publishToolStart({ ...input, toolCall, toolIndex });
     const result = await executeToolWorkflowStep({ ...input, state, toolCall, toolIndex });
     results.push(result);
     state = await publishToolStep(
@@ -316,22 +316,13 @@ async function publishToolStart(
   input: Parameters<typeof executeToolWorkflowSteps>[0] & {
     toolCall: WorkflowModelStepResult["step"]["toolCalls"][number];
     toolIndex: number;
-    toolStepIndex: number;
   },
 ): Promise<void> {
   await input.workflowStep.do(
     `publish tool start ${input.stepIndex}.${input.toolIndex}`,
     STATE_STEP,
-    async () => {
-      emitUserEvent(input.env, {
-        eventName: "step_started",
-        runId: input.payload.input.runId,
-        stepIdx: input.toolStepIndex,
-        stepType: "tool",
-        toolName: input.toolCall.toolName,
-        userId: input.payload.input.userId,
-      });
-      await appendWorkflowEvent(
+    () =>
+      appendWorkflowEvent(
         input.env,
         workflowCallback(input.payload, input.workflowInstanceId),
         `tool-start:${input.stepIndex}:${input.toolIndex}`,
@@ -340,8 +331,7 @@ async function publishToolStart(
           toolCallId: input.toolCall.toolCallId,
           toolName: input.toolCall.toolName,
         }),
-      );
-    },
+      ),
   );
 }
 
@@ -404,6 +394,14 @@ async function publishModelStep(
       "persist Workflow model",
     );
     await appendWorkflowEvent(env, callback, `model:${stepIndex}`, chunks);
+    if (state.selectedLogicalModelId !== model.logicalModelId) {
+      emitUserEvent(env, {
+        eventName: "run_model_resolved",
+        logicalModelId: model.logicalModelId,
+        runId: payload.input.runId,
+        userId: payload.input.userId,
+      });
+    }
   });
   return {
     ...state,
@@ -475,7 +473,6 @@ function emitToolCompletion(
     userId: payload.input.userId,
   } as const;
   emitUserEvent(env, { ...event, eventName: "tool_invoked" });
-  emitUserEvent(env, { ...event, eventName: "step_completed", stepType: "tool" });
   if (result.toolCall.toolName === "skill_invoke" && !result.error) {
     emitUserEvent(env, {
       durationMs: result.durationMs,

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -37,6 +37,11 @@ positions.
   consumes the stream
 - `emitAgentMetric`, `emitUserEvent`, `emitErrorEvent`, `emitPerformanceMetric`
 
+Analytics emitters are best-effort by contract: a missing binding, account
+quota, or per-invocation write allowance cannot fail the product operation that
+produced the telemetry. Callers therefore do not add local error handling or
+make correctness decisions from an Analytics Engine write.
+
 Error Analytics Engine rows intentionally contain only categorical metadata.
 Raw error messages and stack traces are never written to Analytics Engine, and
 the structured logger suppresses error-message, stack, SQL, parameter, body,

--- a/packages/observability/src/analytics.ts
+++ b/packages/observability/src/analytics.ts
@@ -228,11 +228,18 @@ export function emitPerformanceMetric(env: AnalyticsBindings, metric: Performanc
 }
 
 function writePoint(dataset: AnalyticsDataset | undefined, point: AnalyticsDataPoint): void {
-  dataset?.writeDataPoint({
-    indexes: sanitizeBlobs(point.indexes).slice(0, 1),
-    blobs: sanitizeBlobs(point.blobs).slice(0, 20),
-    doubles: sanitizeDoubles(point.doubles).slice(0, 20),
-  });
+  if (!dataset) return;
+  try {
+    dataset.writeDataPoint({
+      indexes: sanitizeBlobs(point.indexes).slice(0, 1),
+      blobs: sanitizeBlobs(point.blobs).slice(0, 20),
+      doubles: sanitizeDoubles(point.doubles).slice(0, 20),
+    });
+  } catch {
+    // Analytics is intentionally outside the product correctness boundary. In
+    // particular, a long-lived Workflow can outgrow Analytics Engine's
+    // per-invocation write allowance even though the user operation is healthy.
+  }
 }
 
 function sanitizeBlobs(values: (string | undefined)[] | undefined): string[] {


### PR DESCRIPTION
## Summary
- prevent Analytics Engine binding errors or quota exhaustion from failing product operations
- replace redundant per-tool lifecycle analytics with one completion event
- emit model-resolution analytics only for the initial selection and actual model changes

## Architecture
Analytics is now explicitly outside the product correctness boundary in the shared observability package. Agent Workflows retain durable step and transcript history for lifecycle debugging while Analytics Engine records compact product outcome events.

## Decisions Made
| Decision | Choice | Alternatives Considered | Reasoning |
|---|---|---|---|
| Analytics failures | Swallow binding exceptions at the shared emitter boundary | Catch at every call site | Every emitter is telemetry-only; the invariant belongs in one package and protects every Worker. |
| Tool telemetry | Keep `tool_invoked`; remove `step_started` and `step_completed` | Keep all three events | The Workflow and transcript already own step lifecycle truth; duplicate events consumed the 250-write invocation allowance. |
| Model attribution | Emit on selection changes | Emit every model turn | Attribution changes only on initial resolution or fallback, so per-turn rows added volume without information. |

## Edge Cases Handled
| Scenario | Handling |
|---|---|
| Analytics Engine per-invocation limit is exhausted | The user run continues and terminal state still persists. |
| Analytics binding is absent | Existing no-op behavior remains. |
| Model fallback changes the selected model | A new resolution event is emitted for the actual change. |
| Long tool-heavy run | Redundant lifecycle writes are removed; durable Workflow history remains complete. |

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- direct emitter simulation with an Analytics binding that throws a quota error
- production failure reproduced as `Analytics Engine write limit exceeded` after a 67-tool run
