### PR TITLE
chore(sandbox): promote managed-preview snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-8399723f56e1-31363645724",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-bb282ba2140d-31373620987",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

PR #208 changed the baked Daytona source synchronizer. Production must point the agent Worker at the reviewed immutable candidate built from that exact main commit before the runtime fix can take effect in restored sandboxes.

## Change

Promote `cheatcode-sandbox-viewer-bundle-bb282ba2140d-31373620987`, produced by protected workflow run 31373620987 from commit `bb282ba2140d79ecdbbec07770161c0a04781e6f`. The workflow completed image construction, security and configuration scans, runtime smoke tests, publication, and active-state verification.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- Protected snapshot workflow run 31373620987: passed

The four existing Knip configuration hints remain unchanged.