### PR TITLE
chore(sandbox): promote mobile runtime snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-869a0de2ec99-31394298516",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-0888ef49ce85-31399152760",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable Daytona runtime produced from the merged mobile preview root-cause fix so production sandboxes use the verified Expo dependency mirror and trusted preview launcher.

## Change

- Updates only DAYTONA_SANDBOX_SNAPSHOT in the agent Worker production configuration.
- Candidate: cheatcode-sandbox-viewer-bundle-0888ef49ce85-31399152760
- Source commit: 0888ef49ce8557da81445164bbe84b6e9829a659
- No schema, migration, secret, or public API changes.

## Verification

- Snapshot workflow 31399152760 passed image build, Trivy configuration/image scans, runtime smoke tests, and Daytona publication/active verification.
- Expo scaffold smoke test verified that mirror node_modules resolves to the immutable runtime dependency tree.
- Candidate published with zero transient provider retries.
- git diff --check passed.

Production mobile acceptance testing will run after this promotion is merged and the Cloudflare deployment completes.