### PR TITLE
fix(web): refresh verified browser previews

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -51,6 +51,9 @@ the same mark in place until the final document has loaded. Preview wake and cap
 paused during fresh scaffold generation; readiness acquires a new one-minute handoff immediately
 before the iframe mounts and exchanges it for the renewable ten-minute host cookie. Existing project
 edits remain visible and continue hot-reloading normally.
+When the agent completes a browser-open action, the Browser panel reloads its entry document exactly
+once so the user sees the same freshly verified build. Read-only extraction, screenshots, and browser
+interactions still open the panel without repeatedly resetting the user's live preview state.
 
 ## Public exports
 

--- a/apps/web/src/components/chat/chat-panel-controller.ts
+++ b/apps/web/src/components/chat/chat-panel-controller.ts
@@ -66,6 +66,7 @@ export function useChatPanelController(input: ChatPanelProps) {
 function useChatPanelRuntime(input: ChatPanelProps) {
   const store = useChatPanelStore(input.threadId);
   const surfaceApplier = useWorkspaceSurfaceApplier({
+    bumpPreviewReloadToken: store.bumpPreviewReloadToken,
     projectId: input.project?.id ?? null,
     setActivePreviewTab: store.setActivePreviewTab,
     setAppPreviewStatus: store.setAppPreviewStatus,
@@ -267,6 +268,7 @@ function chatPanelState(input: ChatPanelProps, runtime: ReturnType<typeof useCha
 function useChatPanelStore(threadId: string) {
   return {
     agentModelId: useAppStore((state) => state.agentModelId),
+    bumpPreviewReloadToken: useAppStore((state) => state.bumpPreviewReloadToken),
     draft: useAppStore((state) => state.draftByThread[threadId] ?? ""),
     resetConsole: useAppStore((state) => state.resetConsole),
     resetPreviewNavigation: useAppStore((state) => state.resetPreviewNavigation),

--- a/apps/web/src/components/chat/use-sandbox-surface-sync.ts
+++ b/apps/web/src/components/chat/use-sandbox-surface-sync.ts
@@ -26,6 +26,10 @@ export interface SandboxStatusActions {
   setSandboxStatus: (status: SandboxState) => void;
 }
 
+interface WorkspaceSurfaceActions extends SandboxStatusActions {
+  bumpPreviewReloadToken: () => void;
+}
+
 interface SandboxSurfaceSyncInput extends SandboxStatusActions {
   chatStatus: ChatStatus;
   messages: readonly CheatcodeUIMessage[];
@@ -41,14 +45,14 @@ interface SandboxSurfaceSyncInput extends SandboxStatusActions {
 export type SurfaceCommand =
   | { kind: "preview-status"; status: AppPreviewStatusData["status"] }
   | { kind: "status"; status: SandboxStatusData["status"] }
-  | { kind: "open-browser-preview"; toolCallId: string };
+  | { kind: "open-browser-preview"; shouldReload: boolean; toolCallId: string };
 
 export interface WorkspaceSurfaceApplier {
   apply: (command: SurfaceCommand) => void;
   reset: () => void;
 }
 
-interface WorkspaceSurfaceApplierInput extends SandboxStatusActions {
+interface WorkspaceSurfaceApplierInput extends WorkspaceSurfaceActions {
   projectId: string | null;
   threadId: string;
 }
@@ -74,12 +78,14 @@ export function useWorkspaceSurfaceApplier(
   }
   const actions = useMemo(
     () => ({
+      bumpPreviewReloadToken: input.bumpPreviewReloadToken,
       setActivePreviewTab: input.setActivePreviewTab,
       setAppPreviewStatus: input.setAppPreviewStatus,
       setPreviewPanelOpen: input.setPreviewPanelOpen,
       setSandboxStatus: input.setSandboxStatus,
     }),
     [
+      input.bumpPreviewReloadToken,
       input.setActivePreviewTab,
       input.setAppPreviewStatus,
       input.setPreviewPanelOpen,
@@ -142,7 +148,11 @@ export function workspaceSurfaceEffect(part: unknown): SurfaceCommand | null {
   }
   const parsed = CHEATCODE_DATA_SCHEMAS.tool.safeParse(part["data"]);
   return parsed.success && isBrowserToolName(parsed.data.toolName)
-    ? { kind: "open-browser-preview", toolCallId: parsed.data.toolCallId }
+    ? {
+        kind: "open-browser-preview",
+        shouldReload: parsed.data.toolName === "browser_open",
+        toolCallId: parsed.data.toolCallId,
+      }
     : null;
 }
 
@@ -248,7 +258,7 @@ function applyWorkspaceSurfaceCommand(
   command: SurfaceCommand,
   threadId: string,
   state: SurfaceCommandState,
-  actions: SandboxStatusActions,
+  actions: WorkspaceSurfaceActions,
 ): void {
   if (command.kind === "status") {
     if (useAppStore.getState().sandboxStatus !== command.status) {
@@ -267,6 +277,9 @@ function applyWorkspaceSurfaceCommand(
     return;
   }
   state.openedBrowserToolKeys.add(onceKey);
+  if (command.shouldReload) {
+    actions.bumpPreviewReloadToken();
+  }
   actions.setActivePreviewTab("app");
   actions.setPreviewPanelOpen(true);
 }


### PR DESCRIPTION
## Why

The production agent could apply an edit with Morph and verify the corrected app through its sandbox browser, while the user's already-mounted Browser iframe kept showing the document from before the managed preview process restarted. Browser tool events opened the panel but did not reconnect the user's iframe after `browser_open` completed.

## What changed

- encode whether a browser surface command should reload the visible preview
- reload exactly once for completed `browser_open` tool calls
- keep browser extraction, screenshots, observation, and interaction events non-disruptive
- document the visible-preview synchronization contract

## Architecture and operations

This is a web-only event-contract change. It does not change APIs, database schema, Worker configuration, environment variables, sandbox processes, or the Daytona snapshot.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (passes with the four existing informational hints)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `git diff --check`

The production mobile edit flow will be repeated after Vercel deploys the merged commit.
