### PR TITLE
chore: promote resilient sandbox snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-bccf2a8fc9b6-31308258885",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-aa11272d1e87-31325857995",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Summary
- Promote the immutable Daytona snapshot built from merged commit `aa11272d1e873d51e45b76bc52d130fa71397bfe`.
- Put the content-addressed source synchronizer and crash-safe package transaction into production sandboxes.

## Candidate
- Snapshot: `cheatcode-sandbox-viewer-bundle-aa11272d1e87-31325857995`
- Build workflow: [31325857995](https://github.com/cheatcode-ai/cheatcode/actions/runs/31325857995)
- Provider retries: `0`

## Verification
- [x] Immutable image build
- [x] Trivy configuration, vulnerability, and secret scans
- [x] Full bundled-runtime smoke test
- [x] Daytona publication and active-state verification
- [x] `pnpm lint`
- [x] Agent Worker typecheck and production dry-run build
- [x] `pnpm architecture:check`
- [ ] Production browser QA after merge and Worker deployment

## Decision
The snapshot pin is reviewed separately from implementation so production cannot reference an image until that exact image has passed scanning, smoke testing, and Daytona active-state verification.
