### PR TITLE
fix(sandbox): restore reviewed Vite dependencies

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -111,6 +111,8 @@ jobs:
       - name: Smoke-test candidate runtime
         run: |
           docker run --rm --platform=linux/amd64 --entrypoint /bin/sh "$IMAGE_TAG" -lc '
+            set -eu
+
             test "$(id -un)" = node
             test "$PWD" = /workspace
             test "$(node --version)" = v24.18.0
@@ -145,7 +147,84 @@ jobs:
             pnpm --version
             python3 --version
             test -x /opt/cheatcode/project-source-sync.py
+            test -x /opt/cheatcode/pnpm-build-policy.mjs
             python3 -c "import ast,pathlib;ast.parse(pathlib.Path(\"/opt/cheatcode/project-source-sync.py\").read_text())"
+            node --check /opt/cheatcode/pnpm-build-policy.mjs
+            policy_test_dir="$(mktemp -d)"
+            printf "packages:\\n  - .\\nallowBuilds:\\n  sharp: false\\n" > "$policy_test_dir/pnpm-workspace.yaml"
+            node /opt/cheatcode/pnpm-build-policy.mjs "$policy_test_dir/pnpm-workspace.yaml"
+            node -e "const y=require(\"/opt/cheatcode-runtime-security-overrides/node_modules/js-yaml\");const p=y.load(require(\"node:fs\").readFileSync(process.argv[1],\"utf8\"));if(p.allowBuilds.esbuild!==true||p.allowBuilds.sharp!==false)throw new Error(\"reviewed build policy merge failed\")" "$policy_test_dir/pnpm-workspace.yaml"
+            rm -rf "$policy_test_dir"
+
+            preview_test_dir="$(mktemp -d)"
+            preview_source="$preview_test_dir/durable"
+            preview_mirror="$preview_test_dir/mirror"
+            preview_lock="$preview_test_dir/project.lock"
+            preview_pid=""
+            cleanup_preview_test() {
+              if [ -n "$preview_pid" ]; then
+                kill "$preview_pid" 2>/dev/null || true
+                wait "$preview_pid" 2>/dev/null || true
+              fi
+              rm -rf "$preview_test_dir"
+            }
+            trap cleanup_preview_test EXIT
+            mkdir -p "$preview_source" "$preview_mirror"
+            printf "%s\n" "{\"name\":\"vite-policy-smoke\",\"private\":true,\"scripts\":{\"dev\":\"vite\"},\"devDependencies\":{\"vite\":\"5.4.11\"}}" > "$preview_source/package.json"
+            printf "%s\n" "<main id=\"app\">reviewed lifecycle policy works</main>" > "$preview_source/index.html"
+
+            wait_for_preview() {
+              preview_port="$1"
+              preview_log="$2"
+              preview_attempt=0
+              while [ "$preview_attempt" -lt 90 ]; do
+                if curl --fail --silent "http://127.0.0.1:$preview_port" | grep --fixed-strings --quiet "reviewed lifecycle policy works"; then
+                  return 0
+                fi
+                if ! kill -0 "$preview_pid" 2>/dev/null; then
+                  break
+                fi
+                sleep 1
+                preview_attempt=$((preview_attempt + 1))
+              done
+              sed -n "1,240p" "$preview_log" >&2
+              return 1
+            }
+
+            cold_started_at="$(date +%s)"
+            PORT=5199 /opt/cheatcode/project-source-sync.py preview-run "$preview_source" "$preview_mirror" "$preview_lock" "$preview_mirror" - -- pnpm run dev --host 0.0.0.0 --port 5199 > "$preview_test_dir/cold.log" 2>&1 &
+            preview_pid="$!"
+            wait_for_preview 5199 "$preview_test_dir/cold.log"
+            cold_elapsed=$(( $(date +%s) - cold_started_at ))
+            kill "$preview_pid" 2>/dev/null || true
+            wait "$preview_pid" 2>/dev/null || true
+            preview_pid=""
+            test "$cold_elapsed" -le 90
+            test ! -e "$preview_source/pnpm-workspace.yaml"
+            test ! -e "$preview_mirror/pnpm-workspace.yaml"
+            test -x "$preview_mirror/node_modules/.bin/vite"
+            test -x "$preview_mirror/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/bin/esbuild"
+            grep --fixed-strings --quiet "esbuild postinstall: Done" "$preview_test_dir/cold.log"
+
+            warm_started_at="$(date +%s)"
+            PORT=5200 /opt/cheatcode/project-source-sync.py preview-run "$preview_source" "$preview_mirror" "$preview_lock" "$preview_mirror" - -- pnpm run dev --host 0.0.0.0 --port 5200 > "$preview_test_dir/warm.log" 2>&1 &
+            preview_pid="$!"
+            wait_for_preview 5200 "$preview_test_dir/warm.log"
+            warm_elapsed=$(( $(date +%s) - warm_started_at ))
+            kill "$preview_pid" 2>/dev/null || true
+            wait "$preview_pid" 2>/dev/null || true
+            preview_pid=""
+            test "$warm_elapsed" -le 10
+            test ! -e "$preview_source/pnpm-workspace.yaml"
+            test ! -e "$preview_mirror/pnpm-workspace.yaml"
+            if grep --fixed-strings --quiet "Progress:" "$preview_test_dir/warm.log"; then
+              echo "Warm preview unexpectedly reinstalled dependencies." >&2
+              exit 1
+            fi
+            echo "Vite preview smoke passed: cold=${cold_elapsed}s warm=${warm_elapsed}s"
+            cleanup_preview_test
+            trap - EXIT
+
             code-server --version
             "$CHROME_PATH" --version
             libreoffice --version
