### PR TITLE
fix(sandbox): preserve Expo source aliases

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -148,6 +148,7 @@ jobs:
             python3 --version
             test -x /opt/cheatcode/project-source-sync.py
             test -x /opt/cheatcode/pnpm-build-policy.mjs
+            test -x /opt/cheatcode/configure-expo-runtime.mjs
             python3 -c "import ast,pathlib;ast.parse(pathlib.Path(\"/opt/cheatcode/project-source-sync.py\").read_text())"
             python3 - <<PY
           import errno
@@ -213,6 +214,7 @@ jobs:
                       raise RuntimeError("preview sync smoke process did not stop")
           PY
             node --check /opt/cheatcode/pnpm-build-policy.mjs
+            node --check /opt/cheatcode/configure-expo-runtime.mjs
             policy_test_dir="$(mktemp -d)"
             printf "packages:\\n  - .\\nallowBuilds:\\n  sharp: false\\n" > "$policy_test_dir/pnpm-workspace.yaml"
             node /opt/cheatcode/pnpm-build-policy.mjs "$policy_test_dir/pnpm-workspace.yaml"
@@ -338,6 +340,12 @@ jobs:
             trap cleanup_expo_test EXIT
             mkdir -p "$expo_source" "$expo_mirror"
             cp -R /home/node/cheatcode-expo-template/. "$expo_source/"
+            (
+              cd "$expo_source"
+              /opt/cheatcode/configure-expo-runtime.mjs \
+                "$expo_mirror/node_modules" \
+                /home/node/.cheatcode/app-runtimes/expo/node_modules
+            )
             CI=1 EXPO_NO_TELEMETRY=1 NODE_PATH=/home/node/.cheatcode/app-runtimes/expo/node_modules \
               /opt/cheatcode/project-source-sync.py preview-run \
               "$expo_source" "$expo_mirror" "$expo_lock" "$expo_mirror" \
@@ -357,6 +365,38 @@ jobs:
             test -L "$expo_mirror/node_modules"
             test "$(readlink -f "$expo_mirror/node_modules")" = \
               /home/node/.cheatcode/app-runtimes/expo/node_modules
+            expo_bundle="$expo_test_dir/entry.bundle.js"
+            curl --fail --silent --show-error --get \
+              --output "$expo_bundle" \
+              --data-urlencode platform=web \
+              --data-urlencode dev=true \
+              --data-urlencode hot=false \
+              --data-urlencode lazy=true \
+              --data-urlencode transform.engine=hermes \
+              --data-urlencode transform.routerRoot=src/app \
+              --data-urlencode transform.reactCompiler=true \
+              --data-urlencode unstable_transformProfile=hermes-stable \
+              http://127.0.0.1:5201/node_modules/expo-router/entry.bundle
+            grep --fixed-strings --quiet "Welcome to" "$expo_bundle"
+            expo_dom="$expo_test_dir/expo-dom.html"
+            expo_chrome_log="$expo_test_dir/chromium.log"
+            if ! timeout 30 "$CHROME_PATH" \
+              --headless \
+              --no-sandbox \
+              --disable-dev-shm-usage \
+              --disable-gpu \
+              --virtual-time-budget=10000 \
+              --dump-dom \
+              http://127.0.0.1:5201 > "$expo_dom" 2> "$expo_chrome_log"; then
+              sed -n "1,240p" "$expo_chrome_log" >&2
+              exit 1
+            fi
+            if ! grep --fixed-strings --quiet "Welcome to" "$expo_dom"; then
+              sed -n "1,240p" "$expo_log" >&2
+              sed -n "1,240p" "$expo_chrome_log" >&2
+              sed -n "1,240p" "$expo_dom" >&2
+              exit 1
+            fi
             printf "%s\n" "mobile source synchronization works" > "$expo_source/.cheatcode-mobile-sync-smoke"
             expo_sync_attempt=0
             until test -f "$expo_mirror/.cheatcode-mobile-sync-smoke" && \

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder-scaffold.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder-scaffold.ts
@@ -10,14 +10,16 @@ import {
   appBuilderLayoutSource,
   appBuilderPageSource,
   appBuilderTypeScriptConfigSource,
-  expoTypeScriptConfigSource,
 } from "./app-builder-template";
 import { metroForwardedHostFixScript } from "./expo-metro-forwarded-host";
 import {
   EXPO_RUNTIME_BIN,
+  EXPO_RUNTIME_CONFIG_BIN,
+  EXPO_RUNTIME_DIR,
   EXPO_TEMPLATE_DIR,
   NEXT_RUNTIME_BIN,
   NEXT_TEMPLATE_DIR,
+  projectLocalModulesDir,
 } from "./project-sandbox-package-runtime";
 
 type ProjectSandboxStub = CodeRuntimeContext["sandbox"];
