### PR TITLE
fix(sandbox): preserve healthy previews across follow-ups

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -209,7 +209,14 @@ Agent-worker owns the custom-skill capacity decision and applies it inside the d
 per-user locked catalog transaction before inserting a new skill.
 
 Managed processes use required stable IDs and a maximum of 32 live metadata slots per user
-sandbox. Reusing an ID atomically replaces that slot. At capacity, ProjectSandbox reconciles the
+sandbox. Callers can explicitly reuse a matching healthy slot or relaunch its persisted command
+after a cold sandbox start; the default remains atomic replacement. The comparison uses the command,
+policy, port, working directory, and a one-way environment digest, so request-scoped environment
+values are neither persisted nor ignored. Follow-up web app-builder runs opt into reuse and
+therefore keep a healthy preview and its build cache alive until an actual configuration change
+requires replacement; Expo retains replacement semantics because its signed launch environment is
+ephemeral and its post-edit file-map must be rebuilt.
+At capacity, ProjectSandbox reconciles the
 bounded record set against Daytona, removes missing or completed sessions and their port state,
 and rejects a new distinct slot only when all 32 remain live.
 App-preview identity and port allocation derive from the canonical project workspace root, while

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -159,10 +159,6 @@ export async function runAppBuilder(options: RunAppBuilderOptions): Promise<AppB
   const { input, logger, sandbox } = options;
   throwIfRunCanceled(options.abortSignal);
   const workspace = await resolveAppWorkspace(sandbox, input, logger);
-  // Stop only THIS project's dev server before rebuilding — other projects in the per-user sandbox
-  // keep running (Cheatcode parity: every project's dev server persists on its own port).
-  await stopProjectPreview(sandbox, logger, workspace.slot);
-  throwIfRunCanceled(options.abortSignal);
   const workspaceOptions: WorkspaceOptions = { ...options, workspace };
   // Marker/.git gate runs FIRST: an imported repo (any framework shape) must
   // never fall back into the destructive reset + re-clone scaffold path on a
@@ -200,7 +196,9 @@ async function runTemplateAppBuilder(
   }
   await prepareTemplateWorkspace(options);
   throwIfRunCanceled(options.abortSignal);
-  await clearBuildCache(sandbox, workspace.dir, workspace.mobile);
+  if (shouldBootstrap) {
+    await clearBuildCache(sandbox, workspace.dir, workspace.mobile);
+  }
   throwIfRunCanceled(options.abortSignal);
   await startTemplatePreview(options);
   return { agentContextNote: templateContextNote(workspace) };
@@ -267,9 +265,9 @@ async function startTemplatePreview(options: WorkspaceOptions): Promise<void> {
 // the same reason the Next.js path force-polls). So its in-memory file-map keeps bundling the
 // scaffold even after the counter lands on disk, and a browser hard-refresh just re-bundles from
 // that stale map. Restarting the dev server once the edit stream completes makes a fresh Metro
-// process re-crawl the workspace and bundle the finished app. startProcess reuses this project's
-// dev-server slot (it kills the old process + frees its port), so the restart is transparent to
-// the authenticated preview wake path. Mobile only — web/Next.js hot-reloads via polling.
+// process re-crawl the workspace and bundle the finished app. This call deliberately replaces the
+// project's stable dev-server slot; the authenticated preview wake path keeps the same port.
+// Mobile only — web/Next.js hot-reloads via polling.
 export async function restartMobilePreview(
   options: Pick<RunAppBuilderOptions, "append" | "input" | "logger" | "sandbox" | "setRunStage">,
 ): Promise<void> {
@@ -612,6 +610,7 @@ async function startAppBuilderDevServer(
       isMobile: false,
       name: workspace.slot,
       port: workspace.port,
+      shouldReuseMatchingProcess: true,
       timeoutMs: 180_000,
     },
     { sandbox, workspaceDir: workspace.dir, workspaceSlug: workspace.slug },
@@ -723,19 +722,4 @@ async function clearBuildCache(
     },
     { sandbox },
   );
-}
-
-async function stopProjectPreview(
-  sandbox: ProjectSandboxStub,
-  logger: AgentRunLogger,
-  slot: string,
-): Promise<void> {
-  try {
-    await sandbox.killProcess({ processId: slot });
-    logger.info("sandbox_project_preview_stopped", { slot });
-  } catch (error) {
-    logger.warn("sandbox_process_stop_failed", {
-      error,
-    });
-  }
 }

