### PR TITLE
chore(sandbox): promote trusted preview snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-aa11272d1e87-31325857995",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-8399723f56e1-31363645724",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable sandbox image containing the trusted direct-argv preview launcher merged in #204. The Worker and sandbox runtime must switch together so production never references a launcher mode missing from the selected snapshot.

## Change

Pin `DAYTONA_SANDBOX_SNAPSHOT` to:

`cheatcode-sandbox-viewer-bundle-8399723f56e1-31363645724`

Provenance:

- source commit: `8399723f56e150ae31aeb69362814253d88eb285`
- snapshot workflow: [31363645724](https://github.com/cheatcode-ai/cheatcode/actions/runs/31363645724)
- Daytona state: active

## Verification

The protected snapshot workflow passed:

- exact-main static-check provenance guard
- AMD64 image build
- Trivy configuration, vulnerability, and secret scans
- runtime smoke tests
- Daytona publication and immutable-candidate verification

Local checks:

- `pnpm --filter @cheatcode/agent-worker typecheck`
- `git diff --check`

After merge, Cloudflare will be deployed from the pinned main commit and the existing production chat will be tested for cold recovery, preview rendering, process reuse, and natural/explicit FastApply edits.