@@ -63,20 +65,6 @@ export function writeAppBuilderFiles(
       { sandbox },
     ),
   ]).then(() => undefined);
-}
-
-export function writeExpoRuntimeFiles(
-  sandbox: ProjectSandboxStub,
-  dir: string,
-  workspaceSlug: string,
-): Promise<void> {
-  return executeWriteFile(
-    {
-      path: `${dir}/tsconfig.json`,
-      content: expoTypeScriptConfigSource(workspaceSlug),
-    },
-    { sandbox },
-  ).then(() => undefined);
 }
 
 export async function scaffoldExpoApp(
@@ -176,6 +164,7 @@ export async function ensureAppBuilderRuntime(
 export async function ensureExpoWebSupport(
   sandbox: ProjectSandboxStub,
   dir: string,
+  workspaceSlug: string,
 ): Promise<void> {
   try {
     await executeShellExec(
@@ -194,6 +183,18 @@ export async function ensureExpoWebSupport(
   } catch {
     throw missingBakedRuntimeError("Expo");
   }
+  await executeShellExec(
+    {
+      command: [
+        EXPO_RUNTIME_CONFIG_BIN,
+        projectLocalModulesDir(workspaceSlug),
+        `${EXPO_RUNTIME_DIR}/node_modules`,
+      ],
+      cwd: dir,
+      timeoutMs: 15_000,
+    },
+    { sandbox },
+  );
   // Force the Metro web bundler + single-page output for Expo Router web. `output:"single"`
   // serves a client-rendered SPA (one index.html) instead of per-request server rendering,
   // which does `new URL(req.url)` behind the proxy and throws. Best-effort: a no-op when the

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -15,7 +15,6 @@ import {
   scaffoldAppBuilder,
   scaffoldExpoApp,
   writeAppBuilderFiles,
-  writeExpoRuntimeFiles,
 } from "./agent-run-app-builder-scaffold";
 import { localExpoPreviewCommand, localNextPreviewCommand } from "./app-builder-local-preview";
 import {
@@ -223,7 +222,7 @@ async function prepareTemplateWorkspace(
       await installAppBuilderDependencies(sandbox, logger, workspace.dir, mobile);
     }
     if (mobile) {
-      await ensureExpoWebSupport(sandbox, workspace.dir);
+      await ensureExpoWebSupport(sandbox, workspace.dir, workspace.slug);
     }
     return;
   }
@@ -231,13 +230,12 @@ async function prepareTemplateWorkspace(
   throwIfRunCanceled(options.abortSignal);
   if (mobile) {
     await scaffoldExpoApp(sandbox, logger, workspace.dir);
-    await writeExpoRuntimeFiles(sandbox, workspace.dir, workspace.slug);
   } else {
     await scaffoldAppBuilder(sandbox, logger, workspace.dir);
   }
   throwIfRunCanceled(options.abortSignal);
   if (mobile) {
-    await ensureExpoWebSupport(sandbox, workspace.dir);
+    await ensureExpoWebSupport(sandbox, workspace.dir, workspace.slug);
   } else {
     await setRunStage("Seeding the starter files.");
     await writeAppBuilderFiles(input, sandbox, workspace.dir);

--- a/apps/agent-worker/src/durable-objects/app-builder-template.ts
+++ b/apps/agent-worker/src/durable-objects/app-builder-template.ts
@@ -109,26 +109,6 @@ export function appBuilderTypeScriptConfigSource(workspaceSlug: string): string 
   )}\n`;
 }
 
-export function expoTypeScriptConfigSource(workspaceSlug: string): string {
-  const localModules = `/home/node/.cheatcode/projects/${workspaceSlug}/node_modules`;
-  const runtimeModules = "/home/node/.cheatcode/app-runtimes/expo/node_modules";
-  return `${JSON.stringify(
-    {
-      extends: `${runtimeModules}/expo/tsconfig.base`,
-      compilerOptions: {
-        paths: {
-          "@/*": ["./*"],
-          "*": [`${localModules}/*`, `${runtimeModules}/*`],
-        },
-        strict: true,
-      },
-      include: ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"],
-    },
-    null,
-    2,
-  )}\n`;
-}
-
 function escapeForTsxText(value: string): string {
   return value.replace(/[<>{}]/g, "");
 }

--- a/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
@@ -15,6 +15,7 @@ export const NEXT_RUNTIME_DIR = `${APP_RUNTIME_ROOT}/next`;
 export const EXPO_RUNTIME_DIR = `${APP_RUNTIME_ROOT}/expo`;
 export const NEXT_RUNTIME_BIN = `${NEXT_RUNTIME_DIR}/node_modules/.bin/next`;
 export const EXPO_RUNTIME_BIN = `${EXPO_RUNTIME_DIR}/node_modules/.bin/expo`;
+export const EXPO_RUNTIME_CONFIG_BIN = "/opt/cheatcode/configure-expo-runtime.mjs";
 export const NEXT_TEMPLATE_DIR = "/home/node/cheatcode-next-template";
 export const EXPO_TEMPLATE_DIR = "/home/node/cheatcode-expo-template";
 

--- a/infra/containers/sandbox/README.md
+++ b/infra/containers/sandbox/README.md
@@ -105,6 +105,11 @@ command instead of transporting executable source through sandbox command argume
 It uses content hashes and atomic replacement on native disk. Writes back to Daytona's
 object-store FUSE use direct overwrite plus checksum verification because that mount does
 not implement replacement renames or portable chmod semantics.
+The adjacent root-owned `/opt/cheatcode/configure-expo-runtime.mjs` helper preserves the
+checksum-pinned Expo template's source and asset aliases while adding only the disposable local
+and immutable dependency locations. Snapshot smoke testing runs that same helper, compiles the
+real Expo Router bundle, and renders the template in headless Chromium; a listening Metro port
+without an executable app is not considered healthy.
 Direct pnpm invocations execute inside one `flock`-guarded transaction; process death
 releases that lock automatically, and successful source changes commit only after a
 three-way conflict check against the durable tree. Long-lived previews invoke the same helper as

--- a/infra/containers/sandbox/scripts/configure-expo-runtime.mjs
+++ b/infra/containers/sandbox/scripts/configure-expo-runtime.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { isAbsolute, join } from "node:path";
+
+const [localModules, runtimeModules] = process.argv.slice(2);
+if (!localModules || !runtimeModules || !isAbsolute(localModules) || !isAbsolute(runtimeModules)) {
+  throw new TypeError("Expo runtime configuration requires absolute local and immutable module paths");
+}
+
+const configPath = join(process.cwd(), "tsconfig.json");
+const config = JSON.parse(await readFile(configPath, "utf8"));
+if (!isRecord(config)) {
+  throw new TypeError("Expo tsconfig.json must contain a JSON object");
+}
+
+const compilerOptions = isRecord(config.compilerOptions) ? config.compilerOptions : {};
+const paths = isRecord(compilerOptions.paths) ? compilerOptions.paths : {};
+
+// The checksum-pinned Expo template owns its source aliases. Runtime configuration only adds the
+// disposable dependency locations; replacing the alias map would silently break template imports.
+config.extends = join(runtimeModules, "expo/tsconfig.base");
+config.compilerOptions = {
+  ...compilerOptions,
+  paths: {
+    ...paths,
+    "*": [`${localModules}/*`, `${runtimeModules}/*`],
+  },
+};
+
+await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -15,6 +15,7 @@
       "entry": [
         "skills/**/*.ts",
         "infra/containers/sandbox/app-generators/configure-expo-template.mjs",
+        "infra/containers/sandbox/scripts/configure-expo-runtime.mjs",
         "infra/containers/sandbox/scripts/pnpm-build-policy.mjs"
       ]
     },


### PR DESCRIPTION
## Summary

- preserve the checksum-pinned Expo template's `src` and asset aliases when adding disposable runtime module paths
- move Expo runtime TypeScript configuration into one immutable sandbox helper used on both fresh and restored projects
- require the sandbox snapshot smoke test to compile the real Expo Router bundle and render visible DOM in Chromium

## Root cause

The Worker replaced the pinned Expo template's TypeScript path map with `@/* -> ./*` and pointed the local module fallback at the wrong directory. The template lives under `src/` and imports `@/global.css`, so Metro returned HTTP 500 for the entry bundle while the existing health check still passed because the HTML port was listening. The agent then spent 190 tool calls chasing individual missing files before the run failed.

## Architecture

The immutable snapshot now owns the executable runtime configuration helper. It preserves template-owned aliases and adds only the sandbox-local dependency locations. Both production preparation and snapshot verification invoke the same helper, avoiding a second generated copy of the Expo alias contract in Worker code.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- production diagnosis: Metro entry bundle returned HTTP 500 with `UnableToResolveError` for `@/global.css`; server HTML alone remained healthy
- production acceptance will be repeated after the protected immutable snapshot is built, promoted, and deployed