@@ -171,7 +250,7 @@ jobs:
             test -f /home/node/.cheatcode/default-skills/generate-media/SKILL.md
             test -f /home/node/.cheatcode/default-skills/product-self-knowledge/SKILL.md
             test "$(find /home/node/.cheatcode/default-skills -type f -name "*.py" | wc -l)" -eq 56
-            test "$(find /home/node/.cheatcode/default-skills -type f -name "*.ts" | wc -l)" -eq 12
+            test "$(find /home/node/.cheatcode/default-skills -type f -name "*.ts" | wc -l)" -eq 11
             test "$(find /home/node/.cheatcode/default-skills -type f -name "*.xsd" | wc -l)" -eq 117
             test ! -e /home/node/.cheatcode/default-skills/deploy
             test ! -e /home/node/.cheatcode/default-skills/landing-page

--- a/infra/containers/sandbox/README.md
+++ b/infra/containers/sandbox/README.md
@@ -108,7 +108,12 @@ three-way conflict check against the durable tree. Long-lived previews invoke th
 direct argv: it synchronizes source, restores dependencies under the project lock, supervises the
 native-disk app and sync-loop children, and forwards termination signals. A dependency-state digest
 skips unchanged reinstalls, while projects without a durable lockfile install without creating one
-as a preview side effect. The Worker therefore does
+as a preview side effect. Dependency restoration temporarily merges the image's reviewed build
+policy into the sandbox-local workspace, currently permitting `esbuild` so Vite can install its
+platform binary while pnpm's default-deny lifecycle policy remains intact for every other package.
+The original workspace manifest is restored byte-for-byte before the app starts, and the managed
+preview disables pnpm's redundant pre-script auto-install because the helper has already restored
+and digested that exact dependency state under the project lock. The Worker therefore does
 not transport an executable shell wrapper or make trusted bootstrap commands indistinguishable from
 model-supplied shell input.
 

