### PR TITLE
fix(web): authorize verified preview reloads

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -51,9 +51,11 @@ the same mark in place until the final document has loaded. Preview wake and cap
 paused during fresh scaffold generation; readiness acquires a new one-minute handoff immediately
 before the iframe mounts and exchanges it for the renewable ten-minute host cookie. Existing project
 edits remain visible and continue hot-reloading normally.
-When the agent completes a browser-open action, the Browser panel reloads its entry document exactly
-once so the user sees the same freshly verified build. Read-only extraction, screenshots, and browser
-interactions still open the panel without repeatedly resetting the user's live preview state.
+When the agent completes a browser-open action, the Browser panel requests one authenticated reload
+so the user sees the same freshly verified build. The preview owner first renews the short-lived
+handoff capability and only then remounts the entry document; an old capability is never reused.
+Read-only extraction, screenshots, and browser interactions still open the panel without repeatedly
+resetting the user's live preview state.
 
 ## Public exports
 

--- a/apps/web/src/components/chat/chat-panel-controller.ts
+++ b/apps/web/src/components/chat/chat-panel-controller.ts
@@ -66,8 +66,8 @@ export function useChatPanelController(input: ChatPanelProps) {
 function useChatPanelRuntime(input: ChatPanelProps) {
   const store = useChatPanelStore(input.threadId);
   const surfaceApplier = useWorkspaceSurfaceApplier({
-    bumpPreviewReloadToken: store.bumpPreviewReloadToken,
     projectId: input.project?.id ?? null,
+    requestPreviewReload: store.requestPreviewReload,
     setActivePreviewTab: store.setActivePreviewTab,
     setAppPreviewStatus: store.setAppPreviewStatus,
     setPreviewPanelOpen: store.setPreviewPanelOpen,
@@ -268,8 +268,8 @@ function chatPanelState(input: ChatPanelProps, runtime: ReturnType<typeof useCha
 function useChatPanelStore(threadId: string) {
   return {
     agentModelId: useAppStore((state) => state.agentModelId),
-    bumpPreviewReloadToken: useAppStore((state) => state.bumpPreviewReloadToken),
     draft: useAppStore((state) => state.draftByThread[threadId] ?? ""),
+    requestPreviewReload: useAppStore((state) => state.requestPreviewReload),
     resetConsole: useAppStore((state) => state.resetConsole),
     resetPreviewNavigation: useAppStore((state) => state.resetPreviewNavigation),
     setActivePreviewTab: useAppStore((state) => state.setActivePreviewTab),

--- a/apps/web/src/components/chat/use-sandbox-surface-sync.ts
+++ b/apps/web/src/components/chat/use-sandbox-surface-sync.ts
@@ -27,7 +27,7 @@ export interface SandboxStatusActions {
 }
 
 interface WorkspaceSurfaceActions extends SandboxStatusActions {
-  bumpPreviewReloadToken: () => void;
+  requestPreviewReload: () => void;
 }
 
 interface SandboxSurfaceSyncInput extends SandboxStatusActions {
@@ -78,14 +78,14 @@ export function useWorkspaceSurfaceApplier(
   }
   const actions = useMemo(
     () => ({
-      bumpPreviewReloadToken: input.bumpPreviewReloadToken,
+      requestPreviewReload: input.requestPreviewReload,
       setActivePreviewTab: input.setActivePreviewTab,
       setAppPreviewStatus: input.setAppPreviewStatus,
       setPreviewPanelOpen: input.setPreviewPanelOpen,
       setSandboxStatus: input.setSandboxStatus,
     }),
     [
-      input.bumpPreviewReloadToken,
+      input.requestPreviewReload,
       input.setActivePreviewTab,
       input.setAppPreviewStatus,
       input.setPreviewPanelOpen,
@@ -278,7 +278,7 @@ function applyWorkspaceSurfaceCommand(
   }
   state.openedBrowserToolKeys.add(onceKey);
   if (command.shouldReload) {
-    actions.bumpPreviewReloadToken();
+    actions.requestPreviewReload();
   }
   actions.setActivePreviewTab("app");
   actions.setPreviewPanelOpen(true);

--- a/apps/web/src/components/preview/preview-side-panel.tsx
+++ b/apps/web/src/components/preview/preview-side-panel.tsx
@@ -2,7 +2,7 @@
 
 import type { ProjectSummary } from "@cheatcode/types/api";
 import { useAuth } from "@clerk/nextjs";
-import { Activity, type ReactNode, useEffect, useState } from "react";
+import { Activity, type ReactNode, useEffect, useRef, useState } from "react";
 import { BrowserTakeoverSurface } from "@/components/preview/browser-takeover-surface";
 import { ExpoDevicePanel } from "@/components/preview/expo-device-panel";
 import {
@@ -83,6 +83,7 @@ function usePreviewPanelController(
     store.previewPanelOpen && project !== null && !isFreshPreviewBuilding,
     store.sandboxStatus,
   );
+  useRequestedPreviewReload(store.previewReloadRequestToken, previewLive.reload);
   useFirstPreviewTelemetry(getToken, store.previewPanelOpen, store.previewUrl);
   const browserTakeover = useBrowserTakeover(activeRunId, threadId);
   useEffect(() => {
@@ -100,12 +101,22 @@ function usePreviewPanelStore() {
     expoUrl: useAppStore((state) => state.expoUrl),
     previewDevice: useAppStore((state) => state.previewDevice),
     previewPanelOpen: useAppStore((state) => state.previewPanelOpen),
+    previewReloadRequestToken: useAppStore((state) => state.previewReloadRequestToken),
     previewReloadToken: useAppStore((state) => state.previewReloadToken),
     previewUrl: useAppStore((state) => state.previewUrl),
     sandboxStatus: useAppStore((state) => state.sandboxStatus),
     setActivePreviewTab: useAppStore((state) => state.setActivePreviewTab),
     setPreviewPanelOpen: useAppStore((state) => state.setPreviewPanelOpen),
   };
+}
+
+function useRequestedPreviewReload(requestToken: number, reload: () => Promise<void>): void {
+  const handledTokenRef = useRef(requestToken);
+  useEffect(() => {
+    if (handledTokenRef.current === requestToken) return;
+    handledTokenRef.current = requestToken;
+    void reload();
+  }, [reload, requestToken]);
 }
 
 function useFirstPreviewTelemetry(

--- a/apps/web/src/lib/store/app-store.ts
+++ b/apps/web/src/lib/store/app-store.ts
@@ -46,6 +46,7 @@ interface AppStoreState {
   previewPanelOpen: boolean;
   previewPath: string;
   previewPathHistory: string[];
+  previewReloadRequestToken: number;
   previewReloadToken: number;
   previewUrl: string | null;
   sandboxStatus: SandboxState;
@@ -70,6 +71,7 @@ interface AppStoreActions {
   resetIdentityState: () => void;
   resetPreviewNavigation: () => void;
   requestFileOpen: (threadId: string, path: string) => void;
+  requestPreviewReload: () => void;
   setActivePreviewTab: (tab: PreviewTab) => void;
   setAgentModelId: (modelId: AgentModelId) => void;
   setAppPreviewStatus: (status: AppPreviewState) => void;
@@ -140,6 +142,7 @@ function initialAppStoreState(): AppStoreState {
     previewPanelOpen: false,
     previewPath: "/",
     previewPathHistory: [],
+    previewReloadRequestToken: 0,
     previewReloadToken: 0,
     previewUrl: null,
     sandboxStatus: "cold",
@@ -208,6 +211,8 @@ function createPreviewActions(set: AppStoreSet) {
           threadId,
         },
       }),
+    requestPreviewReload: () =>
+      set((state) => ({ previewReloadRequestToken: state.previewReloadRequestToken + 1 })),
     setActivePreviewTab: (activePreviewTab: PreviewTab) => set({ activePreviewTab }),
     setAppPreviewStatus: (appPreviewStatus: AppPreviewState) => set({ appPreviewStatus }),
     setExpoUrl: (expoUrl: string | null) => set({ expoUrl }),


### PR DESCRIPTION
## Why

A completed browser-open action remounted the user preview directly. If the original one-minute preview handoff had expired, that remount correctly failed with `auth_token_expired` even though the agent's sandbox browser had verified the app successfully.

## What changed

- Separate browser reload intent from the iframe reload generation.
- Route reload intent through the preview lifecycle owner, which renews the authenticated handoff before remounting.
- Keep read-only browser extraction, screenshots, and interactions from resetting the live preview.
- Document the authenticated reload ownership boundary.

## Architecture

Web-only state and controller change. No API, database, environment, Worker, sandbox image, or migration changes.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (passes with four existing configuration hints)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `git diff --check`

All repository gates were run under Node 24.18.0 and pnpm 11.15.0. Production browser acceptance will be run against the exact merged Vercel deployment.
