### PR TITLE
fix: renew preview capabilities before user navigation

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -39,6 +39,11 @@ does not create or wake Daytona merely because the user opens it.
 Computer preview wakeups rotate the preview session and reload the visible iframe
 once after an actual sandbox/process recovery. Silent capability rotation keeps the
 live iframe mounted so application state is preserved during ordinary use.
+Every user-requested preview navigation—reload, path entry, Back, or opening the
+preview externally—first acquires a fresh one-minute handoff from the authenticated
+wake boundary. The action proceeds only after renewal, so the client never reuses
+the expired handoff embedded in an older preview URL. Concurrent renewal requests
+share one in-flight wake operation.
 Fresh app-builder projects keep the animated Cheatcode mark visible while the internal starter
 scaffold boots and the model generates the requested app. The persisted `app-preview-status`
 stream part reveals the iframe only when generated content is ready, and an iframe-load guard keeps

--- a/apps/web/src/components/preview/preview-path-input.tsx
+++ b/apps/web/src/components/preview/preview-path-input.tsx
@@ -1,12 +1,25 @@
 "use client";
 
+import { useState } from "react";
 import { toast } from "sonner";
 import { normalizePreviewPath, previewOrigin } from "@/components/preview/url-bar";
 import { useAppStore } from "@/lib/store/app-store";
 
