### PR TITLE
fix: accelerate mobile previews and harden agent edits

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -321,6 +321,55 @@ jobs:
             test -x /home/node/.cheatcode/app-runtimes/expo/node_modules/.bin/expo
             NODE_PATH=/home/node/.cheatcode/app-runtimes/next/node_modules node -e "require.resolve(\"next\");require.resolve(\"react\");require.resolve(\"react-dom\")"
             NODE_PATH=/home/node/.cheatcode/app-runtimes/expo/node_modules node -e "require.resolve(\"expo\");require.resolve(\"react-native-web\");require.resolve(\"@expo/metro-runtime\")"
+
+            expo_test_dir="$(mktemp -d)"
+            expo_source="$expo_test_dir/durable"
+            expo_mirror="$expo_test_dir/mirror"
+            expo_lock="$expo_test_dir/project.lock"
+            expo_log="$expo_test_dir/expo.log"
+            expo_pid=""
+            cleanup_expo_test() {
+              if [ -n "$expo_pid" ]; then
+                kill "$expo_pid" 2>/dev/null || true
+                wait "$expo_pid" 2>/dev/null || true
+              fi
+              rm -rf "$expo_test_dir"
+            }
+            trap cleanup_expo_test EXIT
+            mkdir -p "$expo_source" "$expo_mirror"
+            cp -R /home/node/cheatcode-expo-template/. "$expo_source/"
+            CI=1 EXPO_NO_TELEMETRY=1 NODE_PATH=/home/node/.cheatcode/app-runtimes/expo/node_modules \
+              /opt/cheatcode/project-source-sync.py preview-run \
+              "$expo_source" "$expo_mirror" "$expo_lock" "$expo_mirror" \
+              /home/node/cheatcode-expo-template -- \
+              /home/node/.cheatcode/app-runtimes/expo/node_modules/.bin/expo \
+              start -c --web --host lan --port 5201 > "$expo_log" 2>&1 &
+            expo_pid="$!"
+            expo_attempt=0
+            until curl --fail --silent --output /dev/null http://127.0.0.1:5201; do
+              if ! kill -0 "$expo_pid" 2>/dev/null || [ "$expo_attempt" -ge 90 ]; then
+                sed -n "1,240p" "$expo_log" >&2
+                exit 1
+              fi
+              sleep 1
+              expo_attempt=$((expo_attempt + 1))
+            done
+            printf "%s\n" "mobile source synchronization works" > "$expo_source/.cheatcode-mobile-sync-smoke"
+            expo_sync_attempt=0
+            until test -f "$expo_mirror/.cheatcode-mobile-sync-smoke" && \
+              cmp -s "$expo_source/.cheatcode-mobile-sync-smoke" "$expo_mirror/.cheatcode-mobile-sync-smoke"; do
+              if ! kill -0 "$expo_pid" 2>/dev/null || [ "$expo_sync_attempt" -ge 20 ]; then
+                sed -n "1,240p" "$expo_log" >&2
+                exit 1
+              fi
+              sleep 1
+              expo_sync_attempt=$((expo_sync_attempt + 1))
+            done
+            test -n "$(pgrep -P "$expo_pid" -f "project-source-sync.py preview-loop" | head -n 1)"
+            echo "Expo native-mirror preview smoke passed in ${expo_attempt}s"
+            cleanup_expo_test
+            trap - EXIT
+
             test -f /home/node/.cheatcode/default-skills/browser-use/SKILL.md
             test -f /home/node/.cheatcode/default-skills/pptx/SKILL.md
             test -f /home/node/.cheatcode/default-skills/pptx/scripts/thumbnail.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ current architecture.
 |---|---|
 | Backend | Cloudflare Workers, Durable Objects, and Workflows |
 | Frontend | Next.js 16.2.11, React 19.2.7, Tailwind CSS 4.3.2, AI Elements, and Streamdown on Vercel |
-| Agent framework | Mastra 1.51.0 on Vercel AI SDK 6.0.205 |
+| Agent framework | Mastra 1.57.0 on Vercel AI SDK 7.0.58 |
 | Sandbox | Per-user Daytona sandboxes through a bounded REST-over-fetch client |
 | Browser runtime | Stagehand 3.7.0 in local mode inside the Daytona sandbox |
 | Database | Supabase Postgres only, through Cloudflare Hyperdrive and Drizzle ORM 0.45.2 |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ You need:
 - Docker with Docker Compose;
 - a dedicated Supabase project—the free tier is sufficient;
 - Clerk development keys; and
-- a Daytona API key plus an immutable Cheatcode sandbox snapshot.
+- a Daytona API key plus an immutable Cheatcode sandbox snapshot; and
+- a Morph API key for server-side FastApply edits.
 
 Install and launch the guided setup:
 

--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -12,6 +12,8 @@ user header.
 The Worker implements the provider-neutral sandbox and artifact ports from
 `@cheatcode/sandbox-contracts`. Daytona control-plane and toolbox details remain
 behind `@cheatcode/agent-core/tools/code` and do not load the root Mastra surface.
+Mastra's optional local-process dependency is mapped to a fail-fast module at the
+Wrangler boundary because process spawning is unavailable and unused in the Worker.
 
 Generated artifacts use a crash-consistent Postgres/R2 protocol. Content determines the output
 UUID, object key, and SHA-256 metadata. The Worker durably reserves that identity,
@@ -159,11 +161,12 @@ registers the managed preview even when the selected model would otherwise attem
 work and finish without a Computer target.
 The starter page is an internal server-readiness target, not user-facing generated content. A
 fresh template run emits the typed `app-preview-status` transition from `building` to `ready` only
-after model execution (and the mobile preview restart, when applicable), so the web client can keep
+after model execution, so the web client can keep
 the branded loading surface over the scaffold without relying on timers or iframe inspection.
 The canonical app source remains on the durable `/workspace` volume. Managed Next.js previews
-compile from a sandbox-local one-way mirror because Daytona's object-store FUSE mount can stall
-webpack compilation even after the listening socket opens. A baked Python synchronizer compares
+and Expo/Metro previews compile from a sandbox-local one-way mirror because Daytona's object-store
+FUSE mount can stall compilation and does not provide reliable native file-watcher events. A baked
+Python synchronizer compares
 content identities rather than unrelated FUSE/native-disk timestamps, performs atomic replacement
 on native disk and checksum-verified direct overwrites on the non-POSIX durable mount, and mirrors
 subsequent writes and deletions within 250 ms, including equal-size and
@@ -230,8 +233,9 @@ after a cold sandbox start; the default remains atomic replacement. The comparis
 policy, port, working directory, and a one-way environment digest, so request-scoped environment
 values are neither persisted nor ignored. Follow-up web app-builder runs opt into reuse and
 therefore keep a healthy preview and its build cache alive until an actual configuration change
-requires replacement; Expo retains replacement semantics because its signed launch environment is
-ephemeral and its post-edit file-map must be rebuilt.
+requires replacement. Expo retains replacement semantics because its signed launch environment is
+ephemeral, but its native-disk source feed hot-reloads durable edits without a second post-run
+Metro restart.
 At capacity, ProjectSandbox reconciles the
 bounded record set against Daytona, removes missing or completed sessions and their port state,
 and rejects a new distinct slot only when all 32 remain live.

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -21,9 +21,8 @@ import {
   writeAppBuilderFiles,
   writeExpoRuntimeFiles,
 } from "./agent-run-app-builder-scaffold";
