### PR TITLE
chore(deploy): promote verified sandbox snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-bb282ba2140d-31373620987",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-84d08950ddfc-31379522270",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable sandbox image built from main commit 84d08950ddfc393459df975ec3d5696e8596a655 after the Vite/esbuild restore fix merged in #210.

## Candidate

- Snapshot: cheatcode-sandbox-viewer-bundle-84d08950ddfc-31379522270
- Daytona snapshot ID: 7c2d835f-7d95-430b-a241-d9cf8b0890f6
- Build workflow: https://github.com/cheatcode-ai/cheatcode/actions/runs/31379522270
- State: active
- Region: us
- Resources: 2 CPU, 4 GiB memory, 10 GiB disk

The publication workflow passed provenance authorization, image build, security/configuration scan, the real cold/warm Vite runtime smoke, and Daytona snapshot verification.

## Verification

- pnpm lint
- pnpm typecheck
- pnpm turbo build --force
- pnpm deadcode
- pnpm architecture:check
- pnpm turbo skills:build
- git diff --check
- Direct Daytona snapshot lookup returned exactly one active candidate with the expected immutable name.

## Post-merge

Wait for Cloudflare deployment, then exercise the existing production habit-tracker chat twice to verify cold restore and warm process reuse.