--- a/apps/agent-worker/src/durable-objects/project-sandbox-process-support.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-process-support.ts
@@ -22,6 +22,11 @@ export const ProcessRecordSchema = z.strictObject({
     .regex(/^[A-Za-z0-9][A-Za-z0-9._:-]*$/u),
   cmdId: z.string(),
   command: z.string(),
+  environmentSha256: z
+    .string()
+    .length(64)
+    .regex(/^[0-9a-f]+$/u)
+    .optional(),
   port: z.number().optional(),
   isMobile: z.boolean().optional(),
   keepAliveTimeoutMs: z.number().int().nonnegative().optional(),
@@ -92,7 +97,7 @@ export function assertValidProcessStart(input: ParsedProcessStartInput): void {
 export function processRecordFromLaunch(
   input: ParsedProcessStartInput,
   policy: ProcessPolicy,
-  launch: Pick<ProcessRecord, "cmdId" | "command" | "cwd" | "sessionId">,
+  launch: Pick<ProcessRecord, "cmdId" | "command" | "cwd" | "environmentSha256" | "sessionId">,
 ): ProcessRecord {
   return {
     ...launch,

--- a/apps/agent-worker/src/durable-objects/project-sandbox-processes.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-processes.ts
@@ -373,7 +373,6 @@ async function startProcess(
   const id = await context.runtime.ensureSandbox();
   const name = parsed.processId;
   const sessionId = `cc-${name}`;
-  await context.control.prepareProcessSlot(id, name, parsed);
   const cwd = parsed.cwd ?? WORKSPACE_DIR;
   const serializedCommand = commandToShellString(parsed.command);
   const packageRuntime = projectPnpmRuntime(cwd, parsed.command);
@@ -387,18 +386,95 @@ async function startProcess(
         ),
       ])
     : serializedCommand;
+  const requestedEnvironment = projectPackageEnvironment(cwd, parsed.env);
   const policy = processPolicy(parsed);
+  const environmentDigest = parsed.shouldReuseMatchingProcess
+    ? await environmentSha256(requestedEnvironment)
+    : undefined;
   const provisional = processRecordFromLaunch(parsed, policy, {
     cmdId: sessionId,
     command: rawCommand,
     cwd,
+    ...(environmentDigest ? { environmentSha256: environmentDigest } : {}),
     sessionId,
   });
+  const reused = await reuseMatchingProcess(context, id, name, parsed, provisional, parsed.env);
+  if (reused) {
+    await recordSandboxUsageBestEffort(await context.runtime.meteringContext());
+    return processResult(reused, name);
+  }
+  await context.control.prepareProcessSlot(id, name, parsed);
   await context.control.persistProcessOwnershipIntent(name, provisional);
-  const record = await launchProcess(context, id, name, sessionId, parsed, provisional);
+  const record = await launchProcess(
+    context,
+    id,
+    name,
+    sessionId,
+    parsed,
+    provisional,
+    requestedEnvironment,
+  );
   await context.control.persistStartedProcess(id, name, record, parsed.waitForPort);
   await recordSandboxUsageBestEffort(await context.runtime.meteringContext());
+  return processResult(record, name);
+}
+
+async function reuseMatchingProcess(
+  context: ProcessContext,
+  id: string,
+  name: string,
+  input: ParsedProcessStartInput,
+  candidate: ProcessRecord,
+  requestedEnvironment: Record<string, string> | undefined,
+): Promise<ProcessRecord | null> {
+  if (input.shouldReuseMatchingProcess !== true || input.stdin !== undefined) return null;
+  const existing = await context.control.processRecord(name);
+  if (!existing || !hasSameLaunchIntent(existing, candidate) || existing.port === undefined) {
+    return null;
+  }
+  if (await context.control.isPortAlive(id, existing.port)) return existing;
+  const relaunched = await context.control.relaunchDevServer(
+    id,
+    name,
+    existing,
+    requestedEnvironment,
+  );
+  await context.control.waitForPort(
+    id,
+    existing.port,
+    input.waitForPort?.path,
+    input.waitForPort?.timeoutMs,
+    { cmdId: relaunched.cmdId, sessionId: relaunched.sessionId },
+  );
+  return relaunched;
+}
+
+function hasSameLaunchIntent(existing: ProcessRecord, candidate: ProcessRecord): boolean {
+  return (
+    existing.command === candidate.command &&
+    existing.cwd === candidate.cwd &&
+    existing.environmentSha256 === candidate.environmentSha256 &&
+    existing.isMobile === candidate.isMobile &&
+    existing.keepAliveTimeoutMs === candidate.keepAliveTimeoutMs &&
+    existing.maxRestarts === candidate.maxRestarts &&
+    existing.port === candidate.port &&
+    existing.restartOnFailure === candidate.restartOnFailure
+  );
+}
+
+function processResult(record: ProcessRecord, name: string): SandboxProcessResult {
   return { command: record.command, id: name, status: "running" };
+}
+
+async function environmentSha256(
+  environment: Record<string, string> | undefined,
+): Promise<string | undefined> {
+  if (!environment) return undefined;
+  const canonical = JSON.stringify(
+    Object.entries(environment).sort(([left], [right]) => left.localeCompare(right)),
+  );
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function assertSupportedProjectPackageManager(cwd: string, command: readonly string[]): void {
@@ -435,6 +511,7 @@ async function launchProcess(
   sessionId: string,
   input: ParsedProcessStartInput,
   provisional: ProcessRecord,
+  environment: Record<string, string> | undefined,
 ): Promise<ProcessRecord> {
   try {
     const execution = await context.control.launchSessionProcess(
@@ -443,7 +520,7 @@ async function launchProcess(
       name,
       provisional.cwd,
       supervisedProcessCommand(provisional.command, provisional),
-      projectPackageEnvironment(provisional.cwd, input.env),
+      environment,
       input.stdin,
     );
     return { ...provisional, cmdId: execution.cmdId ?? sessionId };

--- a/apps/agent-worker/src/durable-objects/project-sandbox-runtime.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-runtime.ts
@@ -56,6 +56,7 @@ export const ProjectStartProcessInputSchema = z.strictObject({
   maxRestarts: z.number().int().min(0).max(25).optional(),
   processId: ProcessIdSchema,
   restartOnFailure: z.boolean().optional(),
+  shouldReuseMatchingProcess: z.boolean().optional(),
   waitForPort: z
     .strictObject({
       port: z.number().int().positive().max(65_535),

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -36,8 +36,10 @@ actions remain scoped to the user's active account, and secret-bearing input is
 validated before execution. Deterministic prepare/execute boundaries keep dynamic
 ports and Git destinations stable between resolution and execution. The managed
 preview tool owns Computer-visible dev servers, remaps a requested port to the
-project's allocated port when necessary, and is distinct from generic background
-process tools so idle recovery always has a canonical process record.
+project’s allocated port when necessary, and is distinct from generic background
+process tools so idle recovery always has a canonical process record. Web app-builder preparation
+opts into matching-process reuse to avoid taking down a healthy preview on every follow-up; Expo
+retains replacement semantics for its ephemeral signed launch environment and post-edit restart.
 Browser-only runs use the account sandbox without materializing a persistent project;
 workspace-backed file, shell, document, chart, or artifact work resolves the thread's
 project lazily when durable project storage is actually needed. Code tools expose `/workspace`

--- a/packages/agent-core/src/tools/code/preview.ts
+++ b/packages/agent-core/src/tools/code/preview.ts
@@ -28,6 +28,7 @@ const StartDevServerInputSchema = z.strictObject({
   name: z.string().min(1).max(100).default("app-preview"),
   port: z.number().int().positive().max(65_535).default(5173),
   restartOnFailure: z.boolean().default(true),
+  shouldReuseMatchingProcess: z.boolean().default(false),
   timeoutMs: z.number().int().positive().max(600_000).default(120_000),
 });
 
@@ -97,6 +98,7 @@ export async function prepareStartDevServer(
       maxRestarts: parsedInput.maxRestarts,
       processId: `${APP_PREVIEW_SLOT_PREFIX}${slug}`,
       restartOnFailure: parsedInput.restartOnFailure,
+      shouldReuseMatchingProcess: parsedInput.shouldReuseMatchingProcess,
       timeoutMs: parsedInput.timeoutMs,
       waitForPort: { port, timeoutMs: parsedInput.timeoutMs },
     },

--- a/packages/sandbox-contracts/README.md
+++ b/packages/sandbox-contracts/README.md
@@ -26,7 +26,10 @@ project's Deliverables catalog.
 
 Long-running processes require a caller-owned stable `processId`. The sandbox uses that identity
 as an idempotency slot for replacement, inspection, cleanup, and bounded record reaping; anonymous
-fire-and-forget process records are not part of the contract.
+fire-and-forget process records are not part of the contract. Replacement remains the default;
+callers that set `shouldReuseMatchingProcess` ask the implementation to retain a healthy matching
+launch or relaunch it after a cold sandbox start. This opt-in fingerprints the effective environment
+without retaining its values, so it is reserved for caller-owned, non-secret process configuration.
 Project-backed `CodeRuntimeContext` values carry both the canonical `workspaceDir` and the explicit
 `workspaceSlug`. Process ownership uses the slug even when the command runs from a nested directory.
 Project preview ports have separate allocate and read capabilities so browser

--- a/packages/sandbox-contracts/src/runtime.ts
+++ b/packages/sandbox-contracts/src/runtime.ts
@@ -127,6 +127,8 @@ export interface SandboxStartProcessInput extends SandboxExecInput {
   /** Stable idempotency slot used to replace, inspect, and reap this process. */
   processId: string;
   restartOnFailure?: boolean;
+  /** Reuse a healthy process, or relaunch it after a cold start, when its safe launch intent matches. */
+  shouldReuseMatchingProcess?: boolean;
   waitForPort?: {
     path?: string;
     port: number;


### PR DESCRIPTION
## Why

App-builder preparation unconditionally deleted the project preview before every follow-up. If any later preparation or model step failed, the last healthy preview record was already gone, leaving the Browser tab with no recoverable preview and forcing unnecessary dependency/cache work.

## What changed

- remove unconditional preview teardown and preserve build caches on existing workspaces
- add an explicit opt-in process contract for reusing an identical healthy launch or relaunching it after a cold sandbox start
- compare command, cwd, policy, port, mobile mode, and a non-secret effective-environment digest before reuse
- keep atomic replacement as the default for generic processes and Expo, whose signed environment and post-edit file map require a restart
- document the lifecycle contract at the sandbox, tool, and worker boundaries

## Architecture

The provider-neutral sandbox contract now exposes `shouldReuseMatchingProcess`. Only the web app-builder preparation path opts in. Durable process records keep only a SHA-256 launch-environment fingerprint; environment values remain request-scoped and are not persisted. No database, migration, deployment-topology, or provider changes are required.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`

Production browser QA will run after the Cloudflare deployment so warm reuse, cold relaunch, preview recovery, and Morph FastApply are exercised against the real stack.