-export function PreviewPathInput({ previewUrl }: { previewUrl: string | null }) {
+export function PreviewPathInput({
+  onAuthorizeNavigation,
+  previewUrl,
+}: {
+  onAuthorizeNavigation?: () => Promise<boolean>;
+  previewUrl: string | null;
+}) {
   const previewPath = useAppStore((state) => state.previewPath);
   const navigatePreviewPath = useAppStore((state) => state.navigatePreviewPath);
+  const { commitPath, isNavigating } = usePreviewPathCommit({
+    navigatePreviewPath,
+    onAuthorizeNavigation,
+    previewPath,
+    previewUrl,
+  });
   if (!previewUrl) {
     return (
       <div className="min-w-0 flex-1 truncate text-center font-medium text-[13px] text-placeholder">
@@ -14,29 +27,52 @@ export function PreviewPathInput({ previewUrl }: { previewUrl: string | null }) 
       </div>
     );
   }
-  const commitPath = (raw: string) => {
-    const next = normalizePreviewPath(raw, previewUrl);
-    if (next === null) {
-      toast.error("Preview can only navigate within the sandbox origin");
-    } else {
-      navigatePreviewPath(next);
-    }
-  };
   return (
     <input
       aria-label={`Preview path on ${previewOrigin(previewUrl)}`}
+      aria-busy={isNavigating}
       className="min-w-0 flex-1 bg-transparent text-center font-medium text-[14px] text-fg-secondary outline-none placeholder:text-placeholder"
       defaultValue={previewPath}
+      disabled={isNavigating}
       key={previewPath}
-      onBlur={(event) => commitPath(event.currentTarget.value)}
+      onBlur={(event) => void commitPath(event.currentTarget)}
       onKeyDown={(event) => {
-        if (event.key === "Enter") {
-          commitPath(event.currentTarget.value);
-          event.currentTarget.blur();
-        }
+        if (event.key === "Enter") event.currentTarget.blur();
       }}
       placeholder="/"
       spellCheck={false}
     />
   );
+}
+
+function usePreviewPathCommit(input: {
+  navigatePreviewPath: (path: string) => void;
+  onAuthorizeNavigation: (() => Promise<boolean>) | undefined;
+  previewPath: string;
+  previewUrl: string | null;
+}) {
+  const [isNavigating, setIsNavigating] = useState(false);
+  const commitPath = async (element: HTMLInputElement) => {
+    if (isNavigating || !input.previewUrl) return;
+    const next = normalizePreviewPath(element.value, input.previewUrl);
+    if (next === null) {
+      toast.error("Preview can only navigate within the sandbox origin");
+      element.value = input.previewPath;
+      return;
+    }
+    if (next === input.previewPath) return;
+    setIsNavigating(true);
+    try {
+      const isAuthorized = await input.onAuthorizeNavigation?.();
+      if (!isAuthorized) {
+        toast.error("Preview access couldn't be refreshed. Try again.");
+        element.value = input.previewPath;
+        return;
+      }
+      input.navigatePreviewPath(next);
+    } finally {
+      setIsNavigating(false);
+    }
+  };
+  return { commitPath, isNavigating };
 }

--- a/apps/web/src/components/preview/preview-protocol.ts
+++ b/apps/web/src/components/preview/preview-protocol.ts
@@ -1,0 +1,1 @@
+export const PREVIEW_TOKEN_QUERY = "__cc_pt";

--- a/apps/web/src/components/preview/preview-session.tsx
+++ b/apps/web/src/components/preview/preview-session.tsx
@@ -2,9 +2,9 @@
 
 import { PREVIEW_HOSTNAME } from "@cheatcode/env/web";
 import { useEffect, useState } from "react";
+import { PREVIEW_TOKEN_QUERY } from "@/components/preview/preview-protocol";
 
 const PREVIEW_SESSION_PATH = "/.well-known/cheatcode-preview-session";
-const PREVIEW_TOKEN_QUERY = "__cc_pt";
 const PREVIEW_HOST_SUFFIX = `.${PREVIEW_HOSTNAME}`;
 const PREVIEW_HOST_LABEL = /^[a-z0-9]+(?:-[a-z0-9]+)*--\d{1,5}$/u;
 

--- a/apps/web/src/components/preview/preview-side-panel.tsx
+++ b/apps/web/src/components/preview/preview-side-panel.tsx
@@ -232,7 +232,9 @@ function panelBodyProps(
     hasProject: project !== null,
     isMobile: controller.isMobile,
     isRunActive: controller.isRunActive,
+    previewAuthorizeNavigation: controller.previewLive.authorizeNavigation,
     previewPhase: controller.previewLive.phase,
+    previewReload: controller.previewLive.reload,
     previewRetry: controller.previewLive.retry,
     previewReloadToken: controller.previewReloadToken,
     previewUrl: controller.previewUrl,
@@ -251,7 +253,9 @@ interface PanelBodyProps {
   hasProject: boolean;
   isMobile: boolean;
   isRunActive: boolean;
+  previewAuthorizeNavigation: () => Promise<boolean>;
   previewPhase: PreviewLivePhase;
+  previewReload: () => Promise<void>;
   previewRetry: () => Promise<void>;
   previewReloadToken: number;
   previewUrl: string | null;
@@ -269,7 +273,9 @@ function PanelBody({
   hasProject,
   isMobile,
   isRunActive,
+  previewAuthorizeNavigation,
   previewPhase,
+  previewReload,
   previewRetry,
   previewReloadToken,
   previewUrl,
@@ -290,7 +296,9 @@ function PanelBody({
             appPreviewStatus={appPreviewStatus}
             isMobile={isMobile}
             isRunActive={isRunActive}
+            previewAuthorizeNavigation={previewAuthorizeNavigation}
             previewPhase={previewPhase}
+            previewReload={previewReload}
             previewRetry={previewRetry}
             previewReloadToken={previewReloadToken}
             previewUrl={previewUrl}
@@ -321,7 +329,9 @@ function AppTab({
   hasProject,
   isMobile,
   isRunActive,
+  previewAuthorizeNavigation,
   previewPhase,
+  previewReload,
   previewRetry,
   previewReloadToken,
   previewUrl,
@@ -348,7 +358,13 @@ function AppTab({
     );
   }
   return (
-    <AppTabLayout expoUrl={expoUrl} isError={previewPhase === "error"} previewUrl={previewUrl}>
+    <AppTabLayout
+      expoUrl={expoUrl}
+      isError={previewPhase === "error"}
+      onAuthorizeNavigation={previewAuthorizeNavigation}
+      onRefresh={previewReload}
+      previewUrl={previewUrl}
+    >
       <AppTabContent
         frameDevice={frameDevice}
         iframeUrl={iframeUrl}
@@ -367,16 +383,24 @@ function AppTabLayout({
   children,
   expoUrl,
   isError,
+  onAuthorizeNavigation,
+  onRefresh,
   previewUrl,
 }: {
   children: ReactNode;
   expoUrl: string | null;
   isError: boolean;
+  onAuthorizeNavigation: () => Promise<boolean>;
+  onRefresh: () => Promise<void>;
   previewUrl: string | null;
 }) {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-background">
-      <PreviewUrlBar previewUrl={previewUrl} />
+      <PreviewUrlBar
+        onAuthorizeNavigation={onAuthorizeNavigation}
+        onRefresh={onRefresh}
+        previewUrl={previewUrl}
+      />
       <div
         className={cn(
           "relative flex min-h-0 flex-1 overflow-hidden rounded-[20.5px]",

--- a/apps/web/src/components/preview/preview-url-bar.tsx
+++ b/apps/web/src/components/preview/preview-url-bar.tsx
@@ -9,16 +9,34 @@ import {
  * Controls only the preview entry URL. The cross-origin iframe's live SPA
  * location is intentionally opaque to the parent application.
  */
-export function PreviewUrlBar({ previewUrl }: { previewUrl: string | null }) {
+export function PreviewUrlBar({
+  onAuthorizeNavigation,
+  onRefresh,
+  previewUrl,
+}: {
+  onAuthorizeNavigation?: () => Promise<boolean>;
+  onRefresh?: () => Promise<void>;
+  previewUrl: string | null;
+}) {
   return (
     <div className="h-11 shrink-0 bg-background px-2 py-1.5">
       <div className="flex h-8 items-center gap-1 rounded-full bg-background">
-        <PreviewNavigationControls previewUrl={previewUrl} />
+        <PreviewNavigationControls
+          {...(onAuthorizeNavigation ? { onAuthorizeNavigation } : {})}
+          {...(onRefresh ? { onRefresh } : {})}
+          previewUrl={previewUrl}
+        />
         <div className="flex min-h-8 min-w-0 flex-1 cursor-text items-center gap-1.5 rounded-full bg-secondary py-0.5 pr-20 pl-2.5 transition-colors hover:bg-bg-secondary">
           <PreviewDeviceMenu isPreviewAvailable={previewUrl !== null} />
-          <PreviewPathInput previewUrl={previewUrl} />
+          <PreviewPathInput
+            {...(onAuthorizeNavigation ? { onAuthorizeNavigation } : {})}
+            previewUrl={previewUrl}
+          />
         </div>
-        <PreviewExternalLink previewUrl={previewUrl} />
+        <PreviewExternalLink
+          {...(onAuthorizeNavigation ? { onAuthorizeNavigation } : {})}
+          previewUrl={previewUrl}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/components/preview/preview-url-controls.tsx
+++ b/apps/web/src/components/preview/preview-url-controls.tsx
@@ -1,23 +1,35 @@
 "use client";
 
+import { useState } from "react";
+import { toast } from "sonner";
 import { buildPreviewIframeSrc } from "@/components/preview/url-bar";
 import { ChevronLeft, ChevronRight, ExternalLink, RefreshCw } from "@/components/ui";
 import { useAppStore } from "@/lib/store/app-store";
+import { cn } from "@/lib/ui/cn";
 
 const CONTROL_CLASS =
   "flex size-6 shrink-0 items-center justify-center rounded-full p-1 text-fg-secondary transition-colors hover:bg-secondary hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30";
 
-export function PreviewNavigationControls({ previewUrl }: { previewUrl: string | null }) {
+export function PreviewNavigationControls({
+  onAuthorizeNavigation,
+  onRefresh,
+  previewUrl,
+}: {
+  onAuthorizeNavigation?: () => Promise<boolean>;
+  onRefresh?: () => Promise<void>;
+  previewUrl: string | null;
+}) {
   const previewPathHistory = useAppStore((state) => state.previewPathHistory);
-  const bumpPreviewReloadToken = useAppStore((state) => state.bumpPreviewReloadToken);
   const goBackPreviewPath = useAppStore((state) => state.goBackPreviewPath);
+  const actions = usePreviewNavigationActions(onAuthorizeNavigation, onRefresh, goBackPreviewPath);
   return (
     <div className="flex items-center gap-0.5">
       <button
         aria-label="Go back"
+        aria-busy={actions.pending === "back"}
         className={CONTROL_CLASS}
-        disabled={!previewUrl || previewPathHistory.length === 0}
-        onClick={goBackPreviewPath}
+        disabled={!previewUrl || previewPathHistory.length === 0 || actions.pending !== null}
+        onClick={() => void actions.goBack()}
         type="button"
       >
         <ChevronLeft aria-hidden="true" className="h-3.5 w-3.5" />
@@ -27,19 +39,58 @@ export function PreviewNavigationControls({ previewUrl }: { previewUrl: string |
       </button>
       <button
         aria-label="Refresh"
+        aria-busy={actions.pending === "refresh"}
         className={CONTROL_CLASS}
-        disabled={!previewUrl}
-        onClick={bumpPreviewReloadToken}
+        disabled={!previewUrl || !onRefresh || actions.pending !== null}
+        onClick={() => void actions.refresh()}
         type="button"
       >
-        <RefreshCw aria-hidden="true" className="h-3 w-3" />
+        <RefreshCw
+          aria-hidden="true"
+          className={cn("h-3 w-3", actions.pending === "refresh" ? "animate-spin" : null)}
+        />
       </button>
     </div>
   );
 }
 
-export function PreviewExternalLink({ previewUrl }: { previewUrl: string | null }) {
+function usePreviewNavigationActions(
+  onAuthorizeNavigation: (() => Promise<boolean>) | undefined,
+  onRefresh: (() => Promise<void>) | undefined,
+  goBackPreviewPath: () => void,
+) {
+  const [pending, setPending] = useState<"back" | "refresh" | null>(null);
+  const goBack = async () => {
+    if (!onAuthorizeNavigation || pending) return;
+    setPending("back");
+    try {
+      if (await onAuthorizeNavigation()) goBackPreviewPath();
+      else toast.error("Preview access couldn't be refreshed. Try again.");
+    } finally {
+      setPending(null);
+    }
+  };
+  const refresh = async () => {
+    if (!onRefresh || pending) return;
+    setPending("refresh");
+    try {
+      await onRefresh();
+    } finally {
+      setPending(null);
+    }
+  };
+  return { goBack, pending, refresh };
+}
+
+export function PreviewExternalLink({
+  onAuthorizeNavigation,
+  previewUrl,
+}: {
+  onAuthorizeNavigation?: () => Promise<boolean>;
+  previewUrl: string | null;
+}) {
   const previewPath = useAppStore((state) => state.previewPath);
+  const { isOpening, openPreview } = useOpenPreview(onAuthorizeNavigation, previewPath);
   if (!previewUrl) {
     return (
       <button
@@ -53,15 +104,45 @@ export function PreviewExternalLink({ previewUrl }: { previewUrl: string | null 
     );
   }
   return (
-    <a
+    <button
       aria-label="Open preview in a new tab"
+      aria-busy={isOpening}
       className={CONTROL_CLASS}
-      href={buildPreviewIframeSrc(previewUrl, previewPath, 0)}
-      referrerPolicy="origin"
-      rel="noopener"
-      target="_blank"
+      disabled={isOpening || !onAuthorizeNavigation}
+      onClick={() => void openPreview()}
+      type="button"
     >
       <ExternalLink aria-hidden="true" className="h-3.5 w-3.5" />
-    </a>
+    </button>
   );
+}
+
+function useOpenPreview(
+  onAuthorizeNavigation: (() => Promise<boolean>) | undefined,
+  previewPath: string,
+) {
+  const [isOpening, setIsOpening] = useState(false);
+  const openPreview = async () => {
+    if (!onAuthorizeNavigation || isOpening) return;
+    const popup = window.open("about:blank", "_blank");
+    if (!popup) {
+      toast.error("Allow pop-ups to open the preview in a new tab.");
+      return;
+    }
+    popup.opener = null;
+    setIsOpening(true);
+    try {
+      const isAuthorized = await onAuthorizeNavigation();
+      const freshPreviewUrl = useAppStore.getState().previewUrl;
+      if (!isAuthorized || !freshPreviewUrl) {
+        popup.close();
+        toast.error("Preview access couldn't be refreshed. Try again.");
+        return;
+      }
+      popup.location.replace(buildPreviewIframeSrc(freshPreviewUrl, previewPath, 0));
+    } finally {
+      setIsOpening(false);
+    }
+  };
+  return { isOpening, openPreview };
 }

--- a/apps/web/src/components/preview/url-bar.ts
+++ b/apps/web/src/components/preview/url-bar.ts
@@ -7,6 +7,8 @@
  * commanded URL, not where the app actually is.
  */
 
+import { PREVIEW_TOKEN_QUERY } from "@/components/preview/preview-protocol";
+
 const SANDBOX_PROXY_PREFIX = "/__sandbox/";
 
 type SplitPreviewUrl = {
@@ -34,9 +36,9 @@ export function normalizePreviewPath(input: string, previewUrl: string): null | 
     if (pasted === null || pasted.base !== previewOrigin(previewUrl)) {
       return null;
     }
-    return pasted.path;
+    return stripPreviewCredential(pasted.path);
   }
-  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+  return stripPreviewCredential(trimmed.startsWith("/") ? trimmed : `/${trimmed}`);
 }
 
 /** Origin + path, preserving preview auth and adding `cc_preview_reload` when bumped. */
@@ -52,17 +54,29 @@ export function buildPreviewIframeSrc(
   try {
     const url = new URL(base);
     const source = new URL(previewUrl);
+    url.searchParams.delete(PREVIEW_TOKEN_QUERY);
     for (const [key, value] of source.searchParams) {
-      if (!url.searchParams.has(key)) {
+      if (key === PREVIEW_TOKEN_QUERY || !url.searchParams.has(key)) {
         url.searchParams.set(key, value);
       }
     }
+    url.searchParams.delete("cc_preview_reload");
     if (reloadToken > 0) {
       url.searchParams.set("cc_preview_reload", String(reloadToken));
     }
     return url.toString();
   } catch {
     return base;
+  }
+}
+
+function stripPreviewCredential(path: string): string {
+  try {
+    const parsed = new URL(path, "https://preview.invalid");
+    parsed.searchParams.delete(PREVIEW_TOKEN_QUERY);
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return path;
   }
 }
 

--- a/apps/web/src/components/preview/use-ensure-preview-live.ts
+++ b/apps/web/src/components/preview/use-ensure-preview-live.ts
@@ -7,7 +7,9 @@ import { type PreviewTab, useAppStore } from "@/lib/store/app-store";
 export type PreviewLivePhase = "booting" | "error" | "live";
 
 export interface PreviewLiveState {
+  authorizeNavigation: () => Promise<boolean>;
   phase: PreviewLivePhase;
+  reload: () => Promise<void>;
   retry: () => Promise<void>;
 }
 
@@ -25,7 +27,12 @@ type PreviewRefreshOutcome =
   | { kind: "aborted" | "failure" }
   | { kind: "success"; result: PreviewRefreshResult };
 
+interface PreviewRefreshAttempt {
+  outcome: PreviewRefreshOutcome;
+}
+
 interface PreviewRefreshDependencies {
+  bumpPreviewReloadToken: () => void;
   getToken: () => Promise<null | string>;
   setActivePreviewTab: (tab: PreviewTab) => void;
   setExpoUrl: (url: string | null) => void;
@@ -36,12 +43,13 @@ interface PreviewRefreshDependencies {
 interface PreviewLiveRuntime {
   deps: PreviewRefreshDependencies;
   nextRefreshAt: number;
+  refreshRequest: Promise<PreviewRefreshAttempt | null> | null;
   requestGeneration: number;
   wakeAbort: AbortController | null;
-  waking: boolean;
 }
 
 type SetPreviewLivePhase = (phase: PreviewLivePhase) => void;
+type PreviewRefreshMode = "authorize" | "recover" | "reload" | "rotate";
 
 /**
  * Keeps the app preview live while the Computer panel is open. Daytona auto-stops a sandbox after
@@ -61,27 +69,33 @@ export function useEnsurePreviewLive(
   sandboxStatus: string,
 ): PreviewLiveState {
   const setActivePreviewTab = useAppStore((state) => state.setActivePreviewTab);
+  const bumpPreviewReloadToken = useAppStore((state) => state.bumpPreviewReloadToken);
   const setPreviewUrl = useAppStore((state) => state.setPreviewUrl);
   const setExpoUrl = useAppStore((state) => state.setExpoUrl);
   const [phase, setPhase] = useState<PreviewLivePhase>("live");
   const runtime = usePreviewLiveRuntime(
+    bumpPreviewReloadToken,
     getToken,
     setActivePreviewTab,
     setExpoUrl,
     setPreviewUrl,
     threadId,
   );
-  const { refreshPreview, wake } = usePreviewRefresh(runtime, setPhase);
+  const { authorizeNavigation, refreshPreview, reload, wake } = usePreviewRefresh(
+    runtime,
+    setPhase,
+  );
 
   usePreviewActivation(active, threadId, runtime, setPhase, wake);
   useReadySandboxWake(active, sandboxStatus, wake);
   usePreviewStatusPolling(active, threadId, runtime, wake);
   usePreviewSessionRotation(active, threadId, runtime, refreshPreview);
 
-  return { phase, retry: wake };
+  return { authorizeNavigation, phase, reload, retry: wake };
 }
 
 function usePreviewLiveRuntime(
+  bumpPreviewReloadToken: PreviewRefreshDependencies["bumpPreviewReloadToken"],
   getToken: PreviewRefreshDependencies["getToken"],
   setActivePreviewTab: PreviewRefreshDependencies["setActivePreviewTab"],
   setExpoUrl: PreviewRefreshDependencies["setExpoUrl"],
@@ -89,63 +103,99 @@ function usePreviewLiveRuntime(
   threadId: string | null,
 ): PreviewLiveRuntime {
   const runtimeRef = useRef<PreviewLiveRuntime>({
-    deps: { getToken, setActivePreviewTab, setExpoUrl, setPreviewUrl, threadId },
+    deps: {
+      bumpPreviewReloadToken,
+      getToken,
+      setActivePreviewTab,
+      setExpoUrl,
+      setPreviewUrl,
+      threadId,
+    },
     nextRefreshAt: 0,
+    refreshRequest: null,
     requestGeneration: 0,
     wakeAbort: null,
-    waking: false,
   });
   // Commit the latest Clerk token getter without restarting the stable wake callback.
   useEffect(() => {
     runtimeRef.current.deps = {
+      bumpPreviewReloadToken,
       getToken,
       setActivePreviewTab,
       setExpoUrl,
       setPreviewUrl,
       threadId,
     };
-  }, [getToken, setActivePreviewTab, setExpoUrl, setPreviewUrl, threadId]);
+  }, [bumpPreviewReloadToken, getToken, setActivePreviewTab, setExpoUrl, setPreviewUrl, threadId]);
   return runtimeRef.current;
 }
 
 function usePreviewRefresh(runtime: PreviewLiveRuntime, setPhase: SetPreviewLivePhase) {
-  const refreshPreview = useCallback(
-    (showBooting: boolean) => refreshPreviewSession(runtime, showBooting, setPhase),
-    [runtime, setPhase],
-  );
-  const wake = useCallback(() => refreshPreview(true), [refreshPreview]);
-  return { refreshPreview, wake };
+  const authorizeNavigation = useCallback(async () => {
+    const result = await refreshPreviewSession(runtime, "authorize", setPhase);
+    return Boolean(result?.running && result.url);
+  }, [runtime, setPhase]);
+  const refreshPreview = useCallback(async () => {
+    await refreshPreviewSession(runtime, "rotate", setPhase);
+  }, [runtime, setPhase]);
+  const reload = useCallback(async () => {
+    await refreshPreviewSession(runtime, "reload", setPhase);
+  }, [runtime, setPhase]);
+  const wake = useCallback(async () => {
+    await refreshPreviewSession(runtime, "recover", setPhase);
+  }, [runtime, setPhase]);
+  return { authorizeNavigation, refreshPreview, reload, wake };
 }
 
 async function refreshPreviewSession(
   runtime: PreviewLiveRuntime,
-  showBooting: boolean,
+  mode: PreviewRefreshMode,
   setPhase: SetPreviewLivePhase,
-): Promise<void> {
+): Promise<PreviewRefreshResult | null> {
   const deps = runtime.deps;
-  if (!deps.threadId || runtime.waking) return;
-  const requestGeneration = runtime.requestGeneration;
-  const controller = new AbortController();
-  runtime.wakeAbort = controller;
-  runtime.waking = true;
+  const showBooting = mode === "recover" || mode === "reload";
   if (showBooting) {
+    setPhase("booting");
+  }
+  if (mode === "recover") {
     // Unmount a stale cross-origin document before a real wake. The fresh handoff URL then performs
     // its own cookie exchange on remount; silent capability rotation still preserves live SPA state.
     clearPreviewUrls(deps);
-    setPhase("booting");
   }
-  try {
-    const outcome = await requestPreviewRefresh(
-      { ...deps, threadId: deps.threadId },
-      controller.signal,
-    );
-    if (requestGeneration !== runtime.requestGeneration) return;
-    const refreshDelay = applyPreviewRefreshOutcome(outcome, deps, showBooting, setPhase);
-    if (refreshDelay !== null) runtime.nextRefreshAt = Date.now() + refreshDelay;
-  } finally {
-    if (runtime.wakeAbort === controller) runtime.wakeAbort = null;
-    if (requestGeneration === runtime.requestGeneration) runtime.waking = false;
+  const attempt = await acquirePreviewRefresh(runtime);
+  if (!attempt) return null;
+  const refreshDelay = applyPreviewRefreshOutcome(attempt.outcome, deps, showBooting, setPhase);
+  if (refreshDelay !== null) runtime.nextRefreshAt = Date.now() + refreshDelay;
+  if (attempt.outcome.kind !== "success") return null;
+  if (mode === "reload" && attempt.outcome.result.running && attempt.outcome.result.url) {
+    deps.bumpPreviewReloadToken();
   }
+  return attempt.outcome.result;
+}
+
+async function acquirePreviewRefresh(
+  runtime: PreviewLiveRuntime,
+): Promise<PreviewRefreshAttempt | null> {
+  if (runtime.refreshRequest !== null) return runtime.refreshRequest;
+  const deps = runtime.deps;
+  if (!deps.threadId) return null;
+  const requestGeneration = runtime.requestGeneration;
+  const controller = new AbortController();
+  runtime.wakeAbort = controller;
+  const request = requestPreviewRefresh({ ...deps, threadId: deps.threadId }, controller.signal)
+    .then((outcome) => (requestGeneration === runtime.requestGeneration ? { outcome } : null))
+    .finally(() => finishPreviewRefresh(runtime, request, controller));
+  runtime.refreshRequest = request;
+  return request;
+}
+
+function finishPreviewRefresh(
+  runtime: PreviewLiveRuntime,
+  request: Promise<PreviewRefreshAttempt | null>,
+  controller: AbortController,
+): void {
+  if (runtime.refreshRequest === request) runtime.refreshRequest = null;
+  if (runtime.wakeAbort === controller) runtime.wakeAbort = null;
 }
 
 function usePreviewActivation(
@@ -197,7 +247,7 @@ function usePreviewStatusPolling(
       try {
         await pollPreviewStatus({
           getToken: runtime.deps.getToken,
-          isWaking: () => runtime.waking,
+          isWaking: () => runtime.refreshRequest !== null,
           signal: controller.signal,
           threadId,
           wake,
@@ -218,12 +268,12 @@ function usePreviewSessionRotation(
   active: boolean,
   threadId: string | null,
   runtime: PreviewLiveRuntime,
-  refreshPreview: (showBooting: boolean) => Promise<void>,
+  refreshPreview: () => Promise<void>,
 ): void {
   useEffect(() => {
     if (!active || !threadId) return;
     const id = setInterval(() => {
-      if (Date.now() >= runtime.nextRefreshAt) void refreshPreview(false);
+      if (Date.now() >= runtime.nextRefreshAt) void refreshPreview();
     }, PREVIEW_SESSION_CHECK_MS);
     return () => clearInterval(id);
   }, [active, refreshPreview, runtime, threadId]);
@@ -233,7 +283,7 @@ function cancelPreviewRequest(runtime: PreviewLiveRuntime): void {
   runtime.requestGeneration += 1;
   runtime.wakeAbort?.abort();
   runtime.wakeAbort = null;
-  runtime.waking = false;
+  runtime.refreshRequest = null;
 }
 
 function clearPreviewUrls(deps: PreviewRefreshDependencies): void {


### PR DESCRIPTION
## Summary
- renew the one-minute preview handoff before reload, path entry, Back, and external navigation
- coalesce concurrent renewal attempts behind one authenticated wake request
- prevent a stale or user-pasted `__cc_pt` query value from overriding the newly minted capability
- preserve silent background cookie rotation so a healthy live iframe stays mounted during ordinary use

## Architecture
The authenticated preview wake boundary remains the only capability issuer. User navigation now requests a fresh handoff through the existing lifecycle controller, commits the new URL to the preview store, and only then changes the iframe path or reload identity. Concurrent callers share the same in-flight request and activation changes abort stale generations.

## Decisions Made
| Decision | Choice | Alternative | Reasoning |
|---|---|---|---|
| Expired handoff handling | Renew before every user navigation | Lengthen the 60-second token lifetime | Keeps the strict short-lived URL capability contract intact |
| Concurrent clicks | Share one in-flight wake request | Fire one request per control | Avoids duplicate Daytona health probes and produces one authoritative result |
| Manual reload | Renew, then remount | Reuse the stored URL | The stored URL can outlive its query token even while the cookie session remains valid |
| Path credentials | Strip/override `__cc_pt` | Trust path input | A stale pasted query credential must never take precedence over the fresh handoff |

## Edge Cases Handled
| Scenario | Handling |
|---|---|
| Background rotation overlaps a user action | Both await the same renewal request |
| Thread/panel identity changes during renewal | Abort and generation checks prevent stale results from applying |
| Renewal fails | Navigation does not proceed; reload enters the existing retryable error state |
| Full preview URL with an old token is pasted | The credential is stripped and the fresh source token is authoritative |
| External popup is blocked | The user receives a direct error and no background request is started |

## How to Review
1. Start with `use-ensure-preview-live.ts` for request coalescing and lifecycle behavior.
2. Review `preview-url-controls.tsx` and `preview-path-input.tsx` for the user-action ordering.
3. Check `url-bar.ts` and `preview-protocol.ts` for reserved-query handling.
4. The remaining component changes only plumb the lifecycle controller into the URL bar.

## Verification
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm turbo build --force`
- [x] `pnpm deadcode`
- [x] `pnpm architecture:check`
- [x] `pnpm turbo skills:build`
- [ ] Production: wait beyond the 60-second handoff lifetime, reload, and confirm the app renders without `auth_token_expired`
- [ ] Production: navigate a path and Back after expiry and confirm each action acquires a fresh capability
