### PR TITLE
fix(sandbox): preserve Metro file watching

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -346,7 +346,20 @@ jobs:
                 "$expo_mirror/node_modules" \
                 /home/node/.cheatcode/app-runtimes/expo/node_modules
             )
-            CI=1 EXPO_NO_TELEMETRY=1 NODE_PATH=/home/node/.cheatcode/app-runtimes/expo/node_modules \
+            fetch_expo_bundle() {
+              curl --fail --silent --show-error --get \
+                --output "$1" \
+                --data-urlencode platform=web \
+                --data-urlencode dev=true \
+                --data-urlencode hot=false \
+                --data-urlencode lazy=true \
+                --data-urlencode transform.engine=hermes \
+                --data-urlencode transform.routerRoot=src/app \
+                --data-urlencode transform.reactCompiler=true \
+                --data-urlencode unstable_transformProfile=hermes-stable \
+                http://127.0.0.1:5201/node_modules/expo-router/entry.bundle
+            }
+            EXPO_NO_TELEMETRY=1 NODE_PATH=/home/node/.cheatcode/app-runtimes/expo/node_modules \
               /opt/cheatcode/project-source-sync.py preview-run \
               "$expo_source" "$expo_mirror" "$expo_lock" "$expo_mirror" \
               /home/node/.cheatcode/app-runtimes/expo -- \
@@ -366,17 +379,7 @@ jobs:
             test "$(readlink -f "$expo_mirror/node_modules")" = \
               /home/node/.cheatcode/app-runtimes/expo/node_modules
             expo_bundle="$expo_test_dir/entry.bundle.js"
-            curl --fail --silent --show-error --get \
-              --output "$expo_bundle" \
-              --data-urlencode platform=web \
-              --data-urlencode dev=true \
-              --data-urlencode hot=false \
-              --data-urlencode lazy=true \
-              --data-urlencode transform.engine=hermes \
-              --data-urlencode transform.routerRoot=src/app \
-              --data-urlencode transform.reactCompiler=true \
-              --data-urlencode unstable_transformProfile=hermes-stable \
-              http://127.0.0.1:5201/node_modules/expo-router/entry.bundle
+            fetch_expo_bundle "$expo_bundle"
             grep --fixed-strings --quiet "Welcome to" "$expo_bundle"
             expo_dom="$expo_test_dir/expo-dom.html"
             expo_chrome_log="$expo_test_dir/chromium.log"
@@ -395,6 +398,42 @@ jobs:
               sed -n "1,240p" "$expo_log" >&2
               sed -n "1,240p" "$expo_chrome_log" >&2
               sed -n "1,240p" "$expo_dom" >&2
+              exit 1
+            fi
+            expo_watch_source="$(
+              grep --recursive --files-with-matches --fixed-strings \
+                "Welcome to" "$expo_source/src/app" | head -n 1
+            )"
+            test -n "$expo_watch_source"
+            sed -i "s/Welcome to/Metro watcher refreshed/" "$expo_watch_source"
+            expo_watch_bundle="$expo_test_dir/entry-watch.bundle.js"
+            expo_watch_attempt=0
+            until fetch_expo_bundle "$expo_watch_bundle" && \
+              grep --fixed-strings --quiet "Metro watcher refreshed" "$expo_watch_bundle"; do
+              if ! kill -0 "$expo_pid" 2>/dev/null || [ "$expo_watch_attempt" -ge 20 ]; then
+                sed -n "1,240p" "$expo_log" >&2
+                exit 1
+              fi
+              sleep 1
+              expo_watch_attempt=$((expo_watch_attempt + 1))
+            done
+            expo_watch_dom="$expo_test_dir/expo-watch-dom.html"
+            expo_watch_chrome_log="$expo_test_dir/chromium-watch.log"
+            if ! timeout 30 "$CHROME_PATH" \
+              --headless \
+              --no-sandbox \
+              --disable-dev-shm-usage \
+              --disable-gpu \
+              --virtual-time-budget=10000 \
+              --dump-dom \
+              http://127.0.0.1:5201 > "$expo_watch_dom" 2> "$expo_watch_chrome_log"; then
+              sed -n "1,240p" "$expo_watch_chrome_log" >&2
+              exit 1
+            fi
+            if ! grep --fixed-strings --quiet "Metro watcher refreshed" "$expo_watch_dom"; then
+              sed -n "1,240p" "$expo_log" >&2
+              sed -n "1,240p" "$expo_watch_chrome_log" >&2
+              sed -n "1,240p" "$expo_watch_dom" >&2
               exit 1
             fi
             printf "%s\n" "mobile source synchronization works" > "$expo_source/.cheatcode-mobile-sync-smoke"

--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -173,7 +173,11 @@ subsequent writes and deletions within 250 ms, including equal-size and
 shell-based edits. Transient read contention on the durable source is retried within a bounded grace
 period; sustained source failure or a terminated synchronizer fails the whole managed preview so the
 existing bounded process restart policy restores both the app and its source feed instead of reusing
-a stale listening port. The local source,
+a stale listening port. Long-lived Expo processes deliberately run without the `CI` environment
+flag: Expo uses it for automation, but Metro consequently disables its incremental file map watcher
+and would keep serving the first bundle after synchronized source edits. Telemetry remains disabled
+independently, while the snapshot smoke proves a durable-source edit reaches both the next Metro
+bundle and a fresh browser render. The local source,
 dependency tree, and build cache are disposable;
 wake and restart reconstruct them from the durable project without changing the Files surface.
 Persisted pnpm-backed preview commands restore a missing sandbox-local dependency tree before the

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -16,7 +16,11 @@ import {
   scaffoldExpoApp,
   writeAppBuilderFiles,
 } from "./agent-run-app-builder-scaffold";
