### PR TITLE
chore(sandbox): promote preview sync snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -16,7 +16,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-84d08950ddfc-31379522270",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-968af0d7ac92-31384952716",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable Daytona sandbox candidate containing the reviewed preview source-sync liveness fix.

## Candidate

- Snapshot: `cheatcode-sandbox-viewer-bundle-968af0d7ac92-31384952716`
- Source commit: `968af0d7ac92a67106be4cf586b908fade60d0ae`
- Build run: https://github.com/cheatcode-ai/cheatcode/actions/runs/31384952716
- Provider retries during publication: `0`

The candidate passed image vulnerability and secret scans, transient source recovery, live source propagation, warm preview startup, synchronizer failure supervision, and Daytona activation verification.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`

All repository commands ran with Node 24.18.0 and pnpm 11.15.0.
