### PR TITLE
chore(sandbox): promote Expo runtime snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-0888ef49ce85-31399152760",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-6305819f07bc-31418301622",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable Daytona snapshot containing the Expo runtime alias root fix from #221. The snapshot preserves the pinned Expo template aliases and has passed an actual Expo Router bundle request plus headless-browser render smoke.

## Change

- Set `DAYTONA_SANDBOX_SNAPSHOT` to `cheatcode-sandbox-viewer-bundle-6305819f07bc-31418301622`.

## Provenance

- Root fix: #221
- Snapshot build: https://github.com/cheatcode-ai/cheatcode/actions/runs/31418301622
- Daytona status: `ACTIVE`

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- Snapshot workflow: Docker build, Trivy configuration/vulnerability/secret scans, Expo Router entry bundle request, and headless Chromium rendered-DOM assertion

Production mobile acceptance will be run after this exact snapshot is deployed.