-import { localExpoPreviewCommand, localNextPreviewCommand } from "./app-builder-local-preview";
+import {
+  expoPreviewEnvironment,
+  localExpoPreviewCommand,
+  localNextPreviewCommand,
+} from "./app-builder-local-preview";
 import {
   EXPO_TEMPLATE_DIR,
   NEXT_TEMPLATE_DIR,
@@ -516,12 +520,10 @@ async function startExpoDevServer(
       sourceDir: workspace.dir,
       workspaceSlug: workspace.slug,
     }),
-    env: {
-      CHEATCODE_APP_RUNTIME: "expo",
-      CI: "1",
-      EXPO_NO_TELEMETRY: "1",
-      ...(signedUrl ? { EXPO_PACKAGER_PROXY_URL: signedUrl } : {}),
-    },
+    env: expoPreviewEnvironment({
+      port: workspace.port,
+      ...(signedUrl ? { proxyUrl: signedUrl } : {}),
+    }),
     shouldReuseMatchingProcess: false,
   });
 }

--- a/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
+++ b/apps/agent-worker/src/durable-objects/app-builder-local-preview.ts
@@ -13,6 +13,21 @@ interface LocalPreviewCommandInput {
   workspaceSlug: string;
 }
 
+interface ExpoPreviewEnvironmentInput {
+  port: number;
+  proxyUrl?: string | undefined;
+}
+
+/** Centralizes long-lived Expo settings without CI, which disables Metro's incremental watcher. */
+export function expoPreviewEnvironment(input: ExpoPreviewEnvironmentInput): Record<string, string> {
+  return {
+    CHEATCODE_APP_RUNTIME: "expo",
+    EXPO_NO_TELEMETRY: "1",
+    PORT: String(input.port),
+    ...(input.proxyUrl ? { EXPO_PACKAGER_PROXY_URL: input.proxyUrl } : {}),
+  };
+}
+
 /** Runs Next from native sandbox disk while `/workspace` remains the durable project source. */
 export function localNextPreviewCommand(input: LocalPreviewCommandInput): string[] {
   const runtime = requireLocalPreviewRuntime(input);

--- a/apps/agent-worker/src/durable-objects/project-sandbox-content.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-content.ts
@@ -9,6 +9,7 @@ import type {
   SandboxWriteFileResult,
 } from "@cheatcode/sandbox-contracts";
 import { encodeBase64, shellQuote } from "../sandbox-support";
+import { expoPreviewEnvironment } from "./app-builder-local-preview";
 import { metroForwardedHostFixScript } from "./expo-metro-forwarded-host";
 import {
   CODE_SERVER_DISPLAY_DIR,
@@ -559,13 +560,7 @@ async function mobileExpoProxy(
   if (!signed) return null;
   return {
     expoUrl: signedUrlToExpo(signed.url),
-    restartEnv: {
-      CHEATCODE_APP_RUNTIME: "expo",
-      CI: "1",
-      EXPO_NO_TELEMETRY: "1",
-      EXPO_PACKAGER_PROXY_URL: signed.url,
-      PORT: String(record.port),
-    },
+    restartEnv: expoPreviewEnvironment({ port: record.port, proxyUrl: signed.url }),
   };
 }
 

--- a/apps/agent-worker/src/durable-objects/project-sandbox-process-support.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-process-support.ts
@@ -2,6 +2,7 @@ import { type DaytonaSandbox, WorkspacePathSchema } from "@cheatcode/agent-core/
 import { APIError } from "@cheatcode/observability";
 import { z } from "zod";
 import { shellQuote } from "../sandbox-support";
+import { expoPreviewEnvironment } from "./app-builder-local-preview";
 import type { ProjectStartProcessInputSchema } from "./project-sandbox-runtime";
 
 export const APP_PREVIEW_SLOT_PREFIX = "app-preview:";
@@ -205,12 +206,7 @@ export function restartEnvironment(
     return undefined;
   }
   if (record.isMobile) {
-    return {
-      CHEATCODE_APP_RUNTIME: "expo",
-      CI: "1",
-      EXPO_NO_TELEMETRY: "1",
-      PORT: String(record.port),
-    };
+    return expoPreviewEnvironment({ port: record.port });
   }
   return {
     CHEATCODE_APP_RUNTIME: "next",


### PR DESCRIPTION
## Why

Long-lived Expo preview processes were started with `CI=1`. Metro treats CI as non-watch mode, so files synced correctly into the native Daytona workspace but subsequent edits never invalidated the running bundle. The agent then spent minutes diagnosing a stale preview even though Morph FastApply had applied the requested edit correctly.

## What changed

- centralize the long-lived Expo preview environment
- keep telemetry disabled without setting `CI`
- use the same environment for initial start, lifecycle wake, and restart
- extend the snapshot smoke check to edit the running Expo source and require both the bundle and rendered DOM to update
- document the Metro watch-mode invariant

## Architecture and operations

This changes Worker preview-process behavior and the snapshot verification workflow only. It does not change the database schema, public environment contract, Daytona image contents, or deployment topology. No new snapshot is required.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (passes with the four existing informational hints)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `git diff --check`

Production mobile acceptance will be repeated after merge and Cloudflare deployment.
