### PR TITLE
fix: nest browser screenshots in tool activity

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -33,6 +33,11 @@ existence before minting a one-hour HMAC capability; the public signed download 
 streaming second hop. Expiring capabilities and internal R2 keys are never stored in transcripts or
 returned by artifact tools.
 
+Browser screenshots use the same crash-consistent R2 persistence but are classified as internal
+tool evidence. Their reserved filenames keep them out of project-file and slash-command catalogs,
+their stream part is linked to the exact browser tool call, and they do not claim the user's
+first-generated-deliverable activation event.
+
 The project file catalog merges uploaded-file metadata with the newest durable generated-output
 records without starting Daytona. Generated entries use an ID-backed
 `deliverables/<output-id>/<filename>` path, so duplicate names remain unambiguous. When a user

--- a/apps/agent-worker/src/durable-objects/agent-run-artifacts.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-artifacts.ts
@@ -15,10 +15,15 @@ import {
 } from "@cheatcode/observability";
 import type { ArtifactUploadInput, ArtifactUploadResult } from "@cheatcode/sandbox-contracts";
 import type { AgentRunId, ProjectId, ThreadId, UserId } from "@cheatcode/types";
-import { ArtifactKindSchema, GENERATED_OUTPUT_MAX_BYTES } from "@cheatcode/types/artifacts";
+import {
+  ArtifactExposureSchema,
+  ArtifactKindSchema,
+  GENERATED_OUTPUT_MAX_BYTES,
+  INTERNAL_OUTPUT_FILENAME_PREFIX,
+} from "@cheatcode/types/artifacts";
 import { closeDatabaseBestEffort } from "./db-close";
 
