### PR TITLE
chore(sandbox): promote mobile preview snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-968af0d7ac92-31384952716",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-869a0de2ec99-31394298516",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable sandbox image built from `869a0de2ec9905ba9db3e16a578be5f23374e008` so production can exercise the supervised Expo preview runtime and Morph-backed edit path.

## What changed

- Point the agent worker at `cheatcode-sandbox-viewer-bundle-869a0de2ec99-31394298516`.
- Keep snapshot publication and worker deployment separate so the worker cannot reference an unverified image.

## Verification

- Snapshot workflow `31394298516`: image build, Trivy configuration/image scans, runtime smoke test, Daytona publication, and active-state verification all passed.
- `pnpm --filter @cheatcode/agent-worker typecheck` under Node 24.18.0.
- `pnpm --filter @cheatcode/agent-worker build` under Node 24.18.0; Wrangler dry-run confirms the immutable snapshot value and production Morph secret binding.

## Production acceptance

After merge and Cloudflare deployment, create and edit a mobile app on `trycheatcode.com` to verify preview startup and hot reload against the promoted snapshot.