### PR TITLE
fix(sandbox): launch previews through trusted runtime

### DIFF
--- a/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
+++ b/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
@@ -1,5 +1,4 @@
-import { shellQuote } from "../sandbox-support";
-import { localPnpmProjectProcessCommand } from "./project-sandbox-local-source";
+import { localProjectProcessCommand } from "./project-sandbox-local-source";
 import {
   NEXT_RUNTIME_BIN,
   NEXT_TEMPLATE_DIR,
@@ -26,8 +25,6 @@ export function localNextPreviewCommand(input: LocalPreviewCommandInput): string
     "0.0.0.0",
     "--port",
     String(input.port),
-  ]
-    .map(shellQuote)
-    .join(" ");
-  return ["sh", "-lc", localPnpmProjectProcessCommand(runtime, nextCommand, NEXT_TEMPLATE_DIR)];
+  ];
+  return localProjectProcessCommand(runtime, nextCommand, NEXT_TEMPLATE_DIR);
 }

--- a/apps/agent-worker/src/durable-objects/project-sandbox-local-source.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-local-source.ts
@@ -11,16 +11,6 @@ function runtimeStatePaths(runtime: ProjectLocalRuntime): {
   };
 }
 
-function localSourceSyncCommand(
-  runtime: ProjectLocalRuntime,
-  mode: "preview-loop" | "preview-once",
-): string {
-  const { lockPath } = runtimeStatePaths(runtime);
-  return [LOCAL_SOURCE_SYNC_BINARY, mode, runtime.workspaceDir, runtime.localSourceDir, lockPath]
-    .map(shellQuote)
-    .join(" ");
-}
-
 /** Runs pnpm and commits its source changes while holding one crash-safe OS lock. */
 export function localPackageCommand(
   runtime: ProjectLocalRuntime,
@@ -41,54 +31,22 @@ export function localPackageCommand(
     .join(" ");
 }
 
-/** Runs a long-lived package script on native disk while durable source changes keep flowing in. */
-function localProjectProcessCommand(
+/** Runs a long-lived project process on native disk while durable source changes keep flowing in. */
+export function localProjectProcessCommand(
   runtime: ProjectLocalRuntime,
-  rawCommand: string,
-  prepareCommand?: string,
-): string {
-  const syncOnce = localSourceSyncCommand(runtime, "preview-once");
-  const syncLoop = localSourceSyncCommand(runtime, "preview-loop");
-  return [
-    `${syncOnce} || exit $?`,
-    `cd ${shellQuote(runtime.localCwd)} || exit $?`,
-    ...(prepareCommand ? [`${prepareCommand} || exit $?`] : []),
-    `${syncLoop} &`,
-    "sync_pid=$!",
-    `${rawCommand} &`,
-    "app_pid=$!",
-    'terminate() { kill -TERM "$app_pid" "$sync_pid" 2>/dev/null || true; }',
-    "trap terminate HUP INT TERM",
-    'wait "$app_pid"',
-    "status=$?",
-    'kill "$sync_pid" 2>/dev/null || true',
-    'wait "$sync_pid" 2>/dev/null || true',
-    'exit "$status"',
-  ].join("\n");
-}
-
-/** Reconstructs a disposable pnpm tree before a persisted process starts in a new container. */
-export function localPnpmProjectProcessCommand(
-  runtime: ProjectLocalRuntime,
-  rawCommand: string,
+  command: readonly string[],
   dependencyTemplateDir?: string,
-): string {
-  return localProjectProcessCommand(
-    runtime,
-    rawCommand,
-    restorePnpmDependenciesCommand(dependencyTemplateDir),
-  );
-}
-
-function restorePnpmDependenciesCommand(dependencyTemplateDir?: string): string {
-  const templateMatch = dependencyTemplateDir
-    ? `(cmp -s package.json ${shellQuote(`${dependencyTemplateDir}/package.json`)} && ` +
-      `cmp -s pnpm-lock.yaml ${shellQuote(`${dependencyTemplateDir}/pnpm-lock.yaml`)})`
-    : "false";
-  const install =
-    "if [ -f pnpm-lock.yaml ]; then " +
-    "pnpm install --frozen-lockfile --offline || " +
-    "pnpm install --frozen-lockfile --prefer-offline --network-concurrency 4; " +
-    "else pnpm install --prefer-offline --network-concurrency 4; fi";
-  return `if [ -f package.json ] && ! ${templateMatch}; then ` + `${install}; fi`;
+): string[] {
+  const { lockPath } = runtimeStatePaths(runtime);
+  return [
+    LOCAL_SOURCE_SYNC_BINARY,
+    "preview-run",
+    runtime.workspaceDir,
+    runtime.localSourceDir,
+    lockPath,
+    runtime.localCwd,
+    dependencyTemplateDir ?? "-",
+    "--",
+    ...command,
+  ];
 }

--- a/apps/agent-worker/src/durable-objects/project-sandbox-processes.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-processes.ts
@@ -8,10 +8,7 @@ import type {
 import type { SandboxConsoleSnapshot } from "@cheatcode/types/api";
 import { sandboxExecProcessName } from "./project-sandbox-audit";
 import { WORKSPACE_DIR } from "./project-sandbox-content-support";
-import {
-  localPackageCommand,
-  localPnpmProjectProcessCommand,
-} from "./project-sandbox-local-source";
+import { localPackageCommand, localProjectProcessCommand } from "./project-sandbox-local-source";
 import { recordSandboxUsageBestEffort } from "./project-sandbox-metering";
 import {
   localizeProjectPackageCommand,
@@ -374,18 +371,14 @@ async function startProcess(
   const name = parsed.processId;
   const sessionId = `cc-${name}`;
   const cwd = parsed.cwd ?? WORKSPACE_DIR;
-  const serializedCommand = commandToShellString(parsed.command);
   const packageRuntime = projectPnpmRuntime(cwd, parsed.command);
-  const rawCommand = packageRuntime
-    ? commandToShellString([
-        "sh",
-        "-lc",
-        localPnpmProjectProcessCommand(
-          packageRuntime,
-          commandToShellString(localizeProjectPackageCommand(packageRuntime, parsed.command)),
-        ),
-      ])
-    : serializedCommand;
+  const processCommand = packageRuntime
+    ? localProjectProcessCommand(
+        packageRuntime,
+        localizeProjectPackageCommand(packageRuntime, parsed.command),
+      )
+    : parsed.command;
+  const rawCommand = commandToShellString(processCommand);
   const requestedEnvironment = projectPackageEnvironment(cwd, parsed.env);
   const policy = processPolicy(parsed);
   const environmentDigest = parsed.shouldReuseMatchingProcess

--- a/infra/containers/sandbox/README.md
+++ b/infra/containers/sandbox/README.md
@@ -102,7 +102,11 @@ command instead of transporting executable source through sandbox command argume
 It uses content hashes and atomic replacement across the FUSE/native-disk boundary.
 Direct pnpm invocations execute inside one `flock`-guarded transaction; process death
 releases that lock automatically, and successful source changes commit only after a
-three-way conflict check against the durable tree.
+three-way conflict check against the durable tree. Long-lived previews invoke the same helper as
+direct argv: it synchronizes source, restores dependencies under the project lock, supervises the
+native-disk app and sync-loop children, and forwards termination signals. The Worker therefore does
+not transport an executable shell wrapper or make trusted bootstrap commands indistinguishable from
+model-supplied shell input.
 
 Open VSX currently publishes Parquet Viewer 3.1.0 with vulnerable Thrift and WebSocket
 runtimes. The image keeps the extension feature but replaces those two runtime packages

--- a/infra/containers/sandbox/scripts/project-source-sync.py
+++ b/infra/containers/sandbox/scripts/project-source-sync.py
@@ -5,6 +5,7 @@ import fcntl
 import hashlib
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -189,10 +190,7 @@ def commit_local_changes(durable_root, local_root, baseline):
 
 
 def package_run(source, target, lock_path, local_cwd, command):
-    normalized_target = os.path.realpath(target)
-    normalized_cwd = os.path.realpath(local_cwd)
-    if os.path.commonpath([normalized_target, normalized_cwd]) != normalized_target:
-        raise ValueError("package cwd must be inside the local project mirror")
+    validate_local_cwd(target, local_cwd)
     with open_lock(lock_path) as lock:
         fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
         sync_directory(source, target)
@@ -208,6 +206,108 @@ def package_run(source, target, lock_path, local_cwd, command):
     return 0
 
 
+def validate_local_cwd(target, local_cwd):
+    normalized_target = os.path.realpath(target)
+    normalized_cwd = os.path.realpath(local_cwd)
+    if os.path.commonpath([normalized_target, normalized_cwd]) != normalized_target:
+        raise ValueError("package cwd must be inside the local project mirror")
+
+
+def files_equal(left, right):
+    return (
+        os.path.isfile(left)
+        and os.path.isfile(right)
+        and os.path.getsize(left) == os.path.getsize(right)
+        and file_digest(left) == file_digest(right)
+    )
+
+
+def restore_pnpm_dependencies(local_cwd, dependency_template):
+    package_path = os.path.join(local_cwd, "package.json")
+    lock_path = os.path.join(local_cwd, "pnpm-lock.yaml")
+    if not os.path.isfile(package_path):
+        return 0
+    if dependency_template and files_equal(
+        package_path, os.path.join(dependency_template, "package.json")
+    ) and files_equal(lock_path, os.path.join(dependency_template, "pnpm-lock.yaml")):
+        return 0
+    common = ["install", "--prefer-offline", "--network-concurrency", "4"]
+    if not os.path.isfile(lock_path):
+        return subprocess.run(["pnpm", *common], cwd=local_cwd, check=False).returncode
+    offline = subprocess.run(
+        ["pnpm", "install", "--frozen-lockfile", "--offline"],
+        cwd=local_cwd,
+        check=False,
+    )
+    if offline.returncode == 0:
+        return 0
+    return subprocess.run(
+        ["pnpm", "install", "--frozen-lockfile", *common[1:]],
+        cwd=local_cwd,
+        check=False,
+    ).returncode
+
+
+def stop_process(process):
+    if process and process.poll() is None:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            process.terminate()
+
+
+def reap_process(process):
+    if not process:
+        return
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            process.kill()
+        process.wait()
+
+
+def preview_run(source, target, lock_path, local_cwd, dependency_template, command):
+    validate_local_cwd(target, local_cwd)
+    if not command:
+        raise ValueError("preview-run requires an app command")
+    with open_lock(lock_path) as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        sync_directory(source, target)
+        dependency_status = restore_pnpm_dependencies(local_cwd, dependency_template)
+        if dependency_status != 0:
+            return dependency_status
+
+    sync_process = subprocess.Popen(
+        [sys.executable, os.path.realpath(__file__), "preview-loop", source, target, lock_path],
+        start_new_session=True,
+    )
+    app_process = None
+    previous_handlers = {}
+
+    def terminate_children(_signum=None, _frame=None):
+        stop_process(app_process)
+        stop_process(sync_process)
+
+    try:
+        for signal_number in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+            previous_handlers[signal_number] = signal.signal(signal_number, terminate_children)
+        app_process = subprocess.Popen(command, cwd=local_cwd, start_new_session=True)
+        return app_process.wait()
+    finally:
+        terminate_children()
+        reap_process(app_process)
+        reap_process(sync_process)
+        for signal_number, handler in previous_handlers.items():
+            signal.signal(signal_number, handler)
+
+
 def main():
     if len(sys.argv) < 5:
         raise ValueError("missing local source synchronization arguments")
@@ -219,6 +319,20 @@ def main():
         if len(sys.argv) < 8 or sys.argv[6] != "--":
             raise ValueError("package-run requires a cwd and argv after --")
         raise SystemExit(package_run(source, target, lock_path, sys.argv[5], sys.argv[7:]))
+    if mode == "preview-run":
+        if len(sys.argv) < 9 or sys.argv[7] != "--":
+            raise ValueError("preview-run requires a cwd, dependency template, and argv after --")
+        dependency_template = None if sys.argv[6] == "-" else sys.argv[6]
+        raise SystemExit(
+            preview_run(
+                source,
+                target,
+                lock_path,
+                sys.argv[5],
+                dependency_template,
+                sys.argv[8:],
+            )
+        )
     raise ValueError("unknown local source synchronization mode")
 
 


### PR DESCRIPTION
## Why

Production preview preparation failed on every retry with `pnpm must be passed as direct command argv`. Dependency rehydration had wrapped trusted preview bootstrap work in `sh -lc`, so the sandbox command guard correctly treated it like an unsafe model-supplied package-manager command.

## What changed

- add a snapshot-resident `preview-run` mode to the project source runtime
- pass the runtime as direct argv from the Worker
- keep source synchronization, dependency restoration, app supervision, and signal forwarding inside that trusted boundary
- preserve the strict direct-argv package-manager guard for model commands
- document the launcher ownership boundary

## Architecture and rollout

The Worker now depends on the matching sandbox image containing `preview-run`. After this PR merges, a protected sandbox snapshot must be built and pinned before deploying the Worker. No compatibility path is added because this is a clean implementation.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- Python syntax compilation
- launcher normal-completion test
- launcher signal/process-group cleanup test
- `git diff --check`

Local container build was omitted because the local Docker daemon is unavailable. The protected AMD64 snapshot workflow performs the authoritative image build and scan before promotion.

Production QA will run against the same existing chat after the new snapshot is built, pinned, and deployed.