-const ARTIFACT_DIGEST_DOMAIN = "cheatcode:artifact-upload:v2";
+const ARTIFACT_DIGEST_DOMAIN = "cheatcode:artifact-upload:v3";
 const MAX_CONTENT_TYPE_LENGTH = 255;
 const VALID_CONTENT_TYPE = /^[a-z0-9][a-z0-9!#$&^_.+-]*\/[a-z0-9][a-z0-9!#$&^_.+-]*$/iu;
 
@@ -143,13 +148,16 @@ async function putAndFinalize(
   const finalized = await transaction((db) =>
     finalizeArtifactUpload(db, {
       ...prepared.identity,
+      claimFirstArtifact: artifact.exposure === "deliverable",
       createdAt,
       filename: prepared.filename,
       mimeType: artifact.contentType,
     }),
   );
   if (finalized.state === "committed") {
-    emitFirstArtifactEvent(env, input, prepared.outputId, finalized.isFirstForUser);
+    if (artifact.exposure === "deliverable") {
+      emitFirstArtifactEvent(env, input, prepared.outputId, finalized.isFirstForUser);
+    }
     return;
   }
   await env.R2_OUTPUTS.delete(prepared.r2Key);
@@ -180,6 +188,7 @@ async function writeArtifactObject(
   const stored = await env.R2_OUTPUTS.put(identity.r2Key, artifact.data, {
     customMetadata: {
       contentSha256: identity.contentSha256,
+      exposure: artifact.exposure,
       filename: identity.filename,
       kind: artifact.kind,
       outputId: identity.outputId,
@@ -214,6 +223,7 @@ function assertStoredArtifactObject(
     object.httpMetadata?.contentType !== artifact.contentType ||
     !metadata ||
     metadata["contentSha256"] !== identity.contentSha256 ||
+    metadata["exposure"] !== artifact.exposure ||
     metadata["filename"] !== identity.filename ||
     metadata["kind"] !== artifact.kind ||
     metadata["outputId"] !== identity.outputId ||
@@ -235,6 +245,7 @@ async function deterministicOutputId(
       ARTIFACT_DIGEST_DOMAIN,
       runId,
       artifact.kind,
+      artifact.exposure,
       artifact.contentType,
       filename,
       contentSha256,
@@ -306,6 +317,13 @@ function assertArtifactUpload(artifact: ArtifactUploadInput): void {
   }
   if (!ArtifactKindSchema.safeParse(artifact.kind).success) {
     throw invalidArtifact("Artifact kind is invalid");
+  }
+  if (!ArtifactExposureSchema.safeParse(artifact.exposure).success) {
+    throw invalidArtifact("Artifact exposure is invalid");
+  }
+  const usesInternalFilename = artifact.filename.startsWith(INTERNAL_OUTPUT_FILENAME_PREFIX);
+  if (usesInternalFilename !== (artifact.exposure === "internal")) {
+    throw invalidArtifact("Artifact filename does not match its exposure");
   }
 }
 

--- a/apps/agent-worker/src/durable-objects/agent-run-tool-ui.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-tool-ui.ts
@@ -3,7 +3,8 @@ import { TOOL_CAPABILITIES } from "@cheatcode/types/capabilities";
 import type { UIMessageChunk } from "ai";
 
 const SANDBOX_TOOL_NAMES = capabilityNameSet("usesSandbox");
-const ARTIFACT_TOOL_NAMES = capabilityNameSet("producesArtifact");
+const DELIVERABLE_TOOL_NAMES = artifactPresentationNameSet("deliverable");
+const TOOL_EVIDENCE_TOOL_NAMES = artifactPresentationNameSet("tool-evidence");
 
 interface AgentToolCallUiPayload {
   args?: unknown;
@@ -23,21 +24,22 @@ export function agentToolResultUiChunks(payload: AgentToolResultUiPayload): UIMe
     const skill = skillCreatedChunkFromResult(payload.result);
     return skill ? [skill] : [];
   }
-  if (isSandboxTool(payload)) {
-    const chunks = [sandboxStatusChunk("ready")];
-    if (isArtifactTool(payload)) {
-      const artifact = artifactChunkFromResult(payload.result);
-      if (artifact) {
-        chunks.push(artifact);
-      }
-    }
-    return chunks;
+  const chunks = isSandboxTool(payload) ? [sandboxStatusChunk("ready")] : [];
+  const output = toolOutputUiChunk(payload);
+  if (output) {
+    chunks.push(output);
   }
-  if (isArtifactTool(payload)) {
-    const artifact = artifactChunkFromResult(payload.result);
-    return artifact ? [artifact] : [];
+  return chunks;
+}
+
+function toolOutputUiChunk(payload: AgentToolResultUiPayload): UIMessageChunk | undefined {
+  if (isDeliverableTool(payload)) {
+    return artifactChunkFromResult(payload.result);
   }
-  return [];
+  if (isToolEvidenceTool(payload)) {
+    return toolEvidenceChunkFromResult(payload);
+  }
+  return undefined;
 }
 
 function skillCreatedChunkFromResult(result: unknown): UIMessageChunk | undefined {
@@ -151,8 +153,12 @@ function isSandboxTool(payload: { toolName: string }): boolean {
   return SANDBOX_TOOL_NAMES.has(payload.toolName);
 }
 
-function isArtifactTool(payload: { toolName: string }): boolean {
-  return ARTIFACT_TOOL_NAMES.has(payload.toolName);
+function isDeliverableTool(payload: { toolName: string }): boolean {
+  return DELIVERABLE_TOOL_NAMES.has(payload.toolName);
+}
+
+function isToolEvidenceTool(payload: { toolName: string }): boolean {
+  return TOOL_EVIDENCE_TOOL_NAMES.has(payload.toolName);
 }
 
 function artifactChunkFromResult(result: unknown): UIMessageChunk | undefined {
@@ -174,6 +180,38 @@ function artifactChunkFromResult(result: unknown): UIMessageChunk | undefined {
       mimeType,
       outputId,
       sizeBytes,
+    },
+  };
+}
+
+function toolEvidenceChunkFromResult(
+  payload: AgentToolResultUiPayload,
+): UIMessageChunk | undefined {
+  const artifact = artifactRecordFromResult(payload.result);
+  const outputId = stringField(artifact, "outputId");
+  const kind = artifactKind(artifact);
+  const mimeType = stringField(artifact, "mimeType");
+  const filename = stringField(artifact, "filename");
+  const sizeBytes = numberField(artifact, "sizeBytes");
+  if (
+    !outputId ||
+    kind !== "image" ||
+    !mimeType.startsWith("image/") ||
+    !filename ||
+    sizeBytes === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    type: "data-tool-evidence",
+    data: {
+      v: 1,
+      filename,
+      kind,
+      mimeType,
+      outputId,
+      sizeBytes,
+      toolCallId: payload.toolCallId,
     },
   };
 }
@@ -217,8 +255,18 @@ function artifactKind(record: Record<string, unknown>): ArtifactKind | undefined
   return parsed.success ? parsed.data : undefined;
 }
 
-function capabilityNameSet(flag: "producesArtifact" | "usesSandbox"): ReadonlySet<string> {
+function capabilityNameSet(flag: "usesSandbox"): ReadonlySet<string> {
   return new Set(
     TOOL_CAPABILITIES.filter((capability) => capability[flag]).map((capability) => capability.name),
+  );
+}
+
+function artifactPresentationNameSet(
+  presentation: "deliverable" | "tool-evidence",
+): ReadonlySet<string> {
+  return new Set(
+    TOOL_CAPABILITIES.filter((capability) => capability.artifactPresentation === presentation).map(
+      (capability) => capability.name,
+    ),
   );
 }

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -23,6 +23,10 @@ No image capability or object URL is persisted. Opening an image in Files switch
 workspace and asks the trusted code-server bridge to reveal the exact generated asset; an already
 visible Files panel selects a newly generated image without waking a closed sandbox.
 
+Browser screenshots are not Deliverables. A screenshot stream part carries the durable output
+identity plus its originating tool-call ID; the chat loads it only when the corresponding browser
+activity is expanded and offers an accessible full-size viewer inside that activity.
+
 Composer uploads always land in a writable project. If none is selected, choosing the first
 valid file creates and selects a general project named from that file. Files upload sequentially
 as raw bounded requests, show per-batch progress and actionable failures, and become durable

--- a/apps/web/src/components/chat/message-activity-model.ts
+++ b/apps/web/src/components/chat/message-activity-model.ts
@@ -17,10 +17,12 @@ const LARGE_TOOL_FIELDS = new Set([
 
 export type MessagePart = CheatcodeUIMessage["parts"][number];
 export type ToolPart = Extract<MessagePart, { type: "data-tool" }>;
+export type ToolEvidencePart = Extract<MessagePart, { type: "data-tool-evidence" }>;
+export type ToolActivityPart = ToolPart | ToolEvidencePart;
 export type ProjectCreatedPart = Extract<MessagePart, { type: "data-project-created" }>;
 type TextPart = Extract<MessagePart, { type: "text" }>;
 export type ActivityItem =
-  | { kind: "tools"; key: string; parts: ToolPart[] }
+  | { kind: "tools"; key: string; parts: ToolActivityPart[] }
   | { kind: "project-created"; key: string; part: ProjectCreatedPart }
   | { kind: "narration"; key: string; part: TextPart };
 type ToolVerbSpec = { verb: string; argKeys?: string[] };
@@ -77,7 +79,7 @@ const TOOL_VERBS: Record<string, ToolVerbSpec> = {
 
 export function buildActivityRows(parts: MessagePart[]): ActivityItem[] {
   const rows: ActivityItem[] = [];
-  let run: { parts: ToolPart[]; startIndex: number } | null = null;
+  let run: { parts: ToolActivityPart[]; startIndex: number } | null = null;
   const flush = () => {
     if (run) {
       rows.push({ kind: "tools", key: `tools:${run.startIndex}`, parts: run.parts });
@@ -85,7 +87,7 @@ export function buildActivityRows(parts: MessagePart[]): ActivityItem[] {
     }
   };
   parts.forEach((part, index) => {
-    if (isToolPart(part)) {
+    if (isToolActivityPart(part)) {
       run ??= { parts: [], startIndex: index };
       run.parts.push(part);
       return;
@@ -103,16 +105,26 @@ export function buildActivityRows(parts: MessagePart[]): ActivityItem[] {
   return rows;
 }
 
-export function collapseToolRuns(parts: ToolPart[]): { key: string; parts: ToolPart[] }[] {
-  const rows: { key: string; parts: ToolPart[] }[] = [];
+export function collapseToolRuns(
+  parts: ToolActivityPart[],
+): Array<{ evidence: ToolEvidencePart[]; key: string; parts: ToolPart[] }> {
+  const evidence = parts.filter(isToolEvidencePart);
+  const tools = parts.filter(isToolPart);
+  const rows: Array<{ evidence: ToolEvidencePart[]; key: string; parts: ToolPart[] }> = [];
   let index = 0;
-  while (index < parts.length) {
-    const type = parts[index]?.type;
+  while (index < tools.length) {
+    const type = tools[index]?.type;
     let end = index + 1;
-    while (end < parts.length && parts[end]?.type === type) {
+    while (end < tools.length && tools[end]?.type === type) {
       end += 1;
     }
-    rows.push({ key: `${type}:${index}`, parts: parts.slice(index, end) });
+    const toolParts = tools.slice(index, end);
+    const toolCallIds = new Set(toolParts.map((part) => part.data.toolCallId));
+    rows.push({
+      evidence: evidence.filter((part) => toolCallIds.has(part.data.toolCallId)),
+      key: `${type}:${index}`,
+      parts: toolParts,
+    });
     index = end;
   }
   return rows;
@@ -157,6 +169,14 @@ function humanizeToolName(name: string): string {
 
 export function isToolPart(part: MessagePart): part is ToolPart {
   return part.type === "data-tool";
+}
+
+export function isToolEvidencePart(part: MessagePart): part is ToolEvidencePart {
+  return part.type === "data-tool-evidence";
+}
+
+function isToolActivityPart(part: MessagePart): part is ToolActivityPart {
+  return isToolPart(part) || isToolEvidencePart(part);
 }
 
 function toolDetailSections(part: ToolPart): Array<Omit<ToolDetailSection, "key">> {

--- a/apps/web/src/components/chat/message-activity.tsx
+++ b/apps/web/src/components/chat/message-activity.tsx
@@ -11,8 +11,11 @@ import {
   isToolPart,
   type MessagePart,
   type ProjectCreatedPart,
+  type ToolActivityPart,
+  type ToolEvidencePart,
   type ToolPart,
 } from "@/components/chat/message-activity-model";
+import { ToolEvidenceImage } from "@/components/chat/message-tool-evidence";
 import { ChevronDown } from "@/components/ui";
 import { cn } from "@/lib/ui/cn";
 
@@ -116,18 +119,18 @@ export function ProjectCreatedActivity({ part }: { part: ProjectCreatedPart }) {
   );
 }
 
-export function ToolGroup({ parts }: { parts: ToolPart[] }) {
+export function ToolGroup({ parts }: { parts: ToolActivityPart[] }) {
   const rows = collapseToolRuns(parts);
   return (
     <div className="space-y-2">
       {rows.map((row) => (
-        <ToolRow key={row.key} parts={row.parts} />
+        <ToolRow evidence={row.evidence} key={row.key} parts={row.parts} />
       ))}
     </div>
   );
 }
 
-function ToolRow({ parts }: { parts: ToolPart[] }) {
+function ToolRow({ evidence, parts }: { evidence: ToolEvidencePart[]; parts: ToolPart[] }) {
   const [open, setOpen] = useState(false);
   const first = parts[0];
   if (!first) {
@@ -152,7 +155,7 @@ function ToolRow({ parts }: { parts: ToolPart[] }) {
           )}
         />
       </button>
-      {open ? <ToolDetails parts={parts} /> : null}
+      {open ? <ToolDetails evidence={evidence} parts={parts} /> : null}
     </div>
   );
 }
@@ -162,19 +165,26 @@ function toolRowLabel(description: { arg: string | null; verb: string }, extra: 
   return extra > 0 ? `${primary} (+${extra} more)` : primary;
 }
 
-function ToolDetails({ parts }: { parts: ToolPart[] }) {
+function ToolDetails({ evidence, parts }: { evidence: ToolEvidencePart[]; parts: ToolPart[] }) {
   const sections = buildToolDetailSections(parts);
+  const detailCount = sections.length + evidence.length;
   return (
     <div className="relative mt-0 ml-[5px] space-y-0 pt-1.5 pl-5">
       {sections.map((section, index) => (
         <ToolDetailCard
-          continued={index < sections.length - 1}
+          continued={index < detailCount - 1}
           isCommand={section.isCommand}
           key={section.key}
           label={section.label}
           scroll={section.scroll}
           value={section.value}
         />
+      ))}
+      {evidence.map((part, index) => (
+        <div className="relative pb-2 first:pt-1 last:pb-0" key={part.data.outputId}>
+          <TimelineConnector continued={sections.length + index < detailCount - 1} />
+          <ToolEvidenceImage data={part.data} />
+        </div>
       ))}
     </div>
   );

--- a/apps/web/src/components/chat/message-deliverables.tsx
+++ b/apps/web/src/components/chat/message-deliverables.tsx
@@ -2,10 +2,14 @@
 
 import { useAuth } from "@clerk/nextjs";
 import Image from "next/image";
-import { type RefObject, useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { formatBytes } from "@/components/chat/message-deliverable-model";
 import type { ArtifactData } from "@/components/chat/message-parts.types";
+import {
+  type OutputImagePreviewState,
+  useLazyOutputImagePreview,
+} from "@/components/chat/output-image-preview";
 import {
   Code,
   Download,
@@ -20,7 +24,7 @@ import {
   Video,
   X,
 } from "@/components/ui";
-import { createOutputDownloadUrl, loadOutputImagePreview } from "@/lib/api/outputs";
+import { createOutputDownloadUrl } from "@/lib/api/outputs";
 import { useAppStore } from "@/lib/store/app-store";
 import { cn } from "@/lib/ui/cn";
 
@@ -93,7 +97,7 @@ function ImageDeliverableCard({
   threadId: string;
 }) {
   const [isViewerOpen, setViewerOpen] = useState(false);
-  const preview = useLazyImagePreview(data, getToken);
+  const preview = useLazyOutputImagePreview(data, getToken);
   const openInFiles = useOpenImageInFiles(data, threadId, () => setViewerOpen(false));
   return (
     <div className="overflow-hidden rounded-[12px] border border-border bg-background">
@@ -123,13 +127,6 @@ function ImageDeliverableCard({
   );
 }
 
-interface ImagePreview {
-  hostRef: RefObject<HTMLDivElement | null>;
-  message: string | null;
-  status: "error" | "idle" | "loading" | "ready";
-  url: string | null;
-}
-
 function ImageThumbnail({
   data,
   onOpen,
@@ -137,7 +134,7 @@ function ImageThumbnail({
 }: {
   data: ArtifactData;
   onOpen: () => void;
-  preview: ImagePreview;
+  preview: OutputImagePreviewState;
 }) {
   return (
     <div
@@ -171,7 +168,10 @@ function ImageThumbnail({
   );
 }
 
-function ImagePreviewPlaceholder({ message, status }: Pick<ImagePreview, "message" | "status">) {
+function ImagePreviewPlaceholder({
+  message,
+  status,
+}: Pick<OutputImagePreviewState, "message" | "status">) {
   const isLoading = status === "idle" || status === "loading";
   return (
     <div
@@ -347,74 +347,6 @@ function useDeliverableDownload(
     }
   };
   return { isPreparing, start };
-}
-
-function useLazyImagePreview(
-  data: ArtifactData,
-  getToken: () => Promise<null | string>,
-): ImagePreview {
-  const hostRef = useRef<HTMLDivElement | null>(null);
-  const getTokenRef = useRef(getToken);
-  const isNearViewport = useNearViewport(hostRef);
-  const [preview, setPreview] = useState<Omit<ImagePreview, "hostRef">>({
-    message: null,
-    status: "idle",
-    url: null,
-  });
-  useEffect(() => {
-    getTokenRef.current = getToken;
-  }, [getToken]);
-  useEffect(() => {
-    if (!isNearViewport) return;
-    const controller = new AbortController();
-    let objectUrl: string | null = null;
-    setPreview({ message: null, status: "loading", url: null });
-    void loadOutputImagePreview(
-      () => getTokenRef.current(),
-      data.outputId,
-      data.sizeBytes,
-      controller.signal,
-    )
-      .then((blob) => {
-        objectUrl = URL.createObjectURL(blob);
-        setPreview({ message: null, status: "ready", url: objectUrl });
-      })
-      .catch((error: unknown) => {
-        if (controller.signal.aborted) return;
-        setPreview({
-          message: error instanceof Error ? error.message : "Preview unavailable",
-          status: "error",
-          url: null,
-        });
-      });
-    return () => {
-      controller.abort();
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
-    };
-  }, [data.outputId, data.sizeBytes, isNearViewport]);
-  return { ...preview, hostRef };
-}
-
-function useNearViewport(ref: RefObject<HTMLElement | null>): boolean {
-  const [isNear, setNear] = useState(false);
-  useEffect(() => {
-    const element = ref.current;
-    if (!element || typeof IntersectionObserver === "undefined") {
-      setNear(true);
-      return;
-    }
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry?.isIntersecting) return;
-        setNear(true);
-        observer.disconnect();
-      },
-      { rootMargin: "320px" },
-    );
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [ref]);
-  return isNear;
 }
 
 function useOpenImageInFiles(data: ArtifactData, threadId: string, afterOpen: () => void) {

--- a/apps/web/src/components/chat/message-parts.types.ts
+++ b/apps/web/src/components/chat/message-parts.types.ts
@@ -2,6 +2,7 @@ import type { CheatcodeUIMessage } from "@cheatcode/types";
 
 export type MessagePart = CheatcodeUIMessage["parts"][number];
 export type ArtifactData = Extract<MessagePart, { type: "data-artifact" }>["data"];
+export type ToolEvidenceData = Extract<MessagePart, { type: "data-tool-evidence" }>["data"];
 
 export type TimelineItem =
   | { kind: "activity"; key: string; parts: MessagePart[] }

--- a/apps/web/src/components/chat/message-timeline.ts
+++ b/apps/web/src/components/chat/message-timeline.ts
@@ -1,4 +1,4 @@
-import { isToolPart } from "@/components/chat/message-activity-model";
+import { isToolEvidencePart, isToolPart } from "@/components/chat/message-activity-model";
 import type { MessagePart, TimelineItem } from "@/components/chat/message-parts.types";
 
 interface PendingActivity {
@@ -88,7 +88,12 @@ function isNonEmptyText(
 }
 
 function isStepPart(part: MessagePart): boolean {
-  return part.type === "text" || part.type === "data-project-created" || isToolPart(part);
+  return (
+    part.type === "text" ||
+    part.type === "data-project-created" ||
+    isToolPart(part) ||
+    isToolEvidencePart(part)
+  );
 }
 
 function partKey(messageId: string, part: MessagePart, partIndex: number): string {

--- a/apps/web/src/components/chat/message-tool-evidence.tsx
+++ b/apps/web/src/components/chat/message-tool-evidence.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useAuth } from "@clerk/nextjs";
+import Image from "next/image";
+import { useId, useState } from "react";
+import type { ToolEvidenceData } from "@/components/chat/message-parts.types";
+import {
+  type OutputImagePreviewState,
+  useLazyOutputImagePreview,
+} from "@/components/chat/output-image-preview";
+import { Eye, Image as ImageIcon, Loader2, ModalShell, X } from "@/components/ui";
+import { cn } from "@/lib/ui/cn";
+
+export function ToolEvidenceImage({ data }: { data: ToolEvidenceData }) {
+  const { getToken } = useAuth();
+  const [isViewerOpen, setViewerOpen] = useState(false);
+  const titleId = useId();
+  const preview = useLazyOutputImagePreview(data, getToken);
+
+  return (
+    <div className="overflow-hidden rounded-[16px] border-2 border-border bg-background dark:border-[#252525] dark:bg-[#151515]">
+      <EvidenceThumbnail onOpen={() => setViewerOpen(true)} preview={preview} />
+      <EvidenceViewer
+        onClose={() => setViewerOpen(false)}
+        open={isViewerOpen}
+        titleId={titleId}
+        url={preview.url}
+      />
+    </div>
+  );
+}
+
+function EvidenceThumbnail({
+  onOpen,
+  preview,
+}: {
+  onOpen: () => void;
+  preview: OutputImagePreviewState;
+}) {
+  return (
+    <div
+      className="relative aspect-video w-full overflow-hidden bg-secondary"
+      ref={preview.hostRef}
+    >
+      {preview.url ? (
+        <button
+          aria-label="View captured browser screenshot"
+          className="group relative h-full w-full cursor-zoom-in focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+          onClick={onOpen}
+          type="button"
+        >
+          <Image
+            alt=""
+            className="object-contain transition-transform duration-200 ease-out group-hover:scale-[1.01] motion-reduce:transition-none"
+            fill
+            sizes="(max-width: 767px) 100vw, 520px"
+            src={preview.url}
+            unoptimized
+          />
+          <span className="absolute right-2 bottom-2 inline-flex h-8 items-center gap-1.5 rounded-full bg-black/70 px-2.5 font-medium text-[11px] text-white backdrop-blur-sm">
+            <Eye aria-hidden="true" className="h-3.5 w-3.5" />
+            View
+          </span>
+        </button>
+      ) : (
+        <EvidencePlaceholder message={preview.message} status={preview.status} />
+      )}
+    </div>
+  );
+}
+
+function EvidenceViewer({
+  onClose,
+  open,
+  titleId,
+  url,
+}: {
+  onClose: () => void;
+  open: boolean;
+  titleId: string;
+  url: string | null;
+}) {
+  return (
+    <ModalShell
+      className="h-[min(92dvh,960px)] max-w-[min(96vw,1280px)] overflow-hidden rounded-[18px]"
+      labelledBy={titleId}
+      onClose={onClose}
+      open={open}
+    >
+      <div className="flex h-full min-h-0 flex-col bg-background">
+        <EvidenceViewerHeader onClose={onClose} titleId={titleId} />
+        <div className="relative min-h-0 flex-1 bg-secondary/60">
+          {url ? (
+            <Image
+              alt="Browser screenshot captured by the agent"
+              className="object-contain"
+              fill
+              sizes="96vw"
+              src={url}
+              unoptimized
+            />
+          ) : null}
+        </div>
+      </div>
+    </ModalShell>
+  );
+}
+
+function EvidenceViewerHeader({ onClose, titleId }: { onClose: () => void; titleId: string }) {
+  return (
+    <div className="flex min-h-14 items-center gap-2 border-border border-b px-3 sm:px-4">
+      <h2 className="min-w-0 flex-1 truncate font-medium text-[13px]" id={titleId}>
+        Browser screenshot
+      </h2>
+      <button
+        aria-label="Close screenshot viewer"
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-fg-secondary hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={onClose}
+        type="button"
+      >
+        <X aria-hidden="true" className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+function EvidencePlaceholder({
+  message,
+  status,
+}: {
+  message: string | null;
+  status: "error" | "idle" | "loading" | "ready";
+}) {
+  const isLoading = status === "idle" || status === "loading";
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "flex h-full w-full flex-col items-center justify-center gap-2 p-5 text-center text-[12px] text-fg-secondary",
+        isLoading && "motion-safe:animate-pulse",
+      )}
+    >
+      {isLoading ? (
+        <Loader2 aria-hidden="true" className="h-5 w-5 animate-spin motion-reduce:animate-none" />
+      ) : (
+        <ImageIcon aria-hidden="true" className="h-5 w-5" />
+      )}
+      <span>{isLoading ? "Loading screenshot…" : (message ?? "Screenshot unavailable")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/output-image-preview.ts
+++ b/apps/web/src/components/chat/output-image-preview.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { type RefObject, useEffect, useRef, useState } from "react";
+import { loadOutputImagePreview } from "@/lib/api/outputs";
+
+export interface OutputImagePreviewState {
+  hostRef: RefObject<HTMLDivElement | null>;
+  message: string | null;
+  status: "error" | "idle" | "loading" | "ready";
+  url: string | null;
+}
+
+interface OutputImageIdentity {
+  outputId: string;
+  sizeBytes: number;
+}
+
+export function useLazyOutputImagePreview(
+  data: OutputImageIdentity,
+  getToken: () => Promise<null | string>,
+): OutputImagePreviewState {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const getTokenRef = useRef(getToken);
+  const isNearViewport = useNearViewport(hostRef);
+  const [preview, setPreview] = useState<Omit<OutputImagePreviewState, "hostRef">>({
+    message: null,
+    status: "idle",
+    url: null,
+  });
+
+  useEffect(() => {
+    getTokenRef.current = getToken;
+  }, [getToken]);
+
+  useEffect(() => {
+    if (!isNearViewport) return;
+    const controller = new AbortController();
+    let objectUrl: string | null = null;
+    setPreview({ message: null, status: "loading", url: null });
+    void loadOutputImagePreview(
+      () => getTokenRef.current(),
+      data.outputId,
+      data.sizeBytes,
+      controller.signal,
+    )
+      .then((blob) => {
+        objectUrl = URL.createObjectURL(blob);
+        setPreview({ message: null, status: "ready", url: objectUrl });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setPreview({
+          message: error instanceof Error ? error.message : "Preview unavailable",
+          status: "error",
+          url: null,
+        });
+      });
+    return () => {
+      controller.abort();
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [data.outputId, data.sizeBytes, isNearViewport]);
+
+  return { ...preview, hostRef };
+}
+
+function useNearViewport(ref: RefObject<HTMLElement | null>): boolean {
+  const [isNear, setNear] = useState(false);
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || typeof IntersectionObserver === "undefined") {
+      setNear(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+        setNear(true);
+        observer.disconnect();
+      },
+      { rootMargin: "320px" },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+  return isNear;
+}

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -13,8 +13,10 @@ Mastra agents, tool registry, and workflow entrypoints.
 The tool and agent registries are statically constrained by the lightweight
 capability catalog in `@cheatcode/types`. A runtime capability cannot be added
 or removed without updating that shared contract. Sandbox-status and
-artifact-stream routing derive from the catalog's exact runtime traits, so a
-tool's registry and stream behavior move together.
+artifact-stream routing derive from the catalog's exact runtime traits.
+Artifact presentation is explicit: finished user files are Deliverables, while
+browser screenshots are durable tool evidence rendered inside the browser
+action that captured them.
 Sandbox and artifact capabilities cross tool-domain boundaries only through
 `@cheatcode/sandbox-contracts`; concrete code-tool executors remain in
 `src/tools/code` and are available to deployables through the

--- a/packages/agent-core/src/mastra/tool-defs/browser-tools.ts
+++ b/packages/agent-core/src/mastra/tool-defs/browser-tools.ts
@@ -69,7 +69,7 @@ export const mastraBrowserExtract = createTool({
 export const mastraBrowserScreenshot = createTool({
   id: "browser_screenshot",
   description:
-    "Capture the current sandbox browser page as a PNG artifact. The result contains bounded artifact metadata and a download URL, never inline base64 image data.",
+    "Capture the current sandbox browser page as durable visual evidence for this tool step. The screenshot appears inside the expanded browser action and is not a user deliverable.",
   inputSchema: BrowserScreenshotInputSchema,
   outputSchema: BrowserActionsOutputSchema,
   execute: async (input, context) =>

--- a/packages/agent-core/src/tools/browser/actions.ts
+++ b/packages/agent-core/src/tools/browser/actions.ts
@@ -1,5 +1,6 @@
 import { APIError } from "@cheatcode/observability";
 import type { ArtifactUploadResult } from "@cheatcode/sandbox-contracts";
+import { INTERNAL_OUTPUT_FILENAME_PREFIX } from "@cheatcode/types/artifacts";
 import { z } from "zod";
 import type { BrowserRuntimeContext } from "./runtime";
 import { BrowserRuntimeContextSchema } from "./runtime";
@@ -574,7 +575,8 @@ async function normalizeBrowserActionResult(
   const artifact = await runtimeContext.artifacts.put({
     contentType: "image/png",
     data: bytes,
-    filename: `browser-screenshot-${index + 1}-${crypto.randomUUID()}.png`,
+    exposure: "internal",
+    filename: `${INTERNAL_OUTPUT_FILENAME_PREFIX}browser-screenshot-${index + 1}-${crypto.randomUUID()}.png`,
     kind: "image",
   });
   return {

--- a/packages/agent-core/src/tools/data/chart.ts
+++ b/packages/agent-core/src/tools/data/chart.ts
@@ -23,6 +23,7 @@ export async function executeDataChart(
     ? await runtimeContext.artifacts.put({
         contentType: "image/svg+xml",
         data: utf8ToBytes(svg),
+        exposure: "deliverable",
         filename,
         kind: "image",
       })

--- a/packages/agent-core/src/tools/docs/execute.ts
+++ b/packages/agent-core/src/tools/docs/execute.ts
@@ -191,6 +191,7 @@ async function runArtifactScript(
     return await runtimeContext.artifacts.put({
       contentType: generated.mimeType,
       data: base64ToBytes(generated.base64),
+      exposure: "deliverable",
       filename: generated.filename,
       kind,
     });

--- a/packages/agent-core/src/tools/media/execute.ts
+++ b/packages/agent-core/src/tools/media/execute.ts
@@ -300,6 +300,7 @@ async function storeArtifact(
   return runtime.artifacts.put({
     contentType: media.mimeType,
     data: media.bytes,
+    exposure: "deliverable",
     filename,
     kind: type,
   });

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -41,7 +41,9 @@ The schema modules under `src/schema/` define:
 - security-sensitive audit records
 
 Files are not stored in Postgres. `v2_generated_outputs` contains only ownership,
-mime, filename, and R2 object identity.
+mime, filename, and R2 object identity. The reserved `.cheatcode-internal-` filename
+namespace identifies agent UI evidence that remains downloadable by exact authorized
+identity but is excluded from project Deliverables and file references.
 
 ## Invariants
 

--- a/packages/db/src/artifact-upload-intents.ts
+++ b/packages/db/src/artifact-upload-intents.ts
@@ -32,6 +32,7 @@ export interface QuiescedArtifactUploadIntentRecord extends ArtifactUploadIntent
 }
 
 export interface FinalizeArtifactUploadInput extends ArtifactUploadIdentity {
+  claimFirstArtifact: boolean;
   createdAt: Date;
   filename: string;
   mimeType: string;
@@ -140,11 +141,13 @@ async function commitGeneratedOutput(
     r2Key: input.r2Key,
     userId: input.userId,
   });
-  const first = await db
-    .update(users)
-    .set({ firstArtifactAt: input.createdAt })
-    .where(and(eq(users.id, input.userId), isNull(users.firstArtifactAt)))
-    .returning({ id: users.id });
+  const first = input.claimFirstArtifact
+    ? await db
+        .update(users)
+        .set({ firstArtifactAt: input.createdAt })
+        .where(and(eq(users.id, input.userId), isNull(users.firstArtifactAt)))
+        .returning({ id: users.id })
+    : [];
   const removed = await db
     .delete(artifactUploadIntents)
     .where(

--- a/packages/db/src/outputs.ts
+++ b/packages/db/src/outputs.ts
@@ -1,5 +1,6 @@
 import type { ProjectId, UserId } from "@cheatcode/types";
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { INTERNAL_OUTPUT_FILENAME_PREFIX } from "@cheatcode/types/artifacts";
+import { and, desc, eq, inArray, notLike } from "drizzle-orm";
 import type { Database } from "./client";
 import { agentRuns, generatedOutputs, threads } from "./schema";
 
@@ -70,7 +71,11 @@ export async function listReferencedProjectGeneratedOutputs(
 }
 
 function projectOutputScope(projectId: ProjectId, userId: UserId) {
-  return and(eq(generatedOutputs.userId, userId), eq(threads.projectId, projectId));
+  return and(
+    eq(generatedOutputs.userId, userId),
+    eq(threads.projectId, projectId),
+    notLike(generatedOutputs.filename, `${INTERNAL_OUTPUT_FILENAME_PREFIX}%`),
+  );
 }
 
 function runOwnsOutput() {

--- a/packages/sandbox-contracts/README.md
+++ b/packages/sandbox-contracts/README.md
@@ -19,6 +19,11 @@ objects are not cloned or stripped during validation.
 - `CodeRuntimeContext`, `CodeRuntimeContextFor`, and `CodeRuntimeContextSchema`
 - `EnvironmentVariablesSchema`
 
+Artifact uploads declare their exposure. `deliverable` outputs are user files;
+`internal` outputs use the reserved `.cheatcode-internal-` filename namespace and
+support durable agent UI such as browser-step screenshots without entering the
+project's Deliverables catalog.
+
 Long-running processes require a caller-owned stable `processId`. The sandbox uses that identity
 as an idempotency slot for replacement, inspection, cleanup, and bounded record reaping; anonymous
 fire-and-forget process records are not part of the contract.

--- a/packages/sandbox-contracts/src/runtime.ts
+++ b/packages/sandbox-contracts/src/runtime.ts
@@ -1,6 +1,6 @@
 import type { SandboxExecResultBase } from "@cheatcode/types";
 import type { SandboxFileEntry } from "@cheatcode/types/api";
-import type { ArtifactKind } from "@cheatcode/types/artifacts";
+import type { ArtifactExposure, ArtifactKind } from "@cheatcode/types/artifacts";
 import { z } from "zod";
 
 export type { ArtifactKind } from "@cheatcode/types/artifacts";
@@ -190,6 +190,7 @@ export interface SandboxLike {
 export interface ArtifactUploadInput {
   contentType: string;
   data: Uint8Array;
+  exposure: ArtifactExposure;
   filename: string;
   kind: ArtifactKind;
 }

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -308,10 +308,10 @@ const ToolDomainSchema = z.enum([
 ]);
 
 const ToolSummarySchema = z.strictObject({
+  artifactPresentation: z.enum(["deliverable", "none", "tool-evidence"]),
   description: z.string(),
   domain: ToolDomainSchema,
   name: z.string(),
-  producesArtifact: z.boolean(),
   usesSandbox: z.boolean(),
 });
 

--- a/packages/types/src/artifacts.ts
+++ b/packages/types/src/artifacts.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 /** Exact artifact kinds that can be stored, streamed, and rendered by V2. */
 const ARTIFACT_KINDS = ["docx", "image", "pdf", "slide", "video", "xlsx"] as const;
 
+/** Reserved filename namespace for durable outputs that support the agent UI, not the user. */
+export const INTERNAL_OUTPUT_FILENAME_PREFIX = ".cheatcode-internal-";
+
+export const ArtifactExposureSchema = z.enum(["deliverable", "internal"]);
+
 /** One generated deliverable stays bounded for Worker memory and sandbox transfer safety. */
 export const GENERATED_OUTPUT_MAX_BYTES = 32 * 1024 * 1024;
 
@@ -20,6 +25,7 @@ export const OutputDownloadUrlResponseSchema = z.strictObject({
 });
 
 export type ArtifactKind = z.infer<typeof ArtifactKindSchema>;
+export type ArtifactExposure = z.infer<typeof ArtifactExposureSchema>;
 export type OutputDownloadUrlResponse = z.infer<typeof OutputDownloadUrlResponseSchema>;
 
 function isSafeOutputDownloadUrl(value: string): boolean {

--- a/packages/types/src/capabilities.ts
+++ b/packages/types/src/capabilities.ts
@@ -1,8 +1,9 @@
 import type { ToolSummary } from "./api";
 
-const REMOTE_TOOL = { producesArtifact: false, usesSandbox: false } as const;
-const SANDBOX_TOOL = { producesArtifact: false, usesSandbox: true } as const;
-const ARTIFACT_TOOL = { producesArtifact: true, usesSandbox: true } as const;
+const REMOTE_TOOL = { artifactPresentation: "none", usesSandbox: false } as const;
+const SANDBOX_TOOL = { artifactPresentation: "none", usesSandbox: true } as const;
+const DELIVERABLE_TOOL = { artifactPresentation: "deliverable", usesSandbox: true } as const;
+const TOOL_EVIDENCE_TOOL = { artifactPresentation: "tool-evidence", usesSandbox: true } as const;
 
 /**
  * Public tool discovery contract. The Mastra runtime registry is statically
@@ -14,7 +15,12 @@ export const TOOL_CAPABILITIES = [
   tool("browser", "browser_extract", "Extract structured browser data.", SANDBOX_TOOL),
   tool("browser", "browser_observe", "Observe current browser state.", SANDBOX_TOOL),
   tool("browser", "browser_open", "Open a URL in the sandbox browser.", SANDBOX_TOOL),
-  tool("browser", "browser_screenshot", "Capture a sandbox browser screenshot.", ARTIFACT_TOOL),
+  tool(
+    "browser",
+    "browser_screenshot",
+    "Capture a sandbox browser screenshot.",
+    TOOL_EVIDENCE_TOOL,
+  ),
   tool("code", "fs_delete", "Delete workspace files or directories.", SANDBOX_TOOL),
   tool("code", "fs_list", "List project sandbox files.", SANDBOX_TOOL),
   tool("code", "fs_read", "Read a file from the project sandbox.", SANDBOX_TOOL),
@@ -35,17 +41,17 @@ export const TOOL_CAPABILITIES = [
   tool("code", "shell_start_process", "Start a long-running sandbox process.", SANDBOX_TOOL),
   tool("code", "shell_terminal", "Run a short terminal-style command.", SANDBOX_TOOL),
   tool("data", "data_analyze_csv", "Profile and summarize CSV data.", REMOTE_TOOL),
-  tool("data", "data_chart", "Render an accessible SVG chart artifact.", ARTIFACT_TOOL),
+  tool("data", "data_chart", "Render an accessible SVG chart artifact.", DELIVERABLE_TOOL),
   tool("data", "data_scrape_to_csv", "Normalize extracted records to CSV.", REMOTE_TOOL),
-  tool("docs", "docs_generate_docx", "Generate a signed DOCX artifact.", ARTIFACT_TOOL),
-  tool("docs", "docs_generate_pdf", "Generate a signed PDF artifact.", ARTIFACT_TOOL),
-  tool("docs", "docs_generate_slides", "Generate a signed PPTX artifact.", ARTIFACT_TOOL),
-  tool("docs", "docs_generate_xlsx", "Generate a signed XLSX artifact.", ARTIFACT_TOOL),
+  tool("docs", "docs_generate_docx", "Generate a signed DOCX artifact.", DELIVERABLE_TOOL),
+  tool("docs", "docs_generate_pdf", "Generate a signed PDF artifact.", DELIVERABLE_TOOL),
+  tool("docs", "docs_generate_slides", "Generate a signed PPTX artifact.", DELIVERABLE_TOOL),
+  tool("docs", "docs_generate_xlsx", "Generate a signed XLSX artifact.", DELIVERABLE_TOOL),
   tool(
     "data",
     "generate_or_edit_media",
     "Generate or edit an image or video artifact.",
-    ARTIFACT_TOOL,
+    DELIVERABLE_TOOL,
   ),
   tool(
     "integrations",
@@ -66,13 +72,13 @@ export const TOOL_CAPABILITIES = [
     "research",
     "research_deep",
     "Run deep research and generate a cited PDF report.",
-    ARTIFACT_TOOL,
+    DELIVERABLE_TOOL,
   ),
   tool(
     "research",
     "research_fanout",
     "Run deep research fan-out and generate a cited PDF report.",
-    ARTIFACT_TOOL,
+    DELIVERABLE_TOOL,
   ),
   tool("research", "search_company", "Search company intel with Exa.", REMOTE_TOOL),
   tool("research", "search_web", "Search the web with Exa.", REMOTE_TOOL),
@@ -102,7 +108,7 @@ function tool<
   domain: Domain,
   name: Name,
   description: Description,
-  runtime: Pick<ToolSummary, "producesArtifact" | "usesSandbox">,
+  runtime: Pick<ToolSummary, "artifactPresentation" | "usesSandbox">,
 ) {
   return { description, domain, name, ...runtime };
 }

--- a/packages/types/src/ui-message.ts
+++ b/packages/types/src/ui-message.ts
@@ -85,6 +85,16 @@ const ToolDataSchema = z.strictObject({
   toolName: z.string().min(1),
 });
 
+const ToolEvidenceDataSchema = z.strictObject({
+  v: z.literal(1),
+  filename: z.string().min(1),
+  kind: z.literal("image"),
+  mimeType: z.string().startsWith("image/"),
+  outputId: OutputIdSchema,
+  sizeBytes: z.number().int().positive(),
+  toolCallId: z.string().min(1),
+});
+
 const ErrorDataSchema = z.strictObject({
   v: z.literal(1),
   code: z.string().min(1),
@@ -121,6 +131,7 @@ export const CHEATCODE_DATA_SCHEMAS = {
   seq: SeqDataSchema,
   "task-status": TaskStatusDataSchema,
   tool: ToolDataSchema,
+  "tool-evidence": ToolEvidenceDataSchema,
   "transcript-fragment": TranscriptFragmentDataSchema,
 } as const;
 
@@ -151,6 +162,7 @@ export const MessagePartSchema = z.discriminatedUnion("type", [
   dataMessagePartSchema("skill-created"),
   dataMessagePartSchema("task-status"),
   dataMessagePartSchema("tool"),
+  dataMessagePartSchema("tool-evidence"),
   dataMessagePartSchema("transcript-fragment"),
 ]);
 


### PR DESCRIPTION
## Summary
- Treat browser screenshots as internal evidence for the browser action that created them.
- Keep screenshots durable and authenticated without exposing them as chat deliverables or `/` project files.
- Preserve existing deliverable behavior for documents, media, charts, and research reports.

## Architecture
The capability registry now declares an explicit artifact presentation: `none`, `deliverable`, or `tool-evidence`. Browser screenshots are stored through the existing crash-consistent R2/output path with an internal exposure and reserved filename namespace. The stream emits a typed `data-tool-evidence` part linked to the exact tool-call ID, and the web app renders that image only inside the corresponding expanded activity row.

## Decisions Made
| Decision | Choice | Alternatives considered | Reasoning |
|---|---|---|---|
| Screenshot classification | First-class tool evidence | Generic deliverable; ephemeral inline bytes | Matches user intent while retaining durable, authenticated image loading. |
| Persistence | Existing R2/output index with internal exposure | New table; transient stream payload | Reuses proven crash consistency and avoids storing large base64 data in Durable Objects. |
| Project visibility | Reserved internal namespace filtered at query boundary | UI-only filename filtering | Keeps internal outputs out of both `/` and project catalogs at the authoritative data boundary. |
| Historical behavior | No legacy rewrite | Filename-based compatibility shim | This is a clean forward contract without heuristics or legacy branches. |

## Edge Cases Handled
- Internal screenshots cannot use deliverable filenames, and deliverables cannot use the internal namespace.
- Internal evidence cannot claim a user’s first generated artifact.
- Evidence is associated by exact tool-call ID, including grouped activity rows.
- Preview loading remains lazy, authenticated, size-bounded, abortable, and object URLs are revoked.
- Exact authorized output lookup still supports the nested viewer while project listings exclude internal evidence.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- Runtime stream check: browser screenshot -> `data-tool-evidence`; PDF -> `data-artifact`
- UI model check: evidence attaches to the matching browser screenshot tool-call ID

## Production acceptance plan
- Trigger a fresh browser screenshot in the existing production chat.
- Confirm no screenshot Deliverables card or `/` project-file entry appears.
- Expand `Captured a screenshot` and verify the nested preview and full-size viewer.
- Inspect production console and deployment status.