--- a/infra/containers/sandbox/scripts/pnpm-build-policy.mjs
+++ b/infra/containers/sandbox/scripts/pnpm-build-policy.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { dump, load } = require(
+  "/opt/cheatcode-runtime-security-overrides/node_modules/js-yaml",
+);
+
+const REVIEWED_BUILD_POLICY = Object.freeze({
+  esbuild: true,
+});
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readWorkspace(workspacePath) {
+  if (!fs.existsSync(workspacePath)) {
+    return { packages: ["."] };
+  }
+  const workspace = load(fs.readFileSync(workspacePath, "utf8")) ?? {};
+  if (!isRecord(workspace)) {
+    throw new TypeError("pnpm-workspace.yaml must contain a YAML object");
+  }
+  return workspace;
+}
+
+function mergeReviewedPolicy(workspace) {
+  const configured = workspace.allowBuilds ?? {};
+  if (!isRecord(configured)) {
+    throw new TypeError("pnpm-workspace.yaml allowBuilds must contain a YAML object");
+  }
+  return {
+    ...workspace,
+    allowBuilds: {
+      ...REVIEWED_BUILD_POLICY,
+      ...configured,
+    },
+  };
+}
+
+function writeWorkspace(workspacePath, workspace) {
+  fs.mkdirSync(path.dirname(workspacePath), { recursive: true });
+  const temporary = `${workspacePath}.cheatcode-build-policy-${process.pid}`;
+  try {
+    fs.writeFileSync(
+      temporary,
+      dump(workspace, { lineWidth: -1, noRefs: true, sortKeys: false }),
+      { encoding: "utf8", mode: 0o600 },
+    );
+    fs.renameSync(temporary, workspacePath);
+  } finally {
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+const workspacePath = process.argv[2];
+if (!workspacePath || process.argv.length !== 3) {
+  throw new TypeError("usage: pnpm-build-policy.mjs <pnpm-workspace.yaml>");
+}
+writeWorkspace(workspacePath, mergeReviewedPolicy(readWorkspace(workspacePath)));

--- a/infra/containers/sandbox/scripts/project-source-sync.py
+++ b/infra/containers/sandbox/scripts/project-source-sync.py
@@ -10,12 +10,14 @@ import subprocess
 import sys
 import tempfile
 import time
+from contextlib import contextmanager
 
 
 IGNORED_DIRS = {".expo", ".next", ".turbo", "build", "coverage", "dist", "node_modules", "out"}
 LOCAL_ONLY_NAMES = IGNORED_DIRS | {"next-env.d.ts"}
 PACKAGE_CONFLICT_EXIT = 74
 DEPENDENCY_STATE_FILENAME = ".cheatcode-dependency-state"
+PNPM_BUILD_POLICY_BINARY = "/opt/cheatcode/pnpm-build-policy.mjs"
 
 
 def remove_path(path):
@@ -288,6 +290,65 @@ def record_dependency_state(local_cwd, local_root):
             pass
 
 
+def pnpm_workspace_path(local_cwd, local_root):
+    current = os.path.realpath(local_cwd)
+    root = os.path.realpath(local_root)
+    while True:
+        candidate = os.path.join(current, "pnpm-workspace.yaml")
+        if os.path.lexists(candidate):
+            return candidate
+        if current == root:
+            return os.path.join(local_cwd, "pnpm-workspace.yaml")
+        current = os.path.dirname(current)
+
+
+def capture_path(path):
+    if os.path.islink(path):
+        return ("link", os.readlink(path))
+    if os.path.isfile(path):
+        with open(path, "rb") as source:
+            return ("file", source.read(), os.stat(path).st_mode & 0o7777)
+    if os.path.lexists(path):
+        raise ValueError(f"pnpm workspace path must be a file: {path}")
+    return ("missing",)
+
+
+def restore_path(path, captured):
+    remove_path(path)
+    if captured[0] == "missing":
+        return
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if captured[0] == "link":
+        os.symlink(captured[1], path)
+        return
+    descriptor, temporary = tempfile.mkstemp(prefix=".cheatcode-policy-", dir=os.path.dirname(path))
+    try:
+        with os.fdopen(descriptor, "wb") as target:
+            target.write(captured[1])
+        os.chmod(temporary, captured[2])
+        os.replace(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+@contextmanager
+def reviewed_pnpm_build_policy(local_cwd, local_root):
+    workspace_path = pnpm_workspace_path(local_cwd, local_root)
+    captured = capture_path(workspace_path)
+    try:
+        subprocess.run(
+            ["node", PNPM_BUILD_POLICY_BINARY, workspace_path],
+            cwd=local_cwd,
+            check=True,
+        )
+        yield
+    finally:
+        restore_path(workspace_path, captured)
+
+
 def restore_pnpm_dependencies(local_cwd, local_root, dependency_template):
     package_path = os.path.join(local_cwd, "package.json")
     lock_path = os.path.join(local_cwd, "pnpm-lock.yaml")
@@ -300,26 +361,24 @@ def restore_pnpm_dependencies(local_cwd, local_root, dependency_template):
     if dependencies_are_current(local_cwd, local_root):
         return 0
     common = ["install", "--prefer-offline", "--network-concurrency", "4"]
-    if not os.path.isfile(lock_path):
-        status = subprocess.run(
-            ["pnpm", *common, "--lockfile=false"], cwd=local_cwd, check=False
-        ).returncode
-        if status == 0:
-            record_dependency_state(local_cwd, local_root)
-        return status
-    offline = subprocess.run(
-        ["pnpm", "install", "--frozen-lockfile", "--offline"],
-        cwd=local_cwd,
-        check=False,
-    )
-    if offline.returncode == 0:
-        record_dependency_state(local_cwd, local_root)
-        return 0
-    status = subprocess.run(
-        ["pnpm", "install", "--frozen-lockfile", *common[1:]],
-        cwd=local_cwd,
-        check=False,
-    ).returncode
+    with reviewed_pnpm_build_policy(local_cwd, local_root):
+        if not os.path.isfile(lock_path):
+            status = subprocess.run(
+                ["pnpm", *common, "--lockfile=false"], cwd=local_cwd, check=False
+            ).returncode
+        else:
+            offline = subprocess.run(
+                ["pnpm", "install", "--frozen-lockfile", "--offline"],
+                cwd=local_cwd,
+                check=False,
+            )
+            status = offline.returncode
+            if status != 0:
+                status = subprocess.run(
+                    ["pnpm", "install", "--frozen-lockfile", *common[1:]],
+                    cwd=local_cwd,
+                    check=False,
+                ).returncode
     if status == 0:
         record_dependency_state(local_cwd, local_root)
     return status
@@ -375,7 +434,14 @@ def preview_run(source, target, lock_path, local_cwd, dependency_template, comma
     try:
         for signal_number in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
             previous_handlers[signal_number] = signal.signal(signal_number, terminate_children)
-        app_process = subprocess.Popen(command, cwd=local_cwd, start_new_session=True)
+        app_environment = os.environ.copy()
+        app_environment["pnpm_config_verify_deps_before_run"] = "false"
+        app_process = subprocess.Popen(
+            command,
+            cwd=local_cwd,
+            env=app_environment,
+            start_new_session=True,
+        )
         return app_process.wait()
     finally:
         terminate_children()

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -10,8 +10,9 @@
   "workspaces": {
     ".": {
       // Skill TypeScript files are executable snapshot entrypoints discovered by
-      // `cheatcode-skills`; they are intentionally outside the pnpm workspace graph.
-      "entry": ["skills/**/*.ts"]
+      // `cheatcode-skills`; the pnpm policy executable is invoked by the sandbox's
+      // Python supervisor. Both are intentionally outside the pnpm workspace graph.
+      "entry": ["skills/**/*.ts", "infra/containers/sandbox/scripts/pnpm-build-policy.mjs"]
     },
     "packages/db": {
       "drizzle": {


### PR DESCRIPTION
## Why

Restored Vite projects could never reach their dev server because pnpm 11 rejected esbuild's required postinstall under the sandbox's default-deny lifecycle policy. The managed app launch then triggered a second automatic install, repeating the same failure. This made a previously built project appear to load indefinitely after sandbox restore.

## What changed

- Apply a reviewed, sandbox-local pnpm lifecycle policy only while the trusted dependency restore runs.
- Permit esbuild while retaining pnpm's default deny for every other undeclared package script.
- Preserve a project's explicit allowBuilds decisions and restore its workspace manifest byte-for-byte before app launch.
- Disable pnpm's redundant pre-script dependency verification after the locked restore has recorded the exact dependency digest.
- Make the immutable snapshot smoke gate fail fast and exercise a real lockfile-less Vite cold start plus unchanged warm restart.
- Correct the stale bundled TypeScript skill count that fail-fast validation exposed.

No durable project file receives the temporary policy, and no blanket lifecycle-script bypass was added.

## Verification

- Exact snapshot container smoke: Vite cold start 6s, warm start 2s; esbuild postinstall executed; warm start performed no reinstall.
- pnpm lint
- pnpm typecheck
- pnpm turbo build --force
- pnpm deadcode
- pnpm architecture:check
- pnpm turbo skills:build
- git diff --check

## Production rollout

After merge, publish the immutable Daytona snapshot from this exact main commit, promote its snapshot ID through the agent Worker configuration, deploy Cloudflare, then verify the existing habit-tracker chat cold and warm preview paths on production.