-import { localNextPreviewCommand } from "./app-builder-local-preview";
+import { localExpoPreviewCommand, localNextPreviewCommand } from "./app-builder-local-preview";
 import {
-  EXPO_RUNTIME_BIN,
   EXPO_TEMPLATE_DIR,
   NEXT_TEMPLATE_DIR,
   projectLocalCacheDir,
@@ -254,27 +253,6 @@ async function startTemplatePreview(options: WorkspaceOptions): Promise<void> {
   } else {
     await startAppBuilderDevServer(sandbox, workspace);
   }
-  await append({
-    type: "data-sandbox-status",
-    data: { v: 1, status: "ready" },
-  });
-}
-
-// Metro (mobile) starts BEFORE the model edits files, and its file-watcher never observes the
-// agent's Daytona uploadFile writes in the sandbox container (no watchman + unreliable inotify —
-// the same reason the Next.js path force-polls). So its in-memory file-map keeps bundling the
-// scaffold even after the counter lands on disk, and a browser hard-refresh just re-bundles from
-// that stale map. Restarting the dev server once the edit stream completes makes a fresh Metro
-// process re-crawl the workspace and bundle the finished app. This call deliberately replaces the
-// project's stable dev-server slot; the authenticated preview wake path keeps the same port.
-// Mobile only — web/Next.js hot-reloads via polling.
-export async function restartMobilePreview(
-  options: Pick<RunAppBuilderOptions, "append" | "input" | "logger" | "sandbox" | "setRunStage">,
-): Promise<void> {
-  const { append, input, logger, sandbox, setRunStage } = options;
-  await setRunStage("Reloading the preview.");
-  const workspace = await resolveAppWorkspace(sandbox, input, logger);
-  await startExpoDevServer(sandbox, logger, workspace);
   await append({
     type: "data-sandbox-status",
     data: { v: 1, status: "ready" },
@@ -538,19 +516,14 @@ async function startExpoDevServer(
       // build as a real web page at `/` (iframe-renderable in the Computer panel),
       // while the SAME server keeps answering exp:// manifests for Expo Go — so we
       // get both the in-panel preview and the QR from one process on the project port.
-      // `-c` clears Metro's transform/file-map cache on start (boolean flag, order-
-      // independent among the other flags): harmless on the initial boot, and what
-      // makes the post-edit restart (restartMobilePreview) re-crawl from a clean slate.
-      command: [
-        EXPO_RUNTIME_BIN,
-        "start",
-        "-c",
-        "--web",
-        "--host",
-        "lan",
-        "--port",
-        String(workspace.port),
-      ],
+      // Metro runs against the same supervised native-disk source mirror as Next. Durable
+      // workspace edits reach that mirror atomically, so Metro's native watcher hot-reloads them
+      // without the old post-run restart.
+      command: localExpoPreviewCommand({
+        port: workspace.port,
+        sourceDir: workspace.dir,
+        workspaceSlug: workspace.slug,
+      }),
       cwd: workspace.dir,
       env: {
         CHEATCODE_APP_RUNTIME: "expo",

--- a/apps/agent-worker/src/durable-objects/agent-run-path.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-path.ts
@@ -1,7 +1,7 @@
 import type { createLogger } from "@cheatcode/observability";
 import type { CodeRuntimeContext, WorkspaceResolver } from "@cheatcode/sandbox-contracts";
 import type { UIMessageChunk } from "ai";
-import { restartMobilePreview, runAppBuilder, warmSandbox } from "./agent-run-app-builder";
+import { runAppBuilder, warmSandbox } from "./agent-run-app-builder";
 import type { AgentRunEnv } from "./agent-run-env";
 import type { StartRunInput } from "./agent-run-schemas";
 
@@ -55,26 +55,10 @@ export async function finalizeAppBuilderRun(prepared: {
   waitsForGeneratedPreview: boolean;
 }): Promise<void> {
   const options = { ...prepared.options, input: requireProjectBinding(prepared.options.input) };
-  await restartMobilePreviewIfNeeded(options);
   if (prepared.waitsForGeneratedPreview) {
     await options.append({
       type: "data-app-preview-status",
       data: { v: 1, status: "ready" },
-    });
-  }
-}
-
-async function restartMobilePreviewIfNeeded(
-  options: ProjectBoundAppBuilderRunOptions,
-): Promise<void> {
-  if (options.input.projectMode !== "app-builder-mobile") {
-    return;
-  }
-  try {
-    await restartMobilePreview(options);
-  } catch (error) {
-    options.logger.warn("mobile_preview_restart_failed", {
-      error,
     });
   }
 }

--- a/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
+++ b/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
@@ -1,5 +1,7 @@
 import { localProjectProcessCommand } from "./project-sandbox-local-source";
 import {
+  EXPO_RUNTIME_BIN,
+  EXPO_TEMPLATE_DIR,
   NEXT_RUNTIME_BIN,
   NEXT_TEMPLATE_DIR,
   resolveProjectLocalRuntime,
@@ -13,10 +15,7 @@ interface LocalPreviewCommandInput {
 
 /** Runs Next from native sandbox disk while `/workspace` remains the durable project source. */
 export function localNextPreviewCommand(input: LocalPreviewCommandInput): string[] {
-  const runtime = resolveProjectLocalRuntime(input.sourceDir);
-  if (!runtime || runtime.workspaceSlug !== input.workspaceSlug) {
-    throw new TypeError("Preview source does not match its workspace slug.");
-  }
+  const runtime = requireLocalPreviewRuntime(input);
   const nextCommand = [
     NEXT_RUNTIME_BIN,
     "dev",
@@ -27,4 +26,28 @@ export function localNextPreviewCommand(input: LocalPreviewCommandInput): string
     String(input.port),
   ];
   return localProjectProcessCommand(runtime, nextCommand, NEXT_TEMPLATE_DIR);
+}
+
+/** Runs Expo/Metro from native sandbox disk while `/workspace` remains durable source. */
+export function localExpoPreviewCommand(input: LocalPreviewCommandInput): string[] {
+  const runtime = requireLocalPreviewRuntime(input);
+  const expoCommand = [
+    EXPO_RUNTIME_BIN,
+    "start",
+    "-c",
+    "--web",
+    "--host",
+    "lan",
+    "--port",
+    String(input.port),
+  ];
+  return localProjectProcessCommand(runtime, expoCommand, EXPO_TEMPLATE_DIR);
+}
+
+function requireLocalPreviewRuntime(input: LocalPreviewCommandInput) {
+  const runtime = resolveProjectLocalRuntime(input.sourceDir);
+  if (!runtime || runtime.workspaceSlug !== input.workspaceSlug) {
+    throw new TypeError("Preview source does not match its workspace slug.");
+  }
+  return runtime;
 }

--- a/apps/agent-worker/src/platform/execa-unavailable.ts
+++ b/apps/agent-worker/src/platform/execa-unavailable.ts
@@ -1,0 +1,10 @@
+function throwUnavailable(): never {
+  throw new Error("Local process execution is unavailable in the Cloudflare Worker runtime");
+}
+
+export const $ = throwUnavailable;
+export const execa = throwUnavailable;
+export const execaCommand = throwUnavailable;
+export const execaCommandSync = throwUnavailable;
+export const execaNode = throwUnavailable;
+export const execaSync = throwUnavailable;

--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -6,6 +6,9 @@
   "main": "src/index.ts",
   "compatibility_date": "2026-07-15",
   "compatibility_flags": ["nodejs_compat"],
+  "alias": {
+    "execa": "./src/platform/execa-unavailable.ts"
+  },
   "limits": {
     "subrequests": 10000000
   },

--- a/apps/web/src/components/home/home-composer-intents.ts
+++ b/apps/web/src/components/home/home-composer-intents.ts
@@ -1,9 +1,12 @@
 import type { ComponentType } from "react";
-import { skillSurface } from "@/components/home/use-initial-skill";
+import { skillBuildSurface } from "@/components/home/use-initial-skill";
 import { Globe, Smartphone, Star, TrendingUp } from "@/components/ui";
 import { CheatcodeMark } from "@/components/ui/cheatcode-mark";
 
 export type IntentId = "data" | "mobile-app" | "research" | "slides" | "web-app";
+
+/** Runtime/preview topology only; research, data, and slides remain work intents. */
+export type BuildSurface = "mobile" | "web";
 
 export type ComposerIntent = {
   icon: ComponentType<{ className?: string; "aria-hidden"?: boolean | "false" | "true" }>;
@@ -11,7 +14,7 @@ export type ComposerIntent = {
   label: string;
   placeholder: string;
   skill: null | string;
-  surface: "mobile" | "web" | null;
+  buildSurface: BuildSurface | null;
 };
 
 export const COMPOSER_INTENTS: readonly ComposerIntent[] = [
@@ -21,7 +24,7 @@ export const COMPOSER_INTENTS: readonly ComposerIntent[] = [
     label: "Mobile app",
     placeholder: "Describe the app - I'll build it with a live phone preview",
     skill: null,
-    surface: "mobile",
+    buildSurface: "mobile",
   },
   {
     icon: Globe,
@@ -29,7 +32,7 @@ export const COMPOSER_INTENTS: readonly ComposerIntent[] = [
     label: "Web app",
     placeholder: "Describe the site or web app - I'll build and preview it",
     skill: null,
-    surface: "web",
+    buildSurface: "web",
   },
   {
     icon: Star,
@@ -37,7 +40,7 @@ export const COMPOSER_INTENTS: readonly ComposerIntent[] = [
     label: "Slides",
     placeholder: "What's the deck about? Audience and key points help",
     skill: "pitch-deck",
-    surface: null,
+    buildSurface: null,
   },
   {
     icon: CheatcodeMark,
@@ -45,7 +48,7 @@ export const COMPOSER_INTENTS: readonly ComposerIntent[] = [
     label: "Research",
     placeholder: "What should I research? I'll fan out agents and cite sources",
     skill: "deep-research",
-    surface: null,
+    buildSurface: null,
   },
   {
     icon: TrendingUp,
@@ -53,7 +56,7 @@ export const COMPOSER_INTENTS: readonly ComposerIntent[] = [
     label: "Data",
     placeholder: "Attach or describe the data - I'll profile and chart it",
     skill: "csv-analyst",
-    surface: null,
+    buildSurface: null,
   },
 ] as const;
 
@@ -73,14 +76,14 @@ export function resolveSubmitSkill(
 }
 
 /** The build surface (mobile/web/null) implied by the current intent or imported repo. */
-export function resolveSubmitSurface(
+export function resolveSubmitBuildSurface(
   repoUrl: string | null,
   intentId: IntentId | null,
   intent: ComposerIntent | null,
   skillChip: string | null,
-): "mobile" | "web" | null {
+): BuildSurface | null {
   if (repoUrl) {
     return intentId === "mobile-app" ? "mobile" : "web";
   }
-  return intent ? intent.surface : skillSurface(skillChip);
+  return intent ? intent.buildSurface : skillBuildSurface(skillChip);
 }

--- a/apps/web/src/components/home/home-composer-prompt-state.ts
+++ b/apps/web/src/components/home/home-composer-prompt-state.ts
@@ -1,14 +1,15 @@
 "use client";
 
 import type { RunIntent } from "@cheatcode/types/api";
+import type { BuildSurface } from "@/components/home/home-composer-intents";
 import { createPromptHandoff } from "@/lib/input/prompt-handoff";
 
 export function buildLaunchParams(input: {
+  buildSurface: BuildSurface | null;
   intent: RunIntent | null;
   model: null | string;
   prompt: string;
   repo: null | string;
-  surface: "mobile" | "web" | null;
 }): URLSearchParams {
   const params = new URLSearchParams();
   if (input.intent) {
@@ -17,8 +18,8 @@ export function buildLaunchParams(input: {
   if (input.prompt.length > 0) {
     params.set("promptKey", createPromptHandoff(input.prompt).promptKey);
   }
-  if (input.surface) {
-    params.set("surface", input.surface);
+  if (input.buildSurface) {
+    params.set("surface", input.buildSurface);
   }
   if (input.model) {
     params.set("model", input.model);

--- a/apps/web/src/components/home/use-home-composer-submission.ts
+++ b/apps/web/src/components/home/use-home-composer-submission.ts
@@ -5,12 +5,19 @@ import type { ProjectSummary, RunIntent } from "@cheatcode/types/api";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { composePromptWithComposerContext } from "@/components/composer/composer-context-chips";
-import type { ComposerIntent, IntentId } from "@/components/home/home-composer-intents";
-import { resolveSubmitSkill, resolveSubmitSurface } from "@/components/home/home-composer-intents";
+import type {
+  BuildSurface,
+  ComposerIntent,
+  IntentId,
+} from "@/components/home/home-composer-intents";
+import {
+  resolveSubmitBuildSurface,
+  resolveSubmitSkill,
+} from "@/components/home/home-composer-intents";
 import { buildLaunchParams } from "@/components/home/home-composer-prompt-state";
 import { type AgentModelId, agentModelRequestValue } from "@/lib/agent-models";
 import { buildExistingProjectParams, launchIntoProject } from "@/lib/api/home-launch";
-import { createChat, surfaceToMode, threadTitle } from "@/lib/api/project-thread";
+import { buildSurfaceToMode, createChat, threadTitle } from "@/lib/api/project-thread";
 import { assertUserMessageWithinLimit } from "@/lib/input/prompt-attachments";
 
 interface HomeSubmissionState {
@@ -26,12 +33,12 @@ interface HomeSubmissionState {
 }
 
 interface HomeSubmissionSnapshot {
+  buildSurface: BuildSurface | null;
   intent: RunIntent | null;
   model: null | string;
   project: ProjectSummary | null;
   prompt: string;
   repoUrl: string | null;
-  surface: "mobile" | "web" | null;
 }
 
 interface SubmissionRuntime {
@@ -91,12 +98,17 @@ function buildSubmissionSnapshot(state: HomeSubmissionState): HomeSubmissionSnap
     return null;
   }
   return {
+    buildSurface: resolveSubmitBuildSurface(
+      state.repoUrl,
+      state.intentId,
+      state.intent,
+      state.skillChip,
+    ),
     intent: state.skillCreatorMode ? "skill-creator" : null,
     model: agentModelRequestValue(state.agentModelId) ?? null,
     project: state.selectedProject,
     prompt,
     repoUrl: state.repoUrl,
-    surface: resolveSubmitSurface(state.repoUrl, state.intentId, state.intent, state.skillChip),
   };
 }
 
@@ -145,7 +157,7 @@ async function startNewChat(
     const thread = await createChat(runtime.getToken, {
       initialPrompt: snapshot.prompt,
       title: threadTitle(snapshot.prompt),
-      mode: surfaceToMode(snapshot.surface),
+      mode: buildSurfaceToMode(snapshot.buildSurface),
       ...(snapshot.repoUrl ? { importRepoUrl: snapshot.repoUrl } : {}),
       ...(snapshot.model ? { defaultModel: snapshot.model } : {}),
     });
@@ -166,7 +178,7 @@ function preservePromptForSignIn(
       model: snapshot.model,
       prompt: snapshot.prompt,
       repo: snapshot.repoUrl,
-      surface: snapshot.surface,
+      buildSurface: snapshot.buildSurface,
     });
     runtime.setAuthRedirectTo(`/?${params.toString()}`);
   } catch (error) {

--- a/apps/web/src/components/home/use-initial-skill.ts
+++ b/apps/web/src/components/home/use-initial-skill.ts
@@ -1,7 +1,7 @@
 import { SKILL_MANIFEST } from "@cheatcode/skills/manifest";
 
 type SkillIntent = "data" | "research" | "slides";
-export type SkillSurface = "mobile" | "web";
+export type SkillBuildSurface = "mobile" | "web";
 
 // Skills that map onto an existing intent pill (the design's slide/research/data lanes).
 const SKILL_TO_INTENT: Record<string, SkillIntent> = {
@@ -11,7 +11,7 @@ const SKILL_TO_INTENT: Record<string, SkillIntent> = {
 };
 
 // Skills that fix the build surface but have no intent pill.
-const SKILL_TO_SURFACE: Record<string, SkillSurface> = {
+const SKILL_TO_BUILD_SURFACE: Record<string, SkillBuildSurface> = {
   "mobile-app": "mobile",
 };
 
@@ -39,6 +39,6 @@ export function resolveInitialSkill(skill: string | null | undefined): InitialSk
   return { chip: skill, intent: null };
 }
 
-export function skillSurface(skill: string | null): SkillSurface | null {
-  return skill ? (SKILL_TO_SURFACE[skill] ?? null) : null;
+export function skillBuildSurface(skill: string | null): SkillBuildSurface | null {
+  return skill ? (SKILL_TO_BUILD_SURFACE[skill] ?? null) : null;
 }

--- a/apps/web/src/lib/api/project-thread.ts
+++ b/apps/web/src/lib/api/project-thread.ts
@@ -480,12 +480,12 @@ function uiMessageRole(value: string): CheatcodeUIMessage["role"] | null {
   return null;
 }
 
-/** Maps a composer build surface to the chat's launch-intent mode. */
-export function surfaceToMode(surface: string | null): ProjectMode {
-  if (surface === "mobile") {
+/** Maps the composer's preview/runtime choice to the persisted project mode. */
+export function buildSurfaceToMode(buildSurface: string | null): ProjectMode {
+  if (buildSurface === "mobile") {
     return "app-builder-mobile";
   }
-  return surface === "web" ? "app-builder" : "general";
+  return buildSurface === "web" ? "app-builder" : "general";
 }
 
 /** Derives a chat's title from its first prompt; an empty/absent prompt reads "New chat". */

--- a/infra/containers/sandbox/Dockerfile
+++ b/infra/containers/sandbox/Dockerfile
@@ -272,7 +272,7 @@ RUN set -eux; \
   cp /home/node/.cheatcode-template-manifests/expo/pnpm-lock.yaml /home/node/cheatcode-expo-template/pnpm-lock.yaml; \
   cp /home/node/.cheatcode-template-manifests/expo/pnpm-workspace.yaml /home/node/cheatcode-expo-template/pnpm-workspace.yaml; \
   cd /home/node/cheatcode-expo-template; \
-  node -e 'const fs=require("node:fs");const j=JSON.parse(fs.readFileSync("app.json","utf8"));j.expo??={};j.expo.name="cheatcode-expo-template";j.expo.slug="cheatcode-expo-template";j.expo.web={...(j.expo.web??{}),bundler:"metro",output:"single"};fs.writeFileSync("app.json",JSON.stringify(j,null,2)+"\n")'; \
+  node /home/node/.cheatcode-app-generators/configure-expo-template.mjs app.json; \
   rm -rf .git .expo node_modules package-lock.json AGENTS.md CLAUDE.md .claude; \
   cp -a /home/node/cheatcode-expo-template /home/node/.cheatcode/app-runtimes/expo; \
   cd /home/node/.cheatcode/app-runtimes/expo; \

--- a/infra/containers/sandbox/app-generators/configure-expo-template.mjs
+++ b/infra/containers/sandbox/app-generators/configure-expo-template.mjs
@@ -1,0 +1,41 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+const appConfigPath = process.argv[2];
+if (!appConfigPath) {
+  throw new TypeError("Expo template configuration requires an app.json path");
+}
+
+const appConfig = JSON.parse(await readFile(appConfigPath, "utf8"));
+const expoConfig = appConfig.expo;
+if (!expoConfig || typeof expoConfig !== "object" || Array.isArray(expoConfig)) {
+  throw new TypeError("Pinned Expo template does not contain an expo configuration");
+}
+if (!Array.isArray(expoConfig.plugins)) {
+  throw new TypeError("Pinned Expo template does not contain a plugins array");
+}
+
+let hasSplashScreenPlugin = false;
+expoConfig.plugins = expoConfig.plugins.map((entry) => {
+  if (entry === "expo-splash-screen") {
+    hasSplashScreenPlugin = true;
+    return "expo-splash-screen/app.plugin.js";
+  }
+  if (Array.isArray(entry) && entry[0] === "expo-splash-screen") {
+    hasSplashScreenPlugin = true;
+    return ["expo-splash-screen/app.plugin.js", ...entry.slice(1)];
+  }
+  return entry;
+});
+if (!hasSplashScreenPlugin) {
+  throw new TypeError("Pinned Expo template no longer declares expo-splash-screen");
+}
+
+expoConfig.name = "cheatcode-expo-template";
+expoConfig.slug = "cheatcode-expo-template";
+expoConfig.web = {
+  ...(expoConfig.web ?? {}),
+  bundler: "metro",
+  output: "single",
+};
+
+await writeFile(appConfigPath, `${JSON.stringify(appConfig, null, 2)}\n`);

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -10,9 +10,19 @@
   "workspaces": {
     ".": {
       // Skill TypeScript files are executable snapshot entrypoints discovered by
-      // `cheatcode-skills`; the pnpm policy executable is invoked by the sandbox's
-      // Python supervisor. Both are intentionally outside the pnpm workspace graph.
-      "entry": ["skills/**/*.ts", "infra/containers/sandbox/scripts/pnpm-build-policy.mjs"]
+      // `cheatcode-skills`; the container scripts are invoked by the sandbox Dockerfile
+      // or its Python supervisor. These edges sit outside the pnpm workspace graph.
+      "entry": [
+        "skills/**/*.ts",
+        "infra/containers/sandbox/app-generators/configure-expo-template.mjs",
+        "infra/containers/sandbox/scripts/pnpm-build-policy.mjs"
+      ]
+    },
+    "apps/agent-worker": {
+      // Wrangler reaches the platform module through its `alias` deployment
+      // configuration, which is intentionally outside TypeScript's import graph.
+      "entry": ["src/platform/execa-unavailable.ts"],
+      "includeEntryExports": false
     },
     "packages/db": {
       "drizzle": {

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -41,7 +41,8 @@ omits it, and is distinct from generic background process tools so idle recovery
 canonical process record. Identical healthy starts are idempotent, and the sandbox-local launcher
 restores missing dependencies before readiness. Web app-builder preparation
 opts into matching-process reuse to avoid taking down a healthy preview on every follow-up; Expo
-retains replacement semantics for its ephemeral signed launch environment and post-edit restart.
+retains replacement semantics for its ephemeral signed launch environment while the shared
+native-disk source feed provides hot reload without a post-edit restart.
 Browser-only runs use the account sandbox without materializing a persistent project;
 workspace-backed file, shell, document, chart, or artifact work resolves the thread's
 project lazily when durable project storage is actually needed. Code tools expose `/workspace`
@@ -87,6 +88,11 @@ The production agent loop does not rely on that in-memory store for ownership.
 turn in Cloudflare Workflow, and then reconstructs each selected tool in a separate
 Workflow step. Provider keys and tool credentials are reacquired inside each step
 and never enter Workflow state.
+The catalog uses the current AI SDK provider generation. Anthropic's adapter sends the known
+128K Sonnet/Opus output maximum, DeepSeek V4 Pro receives its advertised 384K maximum explicitly
+instead of the API's smaller omitted-value default, and OpenAI/OpenRouter intentionally omit an
+artificial common ceiling so the selected provider model owns its maximum. A model-only turn that
+still ends with `length` is continued semantically rather than treated as successful completion.
 
 Nested research workflows bind the calling tool's abort signal idempotently to
 the Mastra workflow run, forward the synthesis step signal through its nested

--- a/packages/agent-core/src/mastra/durable-agent-step.ts
+++ b/packages/agent-core/src/mastra/durable-agent-step.ts
@@ -4,6 +4,11 @@ import { z } from "zod";
 import { mastra } from "./index";
 import { cheatcodeTools } from "./tool-defs/tool-set";
 
+// DeepSeek leaves max_tokens at a much smaller API default when callers omit it even though the
+// selected V4 Pro model supports a 384K output window. Use the model's advertised maximum so tool
+// arguments are not truncated by a transport default; semantic completion still controls the loop.
+const DEEPSEEK_V4_PRO_MAX_OUTPUT_TOKENS = 384_000;
+
 export const GeneralAgentFinishReasonSchema = z.enum([
   "stop",
   "length",
@@ -57,6 +62,9 @@ export async function generateGeneralAgentStep(
     clientTools: cheatcodeTools,
     ...(options.isDeepSeek
       ? { providerOptions: { deepseek: { thinking: { type: "disabled" as const } } } }
+      : {}),
+    ...(options.isDeepSeek
+      ? { modelSettings: { maxOutputTokens: DEEPSEEK_V4_PRO_MAX_OUTPUT_TOKENS } }
       : {}),
     requestContext: options.requestContext,
     runId: options.runId,

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -70,6 +70,9 @@ The root setup wizard and `scripts/dev.ts` share one scalar local-environment
 contract for required keys, forbidden cloud credentials, development value
 pins, secret distinctness, and Supabase pooler topology. `pnpm dev:setup --check`
 uses that same surface without mutating files or database state.
+`MORPH_API_KEY` is a required Worker-only input in that shared contract: the wizard
+collects it masked, generated local Wrangler config exposes it only to agent-worker,
+and production resolves the matching `morph-api-key` Secrets Store binding.
 
 Destructive Worker-to-Worker calls use named Cloudflare RPC entrypoints with
 static authenticated caller/capability properties. The gateway receives only

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@ai-sdk/anthropic':
-      specifier: 3.0.107
-      version: 3.0.107
+      specifier: 4.0.36
+      version: 4.0.36
     '@ai-sdk/deepseek':
-      specifier: 2.0.39
-      version: 2.0.39
+      specifier: 3.0.26
+      version: 3.0.26
     '@ai-sdk/openai':
-      specifier: 3.0.71
-      version: 3.0.71
+      specifier: 4.0.36
+      version: 4.0.36
     '@ai-sdk/react':
-      specifier: 3.0.207
-      version: 3.0.207
+      specifier: 4.0.61
+      version: 4.0.61
     '@biomejs/biome':
       specifier: 2.5.2
       version: 2.5.2
@@ -34,8 +34,8 @@ catalogs:
       specifier: 1.25.4
       version: 1.25.4
     '@cloudflare/workers-types':
-      specifier: 5.20260716.1
-      version: 5.20260716.1
+      specifier: 5.20260722.1
+      version: 5.20260722.1
     '@commitlint/cli':
       specifier: 21.2.1
       version: 21.2.1
@@ -43,20 +43,20 @@ catalogs:
       specifier: 21.2.0
       version: 21.2.0
     '@google/genai':
-      specifier: 2.12.0
-      version: 2.12.0
+      specifier: 2.16.0
+      version: 2.16.0
     '@hookform/resolvers':
       specifier: 5.4.0
       version: 5.4.0
     '@mastra/core':
-      specifier: 1.51.0
-      version: 1.51.0
+      specifier: 1.57.0
+      version: 1.57.0
     '@next/env':
       specifier: 16.2.11
       version: 16.2.11
     '@openrouter/ai-sdk-provider':
-      specifier: 2.9.1
-      version: 2.9.1
+      specifier: 3.0.0
+      version: 3.0.0
     '@polar-sh/sdk':
       specifier: 0.48.1
       version: 0.48.1
@@ -94,8 +94,8 @@ catalogs:
       specifier: 19.2.3
       version: 19.2.3
     ai:
-      specifier: 6.0.205
-      version: 6.0.205
+      specifier: 7.0.58
+      version: 7.0.58
     arquero:
       specifier: 8.0.3
       version: 8.0.3
@@ -261,7 +261,7 @@ importers:
         version: 6.0.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.114.0(@cloudflare/workers-types@5.20260716.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        version: 4.114.0(@cloudflare/workers-types@5.20260722.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   apps/agent-worker:
     dependencies:
@@ -309,7 +309,7 @@ importers:
         version: link:../../packages/types
       ai:
         specifier: 'catalog:'
-        version: 6.0.205(zod@4.4.3)
+        version: 7.0.58(zod@4.4.3)
       hono:
         specifier: 'catalog:'
         version: 4.12.34
@@ -322,13 +322,13 @@ importers:
         version: link:../../packages/tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 5.20260716.1
+        version: 5.20260722.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.114.0(@cloudflare/workers-types@5.20260716.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        version: 4.114.0(@cloudflare/workers-types@5.20260722.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   apps/gateway-worker:
     dependencies:
@@ -371,13 +371,13 @@ importers:
         version: link:../../packages/tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 5.20260716.1
+        version: 5.20260722.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.114.0(@cloudflare/workers-types@5.20260716.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        version: 4.114.0(@cloudflare/workers-types@5.20260722.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   apps/preview-proxy:
     dependencies:
@@ -402,19 +402,19 @@ importers:
         version: link:../../packages/tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 5.20260716.1
+        version: 5.20260722.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.114.0(@cloudflare/workers-types@5.20260716.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        version: 4.114.0(@cloudflare/workers-types@5.20260722.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   apps/web:
     dependencies:
       '@ai-sdk/react':
         specifier: 'catalog:'
-        version: 3.0.207(react@19.2.7)(zod@4.4.3)
+        version: 4.0.61(react@19.2.7)(zod@4.4.3)
       '@cheatcode/env':
         specifier: workspace:*
         version: link:../../packages/env
@@ -453,7 +453,7 @@ importers:
         version: 3.14.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ai:
         specifier: 'catalog:'
-        version: 6.0.205(zod@4.4.3)
+        version: 7.0.58(zod@4.4.3)
       cmdk:
         specifier: 'catalog:'
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -575,25 +575,25 @@ importers:
         version: link:../../packages/tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 5.20260716.1
+        version: 5.20260722.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
       wrangler:
         specifier: 'catalog:'
-        version: 4.114.0(@cloudflare/workers-types@5.20260716.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+        version: 4.114.0(@cloudflare/workers-types@5.20260722.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   packages/agent-core:
     dependencies:
       '@ai-sdk/anthropic':
         specifier: 'catalog:'
-        version: 3.0.107(zod@4.4.3)
+        version: 4.0.36(zod@4.4.3)
       '@ai-sdk/deepseek':
         specifier: 'catalog:'
-        version: 2.0.39(zod@4.4.3)
+        version: 3.0.26(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: 'catalog:'
-        version: 3.0.71(zod@4.4.3)
+        version: 4.0.36(zod@4.4.3)
       '@cheatcode/composio':
         specifier: workspace:*
         version: link:../composio
@@ -614,16 +614,16 @@ importers:
         version: link:../types
       '@google/genai':
         specifier: 'catalog:'
-        version: 2.12.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(bufferutil@4.1.0)(supports-color@10.2.2)(utf-8-validate@5.0.10)
+        version: 2.16.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(bufferutil@4.1.0)(supports-color@10.2.2)(utf-8-validate@5.0.10)
       '@mastra/core':
         specifier: 'catalog:'
-        version: 1.51.0(ai@6.0.205(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+        version: 1.57.0(ai@7.0.58(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@openrouter/ai-sdk-provider':
         specifier: 'catalog:'
-        version: 2.9.1(ai@6.0.205(zod@4.4.3))(zod@4.4.3)
+        version: 3.0.0(ai@7.0.58(zod@4.4.3))(zod@4.4.3)
       ai:
         specifier: 'catalog:'
-        version: 6.0.205(zod@4.4.3)
+        version: 7.0.58(zod@4.4.3)
       arquero:
         specifier: 'catalog:'
         version: 8.0.3
@@ -683,7 +683,7 @@ importers:
         version: link:../tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 5.20260716.1
+        version: 5.20260722.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -701,7 +701,7 @@ importers:
         version: link:../types
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@5.20260716.1)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+        version: 0.45.2(@cloudflare/workers-types@5.20260722.1)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -739,7 +739,7 @@ importers:
         version: link:../types
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.45.2(@cloudflare/workers-types@5.20260716.1)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
+        version: 0.45.2(@cloudflare/workers-types@5.20260722.1)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0)
       pg:
         specifier: 'catalog:'
         version: 8.22.0
@@ -770,7 +770,7 @@ importers:
         version: link:../tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 5.20260716.1
+        version: 5.20260722.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -789,7 +789,7 @@ importers:
         version: link:../tsconfig
       '@cloudflare/workers-types':
         specifier: 'catalog:'
-        version: 5.20260716.1
+        version: 5.20260722.1
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -876,7 +876,7 @@ importers:
     dependencies:
       ai:
         specifier: 'catalog:'
-        version: 6.0.205(zod@4.4.3)
+        version: 7.0.58(zod@4.4.3)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -905,103 +905,81 @@ packages:
       express:
         optional: true
 
-  '@ai-sdk/anthropic@3.0.107':
-    resolution: {integrity: sha512-aXwAv1v9ezU3lkAvcz4dfuzJb30ioLk0WRhwpuDgCGKN0dEZiNLeDuyVcRqxWRlYc4Zg4Z4rJcZBKmzJTdzrtw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/deepseek@2.0.39':
-    resolution: {integrity: sha512-3wUq1cvqSWkRadCSqcDXBLpOwUAe+JqfWQZS0fK0sWiqDeTIEzsse+r7xcN2x5XpJjefT0d7FQTa3u2lZ/yxbg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/gateway@3.0.131':
-    resolution: {integrity: sha512-CnjOZdywQaUnCyZ0N5wVNm7Sm63+NeHDVZQJKFX2IDq+t03SLwiiuoi3ILTLPlM+YSOhkQ/pvIDoR4qa98Zp5A==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/openai@3.0.71':
-    resolution: {integrity: sha512-j6eBAa5oHFZ4U5CxpIV3T4zXNM/BviodNCZCL1qHkA4aqkwK9iQ18TWYz2DZcXpw4BO5pikKzqpXORxb1EnZGA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@2.2.8':
-    resolution: {integrity: sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
-
-  '@ai-sdk/provider-utils@3.0.28':
-    resolution: {integrity: sha512-bXlX1WX7E50a2N+AJW+1a/x63m52aPhm+6xYe5THxWrx9vW9NR7E2Ay+1G1ndlCdMdYKo2Fnsd7kBhuyQPaphw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.29':
-    resolution: {integrity: sha512-uhukHaCBvqkwBHkT8C2PrnqKTCoLn3pdHXqtcR9I8ErH+flbzgW4o7VHSNIup9LRu+WBvZIZDQLsx6rwl2tiOA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.30':
-    resolution: {integrity: sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.38':
-    resolution: {integrity: sha512-/HHGmtKllqjg1OLc023v9w9kK3laW7Z6TzfZukYQWCsGBbzB9p60zTvvpXFVcs44NZBVXL3viOa1HRKUbeee8g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.42':
-    resolution: {integrity: sha512-Q07lZsq4ir+xwAGVfSbY2WNGLrbfWINFaL2I/vTBFrkuXeP7VZh+UtQgLOKZS6Z/6flNFW22jDYdbINvwTV/PA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@5.0.7':
-    resolution: {integrity: sha512-OSm5/5kdrHa11WIOo5LYgDKnxYWp5aB/wx5EXRHi0jpUGduMDeB6oht9U6p+UNNWIP3F/EqPpV8d7vdP/iRnqg==}
+  '@ai-sdk/anthropic@4.0.36':
+    resolution: {integrity: sha512-Wg5jfray0X4+qkrr73GZ7U7K2JNGx+S+rNY9LorVlXhkhTqnvtNLYWRA1WxSxlCDCw3yjRCJdL9kyc+b7naAog==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@1.1.3':
-    resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
+  '@ai-sdk/deepseek@3.0.26':
+    resolution: {integrity: sha512-NLX7ExuHko38aBKM4x2BxC11fjqFz4lAxAH3v6IRdpUjn3nUunlUXk2Ma4qeDp2bczXs9pHzdHUaMpvXUJZRRw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@4.0.46':
+    resolution: {integrity: sha512-LIAO6kAG8fpXQb9L0iwPk1FIbXftvqnyC56v5NEAzeWTeL8fUsy/Hx86VPBTWEDFdwbVprjWifJOAqS6AOj3mA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mcp@2.0.29':
+    resolution: {integrity: sha512-cK8mYpjKGp7/gmsTYtq/dkdmNlBeWQrwcfsah/W9hN6Vr1yNzunLnAZAqL5tMzumLDBueSz6y+vrb5z8DJ8TMg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.36':
+    resolution: {integrity: sha512-wHJNArBdjJPXb8GXcA+FslbRt+7qIE1KoHSAVi+CeBFidinVrTVBZKFMJz3mNZMj8YILBMl/VIvTD/oGFjX6/g==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@3.0.30':
+    resolution: {integrity: sha512-NCJ9JKow5ENAgEZxzvEvF20thwDiH+hutvzmrUDbloRX0azpJHNst8+7pZIVryYhLM9wgpT5/ShTSjPTFhkxEQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.40':
+    resolution: {integrity: sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.13':
+    resolution: {integrity: sha512-fScDJMDnTbx32kLDQqp0MvPjvwkgiwvlBxlmIg7XW5PbS91LG6JjH3PQG+34oMFglqfpQA355e24OdGj5PPoDw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.25':
+    resolution: {integrity: sha512-xscPPHCSjCHWrdhai25sbHCJeKNLW/3D1uSpUZa4cEtTKXA8OnPQ3+Rfu1SmM5Ea/Mf8Dfn3cllw9zeMzo/zFA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider@2.0.3':
     resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
-    engines: {node: '>=18'}
-
-  '@ai-sdk/provider@3.0.10':
-    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.14':
     resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@4.0.3':
-    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
     engines: {node: '>=22'}
 
-  '@ai-sdk/react@3.0.207':
-    resolution: {integrity: sha512-/wlJv214OQIqUDvoEFO4pqGYCmcXUJMEPcPc+1w2pQhf86onLv7My2+KlsKdK9XGATlI3hHpYaB3MbrpvLDzbQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.7':
+    resolution: {integrity: sha512-6or44XprPzKbr8zkmzosowSE0pxkvJcoojBL+mCZvPUt3kvXp3XSNqeVun9golb1acEfSo6yaEBRT18h2VU+1Q==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/react@4.0.61':
+    resolution: {integrity: sha512-iY59f4092oD3Px2xL5qCmfG5gC0ySHCw5d2Hzq5ReCvig/DIgwUQ6SZG49XIgc8Yg7leTQ4y41CXXY8nQ1eWrA==}
+    engines: {node: '>=22'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
-
-  '@ai-sdk/ui-utils@1.2.11':
-    resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.23.8
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1237,8 +1215,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workers-types@5.20260716.1':
-    resolution: {integrity: sha512-LqQPmGAvdpQxzZGAMlDI6fnCsTlr8nRQibWsREaERqD0PucwFl25aXpUskSob70uSY2n6K1sp6Te9xkmzSFgaw==}
+  '@cloudflare/workers-types@5.20260722.1':
+    resolution: {integrity: sha512-8+kivCgFGzwrAfNOWgSpzy/VDvmT/i5KWBgQhnygv3d1kajNn6mCYTbLKpouG0aY8mXjhv+IQm1a8r2K/H4pqQ==}
 
   '@commitlint/cli@21.2.1':
     resolution: {integrity: sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==}
@@ -1711,10 +1689,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -1739,8 +1713,8 @@ packages:
   '@formkit/auto-animate@0.8.4':
     resolution: {integrity: sha512-DHHC01EJ1p70Q0z/ZFRBIY8NDnmfKccQoyoM84Tgb6omLMat6jivCdf272Y8k3nf4Lzdin/Y4R9q8uFtU0GbnA==}
 
-  '@google/genai@2.12.0':
-    resolution: {integrity: sha512-LUr972DZosqPUhf9Mb3CIVu/B99woD3QW6ZJV1T9aNgxaoimAZARmo+IyyDsxIL+zouFiYSdA4hzfEWXc9oNIQ==}
+  '@google/genai@2.16.0':
+    resolution: {integrity: sha512-K+1C1sqR0u7NJ5xpKJCQBws0QXpfuklo3WTNuUIMvtbQfNW2O5OohX0BYT2V+PXzsUzQEwGCXPWQxttLyGQ6xw==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -2131,14 +2105,14 @@ packages:
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
 
-  '@mastra/core@1.51.0':
-    resolution: {integrity: sha512-MmY2/cA97y8KSJ9w/GlMRKTBNsglO1XHI5zv8oVcYQhGr6AFZ/jnAbKzjIEEBrofRca7TXYYvg6YeZCCY4fBvg==}
+  '@mastra/core@1.57.0':
+    resolution: {integrity: sha512-2ud56Ow5wwyAFegxXkkOHcQfCG0W9Sz1ex2qVf3y/704zwwYZl/RBZXZV/7277RIxWFk8Bnw8pmGtGQ4tZVWEg==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@mastra/schema-compat@1.3.4':
-    resolution: {integrity: sha512-2ObUsd21KIVelQy+eKPxJvnMxtmKnWacsIkZovhEYjVcQX9OYTDQ+u4E4RboIJZvurJnFx++/ujQLFznUaEYMg==}
+  '@mastra/schema-compat@1.3.5':
+    resolution: {integrity: sha512-9CdBZZ2Fb8q6Ms4r6hs0msH8MTmVn99Zrc+i8BnNNuqKlIrywIoH3BghmPr5VsvkBUx7u/GjdYAsJ6i9nPcZZA==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2225,12 +2199,12 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@openrouter/ai-sdk-provider@2.9.1':
-    resolution: {integrity: sha512-okgq07Vdkro4CB5INbfhwa0e6VR1HS7sidNcfHN/MeXLJvX1JmQCff/vem6tcxwT9r1avyFrXSlfv9B28D/Pag==}
-    engines: {node: '>=18'}
+  '@openrouter/ai-sdk-provider@3.0.0':
+    resolution: {integrity: sha512-m9XTSWoODH2RM5OsZpaGiN7QRR8cdP5paBWq699Tu3JVmGPBKT8xF8XwV0ZBVVsjikD/JgWfak4VSsTR4wAVbg==}
+    engines: {node: '>=22'}
     peerDependencies:
-      ai: ^6.0.0
-      zod: ^3.25.0 || ^4.0.0
+      ai: ^7.0.0
+      zod: ^3.25.76 || ^4.1.8
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -3750,9 +3724,9 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ai@6.0.205:
-    resolution: {integrity: sha512-F4akEGF41UdgJO3L4v+D5noVD1/czhJy6x0k9R/i1EXfxqrkBh/PdYSgRSLPiGFvrw76dzI8h4w3NYmLrTb8dw==}
-    engines: {node: '>=18'}
+  ai@7.0.58:
+    resolution: {integrity: sha512-GfgO90CQQ0yYuoxJAUOeQ6tviyYw1BUIDygSZ1q3Ce6kSc93tYmB5eltKY/NxC0YOouAax7JvDqVnYxvIAr04Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -3931,14 +3905,17 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
-  chat@4.30.0:
-    resolution: {integrity: sha512-8LXrauKckMmR83FcYC/R8nNEda5VJDDdIhZwUUu+hzaSbk4lqsro0IWm7rB1GGYXONRrUOG2XJlkNr4C15vgMA==}
+  chat@4.37.0:
+    resolution: {integrity: sha512-rXWcVSPY0YiVXLpApYxuS2EbWzXBy3mI1kSAcnF9iPzw98FbDIDq73+Ri0JpUhS1bdVZPhWZgn8bum+Gy8jF3Q==}
     engines: {node: '>=20'}
     peerDependencies:
-      ai: ^6.0.182
+      ai: ^6.0.182 || ^7.0.0
+      workflow: ^5.0.0-beta.35
       zod: ^3.0.0 || ^4.0.0
     peerDependenciesMeta:
       ai:
+        optional: true
+      workflow:
         optional: true
       zod:
         optional: true
@@ -6134,9 +6111,6 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
-  secure-json-parse@2.7.0:
-    resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -6491,10 +6465,6 @@ packages:
   undici-types@8.5.0:
     resolution: {integrity: sha512-+FxhD+5RUdCZHlVPt+pd0DaYYHBPsgoHovxhMnFq9R1SOejHGE4ma0swzuRoKhOisEzsjFWdFedyD0JQmftrHg==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
-
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -6796,91 +6766,70 @@ snapshots:
     optionalDependencies:
       express: 5.2.1(supports-color@10.2.2)
 
-  '@ai-sdk/anthropic@3.0.107(zod@4.4.3)':
+  '@ai-sdk/anthropic@4.0.36(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.14
-      '@ai-sdk/provider-utils': 4.0.42(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/deepseek@2.0.39(zod@4.4.3)':
+  '@ai-sdk/deepseek@3.0.26(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.131(zod@4.4.3)':
+  '@ai-sdk/gateway@4.0.46(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.71(zod@4.4.3)':
+  '@ai-sdk/mcp@2.0.29(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@2.2.8(zod@4.4.3)':
+  '@ai-sdk/openai@4.0.36(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 1.1.3
-      nanoid: 3.3.17
-      secure-json-parse: 2.7.0
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@3.0.28(zod@4.4.3)':
+  '@ai-sdk/provider-utils@3.0.30(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.29(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider-utils@4.0.30(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider-utils@4.0.38(zod@4.4.3)':
+  '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.14
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.42(zod@4.4.3)':
+  '@ai-sdk/provider-utils@5.0.13(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.14
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      undici: 5.29.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider': 4.0.4
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@1.1.3':
+  '@ai-sdk/provider-utils@5.0.25(zod@4.4.3)':
     dependencies:
-      json-schema: 0.4.0
+      '@ai-sdk/provider': 4.0.7
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.29.0
+      zod: 4.4.3
 
   '@ai-sdk/provider@2.0.3':
-    dependencies:
-      json-schema: 0.4.0
-
-  '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
 
@@ -6888,26 +6837,25 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@4.0.3':
+  '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@3.0.207(react@19.2.7)(zod@4.4.3)':
+  '@ai-sdk/provider@4.0.7':
     dependencies:
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      ai: 6.0.205(zod@4.4.3)
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@4.0.61(react@19.2.7)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/mcp': 2.0.29(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
+      ai: 7.0.58(zod@4.4.3)
       react: 19.2.7
       swr: 2.4.1(react@19.2.7)
       throttleit: 2.1.0
     transitivePeerDependencies:
       - zod
-
-  '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@4.4.3)
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -7167,7 +7115,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260722.1':
     optional: true
 
-  '@cloudflare/workers-types@5.20260716.1': {}
+  '@cloudflare/workers-types@5.20260722.1': {}
 
   '@commitlint/cli@21.2.1(@types/node@22.20.1)(conventional-commits-parser@7.1.0)(typescript@6.0.3)':
     dependencies:
@@ -7553,8 +7501,6 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@fastify/busboy@2.1.1': {}
-
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -7582,7 +7528,7 @@ snapshots:
 
   '@formkit/auto-animate@0.8.4': {}
 
-  '@google/genai@2.12.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(bufferutil@4.1.0)(supports-color@10.2.2)(utf-8-validate@5.0.10)':
+  '@google/genai@2.16.0(@modelcontextprotocol/sdk@1.29.0(supports-color@10.2.2)(zod@4.4.3))(bufferutil@4.1.0)(supports-color@10.2.2)(utf-8-validate@5.0.10)':
     dependencies:
       google-auth-library: 10.9.0(supports-color@10.2.2)
       p-retry: 4.6.2
@@ -7874,24 +7820,23 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@mastra/core@1.51.0(ai@6.0.205(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)(utf-8-validate@5.0.10)(zod@4.4.3)':
+  '@mastra/core@1.57.0(ai@7.0.58(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1(supports-color@10.2.2))(supports-color@10.2.2)(utf-8-validate@5.0.10)(zod@4.4.3)':
     dependencies:
       '@a2a-js/sdk': 0.3.14(express@5.2.1(supports-color@10.2.2))
-      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.28(zod@4.4.3)'
-      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.38(zod@4.4.3)'
-      '@ai-sdk/provider-utils-v7': '@ai-sdk/provider-utils@5.0.7(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v5': '@ai-sdk/provider-utils@3.0.30(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v6': '@ai-sdk/provider-utils@4.0.40(zod@4.4.3)'
+      '@ai-sdk/provider-utils-v7': '@ai-sdk/provider-utils@5.0.13(zod@4.4.3)'
       '@ai-sdk/provider-v5': '@ai-sdk/provider@2.0.3'
       '@ai-sdk/provider-v6': '@ai-sdk/provider@3.0.14'
-      '@ai-sdk/provider-v7': '@ai-sdk/provider@4.0.3'
-      '@ai-sdk/ui-utils-v5': '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)'
+      '@ai-sdk/provider-v7': '@ai-sdk/provider@4.0.4'
       '@isaacs/ttlcache': 2.1.5
       '@lukeed/uuid': 2.0.1
-      '@mastra/schema-compat': 1.3.4(zod@4.4.3)
+      '@mastra/schema-compat': 1.3.5(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(supports-color@10.2.2)(zod@4.4.3)
       '@sindresorhus/slugify': 2.2.1
       '@standard-schema/spec': 1.1.0
       ajv: 8.20.0
-      chat: 4.30.0(ai@6.0.205(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
+      chat: 4.37.0(ai@7.0.58(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3)
       croner: 10.0.1
       dotenv: 17.4.2
       execa: 9.6.1
@@ -7919,8 +7864,9 @@ snapshots:
       - rxjs
       - supports-color
       - utf-8-validate
+      - workflow
 
-  '@mastra/schema-compat@1.3.4(zod@4.4.3)':
+  '@mastra/schema-compat@1.3.5(zod@4.4.3)':
     dependencies:
       json-schema-to-zod: 2.8.1
       zod: 4.4.3
@@ -8000,12 +7946,13 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@openrouter/ai-sdk-provider@2.9.1(ai@6.0.205(zod@4.4.3))(zod@4.4.3)':
+  '@openrouter/ai-sdk-provider@3.0.0(ai@7.0.58(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      ai: 6.0.205(zod@4.4.3)
+      ai: 7.0.58(zod@4.4.3)
       zod: 4.4.3
 
-  '@opentelemetry/api@1.9.1': {}
+  '@opentelemetry/api@1.9.1':
+    optional: true
 
   '@oxc-parser/binding-android-arm-eabi@0.137.0':
     optional: true
@@ -9555,12 +9502,11 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@6.0.205(zod@4.4.3):
+  ai@7.0.58(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.131(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.29(zod@4.4.3)
-      '@opentelemetry/api': 1.9.1
+      '@ai-sdk/gateway': 4.0.46(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.7
+      '@ai-sdk/provider-utils': 5.0.25(zod@4.4.3)
       zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -9730,7 +9676,7 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  chat@4.30.0(ai@6.0.205(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3):
+  chat@4.37.0(ai@7.0.58(zod@4.4.3))(supports-color@10.2.2)(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0
@@ -9740,7 +9686,7 @@ snapshots:
       remend: 1.3.0
       unified: 11.0.5
     optionalDependencies:
-      ai: 6.0.205(zod@4.4.3)
+      ai: 7.0.58(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -10179,9 +10125,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.22.4
 
-  drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260716.1)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0):
+  drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260722.1)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.22.0):
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260716.1
+      '@cloudflare/workers-types': 5.20260722.1
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
       pg: 8.22.0
@@ -12373,8 +12319,6 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
-  secure-json-parse@2.7.0: {}
-
   semver@6.3.1: {}
 
   semver@7.8.5: {}
@@ -12800,10 +12744,6 @@ snapshots:
 
   undici-types@8.5.0: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
-
   undici@7.29.0: {}
 
   unenv@2.0.0-rc.24:
@@ -12949,7 +12889,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260722.1
       '@cloudflare/workerd-windows-64': 1.20260722.1
 
-  wrangler@4.114.0(@cloudflare/workers-types@5.20260716.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+  wrangler@4.114.0(@cloudflare/workers-types@5.20260722.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)
@@ -12960,7 +12900,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260722.1
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260716.1
+      '@cloudflare/workers-types': 5.20260722.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,6 @@ minimumReleaseAgeExclude:
   - '@clerk/react@6.12.4'
   - '@clerk/shared@4.25.4'
   - '@clerk/ui@1.25.4'
-  - '@cloudflare/workers-types@5.20260716.1'
   - '@vercel/backends@0.8.24'
   - '@vercel/build-utils@13.33.1'
   - '@vercel/cervel@0.1.32'
@@ -73,19 +72,11 @@ overrides:
   'uuid@<11.1.1': 11.1.1
   'vercel@56.2.1>undici': 6.28.0
 
-# Mastra 1.51 uses these AI SDK v5 packages only for its v5 message types, but
-# their stale manifests still exclude Zod 4. Mastra itself supports Zod 4; keep
-# this exact, removable allowance until upstream mastra-ai/mastra#16994 ships.
-peerDependencyRules:
-  allowedVersions:
-    '@ai-sdk/provider-utils@2.2.8>zod': '^4.0.0'
-    '@ai-sdk/ui-utils@1.2.11>zod': '^4.0.0'
-
 catalog:
-  '@ai-sdk/anthropic': 3.0.107
-  '@ai-sdk/deepseek': 2.0.39
-  '@ai-sdk/openai': 3.0.71
-  '@ai-sdk/react': 3.0.207
+  '@ai-sdk/anthropic': 4.0.36
+  '@ai-sdk/deepseek': 3.0.26
+  '@ai-sdk/openai': 4.0.36
+  '@ai-sdk/react': 4.0.61
   # 2.5.3-2.5.4 panic in the type-aware module resolver (biomejs/biome#10885).
   # Keep the last non-panicking patch until the upstream fix is released.
   '@biomejs/biome': 2.5.2
@@ -93,14 +84,14 @@ catalog:
   '@clerk/backend': 3.11.6
   '@clerk/nextjs': 7.5.19
   '@clerk/ui': 1.25.4
-  '@cloudflare/workers-types': 5.20260716.1
+  '@cloudflare/workers-types': 5.20260722.1
   '@commitlint/cli': 21.2.1
   '@commitlint/config-conventional': 21.2.0
   '@hookform/resolvers': 5.4.0
-  '@google/genai': 2.12.0
-  '@mastra/core': 1.51.0
+  '@google/genai': 2.16.0
+  '@mastra/core': 1.57.0
   '@next/env': 16.2.11
-  '@openrouter/ai-sdk-provider': 2.9.1
+  '@openrouter/ai-sdk-provider': 3.0.0
   '@polar-sh/sdk': 0.48.1
   '@streamdown/code': 1.1.1
   '@streamdown/math': 1.0.2
@@ -113,7 +104,7 @@ catalog:
   '@types/pg': 8.20.0
   '@types/react': 19.2.17
   '@types/react-dom': 19.2.3
-  ai: 6.0.205
+  ai: 7.0.58
   arquero: 8.0.3
   cmdk: 1.1.1
   dependency-cruiser: 18.1.0


### PR DESCRIPTION
## Summary
- Runs Expo/Metro from the supervised native-disk mirror so durable workspace edits hot-reload without a post-run restart.
- Upgrades Mastra and the AI SDK provider generation, including explicit DeepSeek V4 Pro output settings.
- Keeps Morph FastApply request-scoped for existing text edits and documents its setup/deployment contract.
- Adds production-image Expo startup and source-sync coverage before Daytona snapshot promotion.

## Architecture
The durable project volume remains canonical. Next and Expo compile from a one-way native-disk mirror managed by the existing sandbox supervisor. Morph is resolved only when fs_apply executes, and the final write uses a SHA-256 compare-and-swap against the source that was read.

## Decisions
- Keep build surfaces limited to web/mobile; research, data, and slides remain work intents.
- Retain fs_write only for new files, binaries, and intentional full-file generation.
- Alias Mastra optional process execution to a fail-fast Worker boundary because Cloudflare Workers cannot spawn local processes.
- Use the Expo splash plugin export explicitly because Expo config resolution through the immutable NODE_PATH runtime cannot infer the package subpath.

## Verification
- pnpm lint
- pnpm typecheck
- pnpm turbo build --force
- pnpm deadcode
- pnpm architecture:check
- pnpm turbo skills:build
- pnpm peers check
- Rebuilt production sandbox image: Expo ready in 2s, durable edit mirrored in 1s
- Rebuilt production sandbox image: Next edit mirrored in 1s
- Provider request probes for Anthropic, OpenAI, DeepSeek, and OpenRouter
- Morph transport and atomic compare-and-swap functional probe

## Production acceptance
- [ ] Merge required checks
- [ ] Rebuild and promote the Daytona snapshot
- [ ] Create a mobile app on trycheatcode.com and verify live hot reload
- [ ] Verify an existing-file edit uses the production Morph binding
- [ ] Inspect production browser console and run/deployment logs