### PR TITLE
refactor(web): separate work intents from app targets

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -74,6 +74,27 @@ Product QA is direct `agent-browser --auto-connect --session cheatcode-debug`
 interaction against the running app plus console/network/log review. Do not add
 or run browser-flow scripts for web acceptance testing.
 
+## Composer and Computer semantics
+
+The composer keeps three independent product concepts separate:
+
+- `ComposerWorkIntentId` describes what the user wants to accomplish. Web app,
+  mobile app, slides, research, data, documents, and media are discoverable
+  composer choices. These choices guide prompt context; they are not all project
+  modes.
+- `AppBuildTarget` is only the runtime topology for generated applications:
+  `web` or `mobile`. It maps to `app-builder` or `app-builder-mobile`; every
+  non-app work intent remains a `general` project and can still create typed
+  Deliverables.
+- `ComputerTab` is only the visible workspace view: `browser` or `files`.
+  Artifact kind and MIME type decide how an output renders; neither work intent
+  nor app target selects the Computer tab.
+
+Signed-out launch handoff validates and restores `buildTarget`, model, and
+public GitHub repository state before chat creation. The opaque prompt and
+constrained run intent use the same one-shot handoff path. No `surface` query
+parameter or persisted `app` tab alias is supported.
+
 ## Env
 
 - `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`

--- a/apps/web/src/app/(app)/chats/[chatId]/page.tsx
+++ b/apps/web/src/app/(app)/chats/[chatId]/page.tsx
@@ -3,7 +3,7 @@ import { ProjectsShell } from "@/components/projects/projects-shell";
 import { WorkspaceLoadingState } from "@/components/workspace/workspace-route-state";
 
 // The chat workspace is keyed by the `/chats/{threadId}` path param. Prompt params
-// (prompt/promptKey/surface/repo/model) flow into ProjectsShell through client-side nuqs state.
+// The opaque prompt handoff and constrained run intent flow into ProjectsShell via nuqs state.
 export default async function ChatPage({ params }: { params: Promise<{ chatId: string }> }) {
   const { chatId } = await params;
   return (

--- a/apps/web/src/app/effects.css
+++ b/apps/web/src/app/effects.css
@@ -28,43 +28,43 @@
 }
 
 @media (min-width: 768px) {
-  .cc-agent-run-layout[data-preview-surface="true"] {
+  .cc-agent-run-layout[data-computer-available="true"] {
     flex-direction: row;
   }
 
-  .cc-agent-run-layout[data-preview-surface="true"] > .cc-agent-chat-pane {
+  .cc-agent-run-layout[data-computer-available="true"] > .cc-agent-chat-pane {
     min-width: 0;
     flex: 1 1 100%;
   }
 
-  .cc-agent-run-layout[data-preview-surface="true"][data-computer-open="true"]
+  .cc-agent-run-layout[data-computer-available="true"][data-computer-open="true"]
     > .cc-agent-chat-pane {
     max-width: var(--cc-chat-pane-size, 30%);
     flex-basis: var(--cc-chat-pane-size, 30%);
   }
 
-  .cc-agent-run-layout[data-preview-surface="true"][data-computer-open="false"]
+  .cc-agent-run-layout[data-computer-available="true"][data-computer-open="false"]
     > .cc-agent-chat-pane {
     max-width: 100%;
     flex-basis: 100%;
   }
 
-  .cc-agent-run-layout[data-preview-surface="true"] > .cc-agent-run-divider {
+  .cc-agent-run-layout[data-computer-available="true"] > .cc-agent-run-divider {
     flex: 0 0 1px;
   }
 
-  .cc-agent-run-layout[data-preview-surface="true"][data-computer-open="false"]
+  .cc-agent-run-layout[data-computer-available="true"][data-computer-open="false"]
     > .cc-agent-run-divider {
     width: 0;
     flex-basis: 0;
   }
 
-  .cc-agent-run-layout[data-preview-surface="true"] > .cc-agent-computer-pane {
+  .cc-agent-run-layout[data-computer-available="true"] > .cc-agent-computer-pane {
     min-width: 0;
     flex: 1 1 calc(100% - var(--cc-chat-pane-size, 30%));
   }
 
-  .cc-agent-run-layout[data-preview-surface="true"][data-computer-open="false"]
+  .cc-agent-run-layout[data-computer-available="true"][data-computer-open="false"]
     > .cc-agent-computer-pane {
     width: 0;
     flex: 0 0 0;

--- a/apps/web/src/components/chat/chat-panel-controller.ts
+++ b/apps/web/src/components/chat/chat-panel-controller.ts
@@ -21,14 +21,14 @@ import {
   useVisibleStreamResume,
 } from "@/components/chat/use-chat-lifecycle";
 import { useChatSubmission } from "@/components/chat/use-chat-submission";
-import type { OlderMessagesLoadResult } from "@/components/chat/use-message-list-scroll";
 import {
+  type ComputerViewApplier,
+  computerViewEffect,
   type SandboxStatusActions,
-  useSandboxSurfaceSync,
-  useWorkspaceSurfaceApplier,
-  type WorkspaceSurfaceApplier,
-  workspaceSurfaceEffect,
-} from "@/components/chat/use-sandbox-surface-sync";
+  useComputerViewApplier,
+  useSandboxComputerSync,
+} from "@/components/chat/use-computer-view-sync";
+import type { OlderMessagesLoadResult } from "@/components/chat/use-message-list-scroll";
 import { agentModelRequestValue } from "@/lib/agent-models";
 import { cancelRun, getThread } from "@/lib/api/project-thread";
 import { invalidateChatLists, projectKeys, threadKeys } from "@/lib/api/query-keys";
@@ -65,16 +65,16 @@ export function useChatPanelController(input: ChatPanelProps) {
 
 function useChatPanelRuntime(input: ChatPanelProps) {
   const store = useChatPanelStore(input.threadId);
-  const surfaceApplier = useWorkspaceSurfaceApplier({
+  const viewApplier = useComputerViewApplier({
     projectId: input.project?.id ?? null,
     requestPreviewReload: store.requestPreviewReload,
-    setActivePreviewTab: store.setActivePreviewTab,
+    setActiveComputerTab: store.setActiveComputerTab,
     setAppPreviewStatus: store.setAppPreviewStatus,
     setPreviewPanelOpen: store.setPreviewPanelOpen,
     setSandboxStatus: store.setSandboxStatus,
     threadId: input.threadId,
   });
-  const runtime = useChatRuntimeBase(input, store, surfaceApplier);
+  const runtime = useChatRuntimeBase(input, store, viewApplier);
   const resumeStream = useSerializedResume(runtime.chat.resumeStream);
   const messages = useDeferredValue(runtime.chat.messages);
   const loadOlderMessages = useOlderMessageLoader(
@@ -88,7 +88,7 @@ function useChatPanelRuntime(input: ChatPanelProps) {
     pendingSubmissionRef: runtime.pendingSubmissionRef,
     queryClient: runtime.queryClient,
     resumeStream,
-    surfaceApplier,
+    viewApplier,
   });
   return { ...runtime, loadOlderMessages, messages, store };
 }
@@ -96,7 +96,7 @@ function useChatPanelRuntime(input: ChatPanelProps) {
 function useChatRuntimeBase(
   input: ChatPanelProps,
   store: ReturnType<typeof useChatPanelStore>,
-  surfaceApplier: WorkspaceSurfaceApplier,
+  viewApplier: ComputerViewApplier,
 ) {
   const { getToken } = useAuth();
   const router = useRouter();
@@ -127,7 +127,7 @@ function useChatRuntimeBase(
     queryClient,
     setRunStartedAt,
     sandboxActions: store,
-    surfaceApplier,
+    viewApplier,
     threadId: input.threadId,
     transport,
   });
@@ -272,7 +272,7 @@ function useChatPanelStore(threadId: string) {
     requestPreviewReload: useAppStore((state) => state.requestPreviewReload),
     resetConsole: useAppStore((state) => state.resetConsole),
     resetPreviewNavigation: useAppStore((state) => state.resetPreviewNavigation),
-    setActivePreviewTab: useAppStore((state) => state.setActivePreviewTab),
+    setActiveComputerTab: useAppStore((state) => state.setActiveComputerTab),
     setAppPreviewStatus: useAppStore((state) => state.setAppPreviewStatus),
     setDraft: useAppStore((state) => state.setDraft),
     setExpoUrl: useAppStore((state) => state.setExpoUrl),
@@ -311,7 +311,7 @@ function useChatSession(input: {
   queryClient: ReturnType<typeof useQueryClient>;
   setRunStartedAt: (value: null | number) => void;
   sandboxActions: SandboxStatusActions;
-  surfaceApplier: WorkspaceSurfaceApplier;
+  viewApplier: ComputerViewApplier;
   threadId: string;
   transport: ReturnType<typeof createChatTransport>;
 }) {
@@ -356,9 +356,9 @@ function handleStreamData(
   if (part.type === "data-seq") {
     handleSequenceData(part.data, input.threadId);
   }
-  const surfaceCommand = workspaceSurfaceEffect(part);
-  if (surfaceCommand) {
-    input.surfaceApplier.apply(surfaceCommand);
+  const viewCommand = computerViewEffect(part);
+  if (viewCommand) {
+    input.viewApplier.apply(viewCommand);
   }
   if (part.type === "data-project-created") {
     handleProjectCreatedData(part.data, input);
@@ -393,7 +393,7 @@ function handleSkillCreatedData(
   const parsed = CHEATCODE_DATA_SCHEMAS["skill-created"].safeParse(data);
   if (parsed.success) {
     void queryClient.invalidateQueries({ queryKey: USER_SKILLS_QUERY });
-    actions.setActivePreviewTab("files");
+    actions.setActiveComputerTab("files");
     actions.setPreviewPanelOpen(true);
   }
 }
@@ -405,7 +405,7 @@ function handleProjectCreated(
   input.queryClient.setQueryData<Thread>(threadKeys.detail(input.threadId), (thread) =>
     thread ? { ...thread, projectId } : thread,
   );
-  input.sandboxActions.setActivePreviewTab("files");
+  input.sandboxActions.setActiveComputerTab("files");
   input.sandboxActions.setPreviewPanelOpen(true);
   for (const queryKey of [threadKeys.detail(input.threadId), projectKeys.detail(projectId)]) {
     void input.queryClient.invalidateQueries({ queryKey });
@@ -471,22 +471,22 @@ function useChatPanelEffects(
     pendingSubmissionRef: { current: PendingSubmission | null };
     queryClient: ReturnType<typeof useQueryClient>;
     resumeStream: () => Promise<void>;
-    surfaceApplier: WorkspaceSurfaceApplier;
+    viewApplier: ComputerViewApplier;
   },
 ): void {
-  useSandboxSurfaceSync({
+  useSandboxComputerSync({
     chatStatus: chat.status,
     messages,
     project: input.project,
     resetConsole: store.resetConsole,
     resetPreviewNavigation: store.resetPreviewNavigation,
-    setActivePreviewTab: store.setActivePreviewTab,
+    setActiveComputerTab: store.setActiveComputerTab,
     setAppPreviewStatus: store.setAppPreviewStatus,
     setExpoUrl: store.setExpoUrl,
     setPreviewPanelOpen: store.setPreviewPanelOpen,
     setPreviewUrl: store.setPreviewUrl,
     setSandboxStatus: store.setSandboxStatus,
-    surfaceApplier: shared.surfaceApplier,
+    viewApplier: shared.viewApplier,
   });
   useConnectionStateSync();
   useVisibleStreamResume({

--- a/apps/web/src/components/chat/message-deliverables.tsx
+++ b/apps/web/src/components/chat/message-deliverables.tsx
@@ -351,7 +351,7 @@ function useDeliverableDownload(
 
 function useOpenImageInFiles(data: ArtifactData, threadId: string, afterOpen: () => void) {
   const requestFileOpen = useAppStore((state) => state.requestFileOpen);
-  const setActivePreviewTab = useAppStore((state) => state.setActivePreviewTab);
+  const setActiveComputerTab = useAppStore((state) => state.setActiveComputerTab);
   const setPreviewPanelOpen = useAppStore((state) => state.setPreviewPanelOpen);
   return () => {
     const path = imageWorkspacePath(data);
@@ -360,22 +360,22 @@ function useOpenImageInFiles(data: ArtifactData, threadId: string, afterOpen: ()
       return;
     }
     requestFileOpen(threadId, path);
-    setActivePreviewTab("files");
+    setActiveComputerTab("files");
     setPreviewPanelOpen(true);
     afterOpen();
   };
 }
 
 function useAutoOpenLatestImage(items: readonly ArtifactData[], threadId: string): void {
-  const activePreviewTab = useAppStore((state) => state.activePreviewTab);
+  const activeComputerTab = useAppStore((state) => state.activeComputerTab);
   const previewPanelOpen = useAppStore((state) => state.previewPanelOpen);
   const requestFileOpen = useAppStore((state) => state.requestFileOpen);
   const latestImage = items.findLast(isImageArtifact);
   const latestImagePath = latestImage ? imageWorkspacePath(latestImage) : null;
   useEffect(() => {
-    if (!previewPanelOpen || activePreviewTab !== "files" || !latestImagePath) return;
+    if (!previewPanelOpen || activeComputerTab !== "files" || !latestImagePath) return;
     requestFileOpen(threadId, latestImagePath);
-  }, [activePreviewTab, latestImagePath, previewPanelOpen, requestFileOpen, threadId]);
+  }, [activeComputerTab, latestImagePath, previewPanelOpen, requestFileOpen, threadId]);
 }
 
 function imageWorkspacePath(data: ArtifactData): string | null {

--- a/apps/web/src/components/chat/message-parts.tsx
+++ b/apps/web/src/components/chat/message-parts.tsx
@@ -133,7 +133,7 @@ type SkillCreatedData = Extract<MessagePart, { type: "data-skill-created" }>["da
 function SkillCreatedBlock({ data, threadId }: { data: SkillCreatedData; threadId: string }) {
   const { getToken } = useAuth();
   const queryClient = useQueryClient();
-  const setActivePreviewTab = useAppStore((state) => state.setActivePreviewTab);
+  const setActiveComputerTab = useAppStore((state) => state.setActiveComputerTab);
   const setPreviewPanelOpen = useAppStore((state) => state.setPreviewPanelOpen);
   const mutation = useMutation({
     mutationFn: async () => {
@@ -144,7 +144,7 @@ function SkillCreatedBlock({ data, threadId }: { data: SkillCreatedData; threadI
       toast.error(error instanceof Error ? error.message : "The skill file could not be opened."),
     onSuccess: (session) => {
       queryClient.setQueryData(["sandbox-ide", threadId], session);
-      setActivePreviewTab("files");
+      setActiveComputerTab("files");
       setPreviewPanelOpen(true);
     },
   });

--- a/apps/web/src/components/chat/use-computer-view-sync.ts
+++ b/apps/web/src/components/chat/use-computer-view-sync.ts
@@ -7,7 +7,7 @@ import {
 import type { ProjectSummary } from "@cheatcode/types/api";
 import type { ChatStatus } from "ai";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { type PreviewTab, useAppStore } from "@/lib/store/app-store";
+import { type ComputerTab, useAppStore } from "@/lib/store/app-store";
 
 type SandboxStatusData = Extract<
   CheatcodeUIMessage["parts"][number],
@@ -20,17 +20,17 @@ type AppPreviewStatusData = Extract<
 >["data"];
 
 export interface SandboxStatusActions {
-  setActivePreviewTab: (tab: PreviewTab) => void;
+  setActiveComputerTab: (tab: ComputerTab) => void;
   setAppPreviewStatus: (status: AppPreviewStatusData["status"] | "idle") => void;
   setPreviewPanelOpen: (open: boolean) => void;
   setSandboxStatus: (status: SandboxState) => void;
 }
 
-interface WorkspaceSurfaceActions extends SandboxStatusActions {
+interface ComputerViewActions extends SandboxStatusActions {
   requestPreviewReload: () => void;
 }
 
-interface SandboxSurfaceSyncInput extends SandboxStatusActions {
+interface SandboxComputerSyncInput extends SandboxStatusActions {
   chatStatus: ChatStatus;
   messages: readonly CheatcodeUIMessage[];
   project: ProjectSummary | null;
@@ -39,99 +39,97 @@ interface SandboxSurfaceSyncInput extends SandboxStatusActions {
   setExpoUrl: (url: null | string) => void;
   setPreviewPanelOpen: (open: boolean) => void;
   setPreviewUrl: (url: null | string) => void;
-  surfaceApplier: WorkspaceSurfaceApplier;
+  viewApplier: ComputerViewApplier;
 }
 
-export type SurfaceCommand =
+export type ComputerViewCommand =
   | { kind: "preview-status"; status: AppPreviewStatusData["status"] }
   | { kind: "status"; status: SandboxStatusData["status"] }
   | { kind: "open-browser-preview"; shouldReload: boolean; toolCallId: string };
 
-export interface WorkspaceSurfaceApplier {
-  apply: (command: SurfaceCommand) => void;
+export interface ComputerViewApplier {
+  apply: (command: ComputerViewCommand) => void;
   reset: () => void;
 }
 
-interface WorkspaceSurfaceApplierInput extends WorkspaceSurfaceActions {
+interface ComputerViewApplierInput extends ComputerViewActions {
   projectId: string | null;
   threadId: string;
 }
 
-interface SurfaceCommandState {
+interface ComputerViewCommandState {
   openedBrowserToolKeys: Set<string>;
   scopeKey: string;
 }
 
-interface HydratedSurfaceCommands {
-  browser: SurfaceCommand | null;
-  preview: SurfaceCommand | null;
-  status: SurfaceCommand | null;
+interface HydratedComputerViewCommands {
+  browser: ComputerViewCommand | null;
+  preview: ComputerViewCommand | null;
+  status: ComputerViewCommand | null;
 }
 
-export function useWorkspaceSurfaceApplier(
-  input: WorkspaceSurfaceApplierInput,
-): WorkspaceSurfaceApplier {
+export function useComputerViewApplier(input: ComputerViewApplierInput): ComputerViewApplier {
   const scopeKey = `${input.threadId}:${input.projectId ?? ""}`;
-  const stateRef = useRef<SurfaceCommandState>(createSurfaceCommandState(scopeKey));
+  const stateRef = useRef<ComputerViewCommandState>(createComputerViewCommandState(scopeKey));
   if (stateRef.current.scopeKey !== scopeKey) {
-    stateRef.current = createSurfaceCommandState(scopeKey);
+    stateRef.current = createComputerViewCommandState(scopeKey);
   }
   const actions = useMemo(
     () => ({
       requestPreviewReload: input.requestPreviewReload,
-      setActivePreviewTab: input.setActivePreviewTab,
+      setActiveComputerTab: input.setActiveComputerTab,
       setAppPreviewStatus: input.setAppPreviewStatus,
       setPreviewPanelOpen: input.setPreviewPanelOpen,
       setSandboxStatus: input.setSandboxStatus,
     }),
     [
       input.requestPreviewReload,
-      input.setActivePreviewTab,
+      input.setActiveComputerTab,
       input.setAppPreviewStatus,
       input.setPreviewPanelOpen,
       input.setSandboxStatus,
     ],
   );
   const apply = useCallback(
-    (command: SurfaceCommand) =>
-      applyWorkspaceSurfaceCommand(command, input.threadId, stateRef.current, actions),
+    (command: ComputerViewCommand) =>
+      applyComputerViewCommand(command, input.threadId, stateRef.current, actions),
     [actions, input.threadId],
   );
   const reset = useCallback(() => {
-    stateRef.current = createSurfaceCommandState(scopeKey);
+    stateRef.current = createComputerViewCommandState(scopeKey);
   }, [scopeKey]);
   return useMemo(() => ({ apply, reset }), [apply, reset]);
 }
 
-export function useSandboxSurfaceSync(input: SandboxSurfaceSyncInput): void {
-  const commands = useMemo(() => hydratedSurfaceCommands(input.messages), [input.messages]);
+export function useSandboxComputerSync(input: SandboxComputerSyncInput): void {
+  const commands = useMemo(() => hydratedComputerViewCommands(input.messages), [input.messages]);
   const status = commands.status?.kind === "status" ? commands.status.status : null;
   const defaultedProjectFilesRef = useRef<string | null>(null);
   const previousStatusRef = useRef(input.chatStatus);
   const actions = useMemo(
     () => ({
-      setActivePreviewTab: input.setActivePreviewTab,
+      setActiveComputerTab: input.setActiveComputerTab,
       setAppPreviewStatus: input.setAppPreviewStatus,
       setPreviewPanelOpen: input.setPreviewPanelOpen,
       setSandboxStatus: input.setSandboxStatus,
     }),
     [
-      input.setActivePreviewTab,
+      input.setActiveComputerTab,
       input.setAppPreviewStatus,
       input.setPreviewPanelOpen,
       input.setSandboxStatus,
     ],
   );
 
-  useResetSandboxSurface(input);
-  useHydratedSurfaceCommand(commands.status, input.surfaceApplier);
-  useHydratedSurfaceCommand(commands.preview, input.surfaceApplier);
+  useResetSandboxComputer(input);
+  useHydratedComputerViewCommand(commands.status, input.viewApplier);
+  useHydratedComputerViewCommand(commands.preview, input.viewApplier);
   useProjectFilesDefault(input.project, status, actions, defaultedProjectFilesRef);
-  useHydratedSurfaceCommand(commands.browser, input.surfaceApplier);
+  useHydratedComputerViewCommand(commands.browser, input.viewApplier);
   useCompletionPreview(input.chatStatus, previousStatusRef);
 }
 
-export function workspaceSurfaceEffect(part: unknown): SurfaceCommand | null {
+export function computerViewEffect(part: unknown): ComputerViewCommand | null {
   if (!isRecord(part)) {
     return null;
   }
@@ -156,9 +154,9 @@ export function workspaceSurfaceEffect(part: unknown): SurfaceCommand | null {
     : null;
 }
 
-function useResetSandboxSurface(input: SandboxSurfaceSyncInput): void {
+function useResetSandboxComputer(input: SandboxComputerSyncInput): void {
   useEffect(() => {
-    input.surfaceApplier.reset();
+    input.viewApplier.reset();
     input.resetConsole();
     input.resetPreviewNavigation();
     input.setAppPreviewStatus("idle");
@@ -174,13 +172,13 @@ function useResetSandboxSurface(input: SandboxSurfaceSyncInput): void {
     input.setPreviewPanelOpen,
     input.setPreviewUrl,
     input.setSandboxStatus,
-    input.surfaceApplier,
+    input.viewApplier,
   ]);
 }
 
-function useHydratedSurfaceCommand(
-  command: SurfaceCommand | null,
-  applier: WorkspaceSurfaceApplier,
+function useHydratedComputerViewCommand(
+  command: ComputerViewCommand | null,
+  applier: ComputerViewApplier,
 ): void {
   useEffect(() => {
     if (command) {
@@ -200,7 +198,7 @@ function useProjectFilesDefault(
       return;
     }
     defaultedProjectFilesRef.current = project.id;
-    actions.setActivePreviewTab("files");
+    actions.setActiveComputerTab("files");
   }, [actions, defaultedProjectFilesRef, project, status]);
 }
 
@@ -222,8 +220,10 @@ function useCompletionPreview(
   }, [previousStatusRef, status]);
 }
 
-function hydratedSurfaceCommands(messages: readonly CheatcodeUIMessage[]): HydratedSurfaceCommands {
-  const commands: HydratedSurfaceCommands = { browser: null, preview: null, status: null };
+function hydratedComputerViewCommands(
+  messages: readonly CheatcodeUIMessage[],
+): HydratedComputerViewCommands {
+  const commands: HydratedComputerViewCommands = { browser: null, preview: null, status: null };
   for (let messageIndex = 0; messageIndex < messages.length; messageIndex += 1) {
     const message = messages[messageIndex];
     if (!message) {
@@ -235,15 +235,15 @@ function hydratedSurfaceCommands(messages: readonly CheatcodeUIMessage[]): Hydra
       if (!part) {
         continue;
       }
-      recordHydratedSurfaceCommand(commands, workspaceSurfaceEffect(part));
+      recordHydratedComputerViewCommand(commands, computerViewEffect(part));
     }
   }
   return commands;
 }
 
-function recordHydratedSurfaceCommand(
-  commands: HydratedSurfaceCommands,
-  command: SurfaceCommand | null,
+function recordHydratedComputerViewCommand(
+  commands: HydratedComputerViewCommands,
+  command: ComputerViewCommand | null,
 ): void {
   if (command?.kind === "status") {
     commands.status = command;
@@ -254,11 +254,11 @@ function recordHydratedSurfaceCommand(
   }
 }
 
-function applyWorkspaceSurfaceCommand(
-  command: SurfaceCommand,
+function applyComputerViewCommand(
+  command: ComputerViewCommand,
   threadId: string,
-  state: SurfaceCommandState,
-  actions: WorkspaceSurfaceActions,
+  state: ComputerViewCommandState,
+  actions: ComputerViewActions,
 ): void {
   if (command.kind === "status") {
     if (useAppStore.getState().sandboxStatus !== command.status) {
@@ -280,11 +280,11 @@ function applyWorkspaceSurfaceCommand(
   if (command.shouldReload) {
     actions.requestPreviewReload();
   }
-  actions.setActivePreviewTab("app");
+  actions.setActiveComputerTab("browser");
   actions.setPreviewPanelOpen(true);
 }
 
-function createSurfaceCommandState(scopeKey: string): SurfaceCommandState {
+function createComputerViewCommandState(scopeKey: string): ComputerViewCommandState {
   return { openedBrowserToolKeys: new Set<string>(), scopeKey };
 }
 

--- a/apps/web/src/components/home/home-composer-controller.ts
+++ b/apps/web/src/components/home/home-composer-controller.ts
@@ -19,11 +19,16 @@ import { useHomeComposerSelection } from "@/components/home/use-home-composer-se
 import { useHomeComposerSubmission } from "@/components/home/use-home-composer-submission";
 import { useHomePromptState } from "@/components/home/use-home-prompt-state";
 import { resolveInitialSkill } from "@/components/home/use-initial-skill";
+import type { AgentModelId } from "@/lib/agent-models";
+import type { AppBuildTarget } from "@/lib/app-build-target";
 import { usePromptHandoff } from "@/lib/hooks/use-prompt-handoff";
 import { useAppStore } from "@/lib/store/app-store";
 
 export interface HomeComposerProps {
+  initialAppBuildTarget?: AppBuildTarget | undefined;
+  initialModel?: AgentModelId | undefined;
   initialPromptKey?: string | undefined;
+  initialRepoUrl?: string | undefined;
   initialSkill?: string | undefined;
   initialTool?: IntegrationName | undefined;
   quickActionsSlot?: HTMLElement | null | undefined;
@@ -31,19 +36,11 @@ export interface HomeComposerProps {
 }
 
 export function useHomeComposerController(input: HomeComposerProps) {
-  const identity = useHomeComposerIdentity();
+  const identity = useHomeComposerIdentity(input.initialModel);
   const textarea = useHomeComposerTextarea();
   const prompt = useHomePromptState();
   useInitialPromptHandoff(input.initialPromptKey, prompt);
-  const initialSkill = useResolvedInitialSkill(input.initialSkill);
-  const selection = useHomeComposerSelection(
-    {
-      initialSkill,
-      initialTool: input.initialTool ?? null,
-      skillCreator: input.skillCreator ?? false,
-    },
-    textarea.focus,
-  );
+  const selection = useInitialHomeSelection(input, textarea.focus);
   const uploads = useProjectFileUploads({
     getToken: identity.getToken,
     latestValueRef: prompt.refs.latestValueRef,
@@ -89,12 +86,39 @@ export function useHomeComposerController(input: HomeComposerProps) {
   });
 }
 
-function useHomeComposerIdentity() {
+function useInitialHomeSelection(input: HomeComposerProps, focusTextarea: () => void) {
+  const initialSkill = useResolvedInitialSkill(input.initialSkill);
+  return useHomeComposerSelection(
+    {
+      appBuildTarget: input.initialAppBuildTarget ?? null,
+      initialSkill,
+      initialTool: input.initialTool ?? null,
+      repoUrl: input.initialRepoUrl ?? null,
+      skillCreator: input.skillCreator ?? false,
+    },
+    focusTextarea,
+  );
+}
+
+function useHomeComposerIdentity(initialModel: AgentModelId | undefined) {
   const router = useRouter();
   const { getToken: getAuthToken } = useAuth();
   const getToken = useCallback(() => resolveComposerAuthToken(getAuthToken), [getAuthToken]);
   const agentModelId = useAppStore((state) => state.agentModelId);
+  useInitialAgentModel(initialModel);
   return { agentModelId, getToken, router };
+}
+
+function useInitialAgentModel(initialModel: AgentModelId | undefined): void {
+  useEffect(() => {
+    if (!initialModel) return;
+    const applyInitialModel = () => useAppStore.getState().setAgentModelId(initialModel);
+    const unsubscribe = useAppStore.persist.onFinishHydration(applyInitialModel);
+    if (useAppStore.persist.hasHydrated()) {
+      applyInitialModel();
+    }
+    return unsubscribe;
+  }, [initialModel]);
 }
 
 function useHomeComposerTextarea() {

--- a/apps/web/src/components/home/home-composer-controls.tsx
+++ b/apps/web/src/components/home/home-composer-controls.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import type { ComposerWorkIntentId } from "@/components/home/home-composer.types";
 import {
-  type ComposerIntent,
-  type IntentId,
+  type ComposerWorkIntent,
   QUICK_ACTION_PRIMARY_INTENTS,
   QUICK_ACTION_SECONDARY_INTENTS,
+  QUICK_ACTION_TERTIARY_INTENTS,
 } from "@/components/home/home-composer-intents";
 import { Puzzle, X } from "@/components/ui";
 import { cn } from "@/lib/ui/cn";
@@ -50,8 +51,8 @@ export function HomeQuickActions({
   activeIntentId,
   onIntentClick,
 }: {
-  activeIntentId: IntentId | null;
-  onIntentClick: (intentId: IntentId) => void;
+  activeIntentId: ComposerWorkIntentId | null;
+  onIntentClick: (intentId: ComposerWorkIntentId) => void;
 }) {
   return (
     <div className="paper-soft-panel mx-auto flex w-full max-w-[448px] flex-col gap-1 overflow-hidden rounded-[17px] p-1">
@@ -77,6 +78,17 @@ export function HomeQuickActions({
           />
         ))}
       </div>
+      <div className="grid w-full grid-cols-2 gap-1">
+        {QUICK_ACTION_TERTIARY_INTENTS.map((intent) => (
+          <HomeQuickAction
+            active={activeIntentId === intent.id}
+            icon={intent.icon}
+            key={intent.id}
+            label={intent.label}
+            onClick={() => onIntentClick(intent.id)}
+          />
+        ))}
+      </div>
     </div>
   );
 }
@@ -88,7 +100,7 @@ function HomeQuickAction({
   onClick,
 }: {
   active: boolean;
-  icon: ComposerIntent["icon"];
+  icon: ComposerWorkIntent["icon"];
   label: string;
   onClick: () => void;
 }) {

--- a/apps/web/src/components/home/home-composer-from-search-params.tsx
+++ b/apps/web/src/components/home/home-composer-from-search-params.tsx
@@ -2,11 +2,17 @@
 
 import { SKILL_MANIFEST } from "@cheatcode/skills/manifest";
 import { type IntegrationName, IntegrationNameSchema } from "@cheatcode/types";
+import { GitHubRepoUrlSchema } from "@cheatcode/types/api";
 import { useEffect, useState } from "react";
+import { type AgentModelId, isAgentModelId } from "@/lib/agent-models";
+import { type AppBuildTarget, isAppBuildTarget } from "@/lib/app-build-target";
 import { HomeComposer } from "./home-composer";
 
 type InitialComposerParams = {
+  appBuildTarget?: AppBuildTarget | undefined;
+  model?: AgentModelId | undefined;
   promptKey?: string | undefined;
+  repoUrl?: string | undefined;
   skill?: string | undefined;
   skillCreator?: boolean | undefined;
   tool?: IntegrationName | undefined;
@@ -22,9 +28,12 @@ export function HomeComposerFromSearchParams({
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);
     setParams({
+      appBuildTarget: validAppBuildTarget(searchParams.get("buildTarget")),
+      model: validInitialModel(searchParams.get("model")),
       promptKey: validInitialPromptKey(searchParams.get("promptKey")),
+      repoUrl: validInitialRepoUrl(searchParams.get("repo")),
       skill: validInitialSkill(searchParams.get("skill")),
-      skillCreator: searchParams.get("mode") === "skill-creator",
+      skillCreator: searchParams.get("intent") === "skill-creator",
       tool: validInitialTool(searchParams.get("tool")),
     });
   }, []);
@@ -35,14 +44,30 @@ export function HomeComposerFromSearchParams({
 
   return (
     <HomeComposer
+      initialAppBuildTarget={params.appBuildTarget}
+      initialModel={params.model}
       initialPromptKey={params.promptKey}
+      initialRepoUrl={params.repoUrl}
       initialSkill={params.skill}
       initialTool={params.tool}
-      key={`${params.promptKey ?? ""}:${params.skill ?? ""}:${params.tool ?? ""}:${params.skillCreator ? "sc" : ""}`}
+      key={`${params.promptKey ?? ""}:${params.skill ?? ""}:${params.tool ?? ""}:${params.appBuildTarget ?? ""}:${params.model ?? ""}:${params.repoUrl ?? ""}:${params.skillCreator ? "sc" : ""}`}
       quickActionsSlot={quickActionsSlot}
       skillCreator={params.skillCreator}
     />
   );
+}
+
+function validAppBuildTarget(value: string | null): AppBuildTarget | undefined {
+  return isAppBuildTarget(value) ? value : undefined;
+}
+
+function validInitialModel(value: string | null): AgentModelId | undefined {
+  return isAgentModelId(value) ? value : undefined;
+}
+
+function validInitialRepoUrl(value: string | null): string | undefined {
+  const result = GitHubRepoUrlSchema.safeParse(value);
+  return result.success ? result.data : undefined;
 }
 
 function validInitialSkill(value: string | null): string | undefined {

--- a/apps/web/src/components/home/home-composer-intents.ts
+++ b/apps/web/src/components/home/home-composer-intents.ts
@@ -1,72 +1,86 @@
 import type { ComponentType } from "react";
-import { skillBuildSurface } from "@/components/home/use-initial-skill";
-import { Globe, Smartphone, Star, TrendingUp } from "@/components/ui";
+import type { ComposerWorkIntentId } from "@/components/home/home-composer.types";
+import { skillAppBuildTarget } from "@/components/home/use-initial-skill";
+import { FileText, Globe, Image, Smartphone, Star, TrendingUp } from "@/components/ui";
 import { CheatcodeMark } from "@/components/ui/cheatcode-mark";
+import type { AppBuildTarget } from "@/lib/app-build-target";
 
-export type IntentId = "data" | "mobile-app" | "research" | "slides" | "web-app";
-
-/** Runtime/preview topology only; research, data, and slides remain work intents. */
-export type BuildSurface = "mobile" | "web";
-
-export type ComposerIntent = {
+export type ComposerWorkIntent = {
   icon: ComponentType<{ className?: string; "aria-hidden"?: boolean | "false" | "true" }>;
-  id: IntentId;
+  id: ComposerWorkIntentId;
   label: string;
   placeholder: string;
   skill: null | string;
-  buildSurface: BuildSurface | null;
+  appBuildTarget: AppBuildTarget | null;
 };
 
-export const COMPOSER_INTENTS: readonly ComposerIntent[] = [
+export const COMPOSER_WORK_INTENTS: readonly ComposerWorkIntent[] = [
   {
+    appBuildTarget: "mobile",
     icon: Smartphone,
     id: "mobile-app",
     label: "Mobile app",
     placeholder: "Describe the app - I'll build it with a live phone preview",
     skill: null,
-    buildSurface: "mobile",
   },
   {
+    appBuildTarget: "web",
     icon: Globe,
     id: "web-app",
     label: "Web app",
     placeholder: "Describe the site or web app - I'll build and preview it",
     skill: null,
-    buildSurface: "web",
   },
   {
+    appBuildTarget: null,
     icon: Star,
     id: "slides",
     label: "Slides",
     placeholder: "What's the deck about? Audience and key points help",
     skill: "pitch-deck",
-    buildSurface: null,
   },
   {
+    appBuildTarget: null,
     icon: CheatcodeMark,
     id: "research",
     label: "Research",
     placeholder: "What should I research? I'll fan out agents and cite sources",
     skill: "deep-research",
-    buildSurface: null,
   },
   {
+    appBuildTarget: null,
     icon: TrendingUp,
     id: "data",
     label: "Data",
     placeholder: "Attach or describe the data - I'll profile and chart it",
     skill: "csv-analyst",
-    buildSurface: null,
+  },
+  {
+    appBuildTarget: null,
+    icon: FileText,
+    id: "documents",
+    label: "Documents",
+    placeholder: "Describe the report, memo, PDF, or document you need",
+    skill: null,
+  },
+  {
+    appBuildTarget: null,
+    icon: Image,
+    id: "media",
+    label: "Media",
+    placeholder: "Describe the image or video you want to create or edit",
+    skill: "generate-media",
   },
 ] as const;
 
-export const QUICK_ACTION_PRIMARY_INTENTS = COMPOSER_INTENTS.slice(0, 2);
-export const QUICK_ACTION_SECONDARY_INTENTS = COMPOSER_INTENTS.slice(2);
+export const QUICK_ACTION_PRIMARY_INTENTS = COMPOSER_WORK_INTENTS.slice(0, 2);
+export const QUICK_ACTION_SECONDARY_INTENTS = COMPOSER_WORK_INTENTS.slice(2, 5);
+export const QUICK_ACTION_TERTIARY_INTENTS = COMPOSER_WORK_INTENTS.slice(5);
 
 /** The skill to attach on submit — a repo import carries no skill. */
 export function resolveSubmitSkill(
   repoUrl: string | null,
-  intent: ComposerIntent | null,
+  intent: ComposerWorkIntent | null,
   skillChip: string | null,
 ): string | null {
   if (repoUrl) {
@@ -75,15 +89,15 @@ export function resolveSubmitSkill(
   return intent?.skill ?? skillChip;
 }
 
-/** The build surface (mobile/web/null) implied by the current intent or imported repo. */
-export function resolveSubmitBuildSurface(
+/** The app target implied by the current intent, skill, or imported repository. */
+export function resolveSubmitAppBuildTarget(
   repoUrl: string | null,
-  intentId: IntentId | null,
-  intent: ComposerIntent | null,
+  intentId: ComposerWorkIntentId | null,
+  intent: ComposerWorkIntent | null,
   skillChip: string | null,
-): BuildSurface | null {
+): AppBuildTarget | null {
   if (repoUrl) {
     return intentId === "mobile-app" ? "mobile" : "web";
   }
-  return intent ? intent.buildSurface : skillBuildSurface(skillChip);
+  return intent ? intent.appBuildTarget : skillAppBuildTarget(skillChip);
 }

--- a/apps/web/src/components/home/home-composer-prompt-state.ts
+++ b/apps/web/src/components/home/home-composer-prompt-state.ts
@@ -1,11 +1,11 @@
 "use client";
 
 import type { RunIntent } from "@cheatcode/types/api";
-import type { BuildSurface } from "@/components/home/home-composer-intents";
+import type { AppBuildTarget } from "@/lib/app-build-target";
 import { createPromptHandoff } from "@/lib/input/prompt-handoff";
 
 export function buildLaunchParams(input: {
-  buildSurface: BuildSurface | null;
+  appBuildTarget: AppBuildTarget | null;
   intent: RunIntent | null;
   model: null | string;
   prompt: string;
@@ -18,8 +18,8 @@ export function buildLaunchParams(input: {
   if (input.prompt.length > 0) {
     params.set("promptKey", createPromptHandoff(input.prompt).promptKey);
   }
-  if (input.buildSurface) {
-    params.set("surface", input.buildSurface);
+  if (input.appBuildTarget) {
+    params.set("buildTarget", input.appBuildTarget);
   }
   if (input.model) {
     params.set("model", input.model);

--- a/apps/web/src/components/home/home-composer.tsx
+++ b/apps/web/src/components/home/home-composer.tsx
@@ -17,6 +17,7 @@ import { ComposerTextarea } from "@/components/composer/composer-textarea";
 import { ModelMenu } from "@/components/composer/model-menu";
 import { ProjectPicker } from "@/components/composer/project-picker";
 import type { ComposerTriggers } from "@/components/composer/use-composer-triggers";
+import type { ComposerWorkIntentId } from "@/components/home/home-composer.types";
 import {
   type HomeComposerProps,
   useHomeComposerController,
@@ -26,7 +27,7 @@ import {
   RemovableChip,
   SkillCreatorSuggestions,
 } from "@/components/home/home-composer-controls";
-import type { ComposerIntent, IntentId } from "@/components/home/home-composer-intents";
+import type { ComposerWorkIntent } from "@/components/home/home-composer-intents";
 import { SandboxUsageBanner } from "@/components/home/home-composer-plan-banner";
 import { repoLabel } from "@/components/home/home-composer-prompt-state";
 import { ArrowUp, X } from "@/components/ui";
@@ -149,7 +150,7 @@ function HomeComposerEditor(props: HomeComposerEditorProps) {
 interface HomeComposerToolbarProps {
   attachmentInputRef: RefObject<HTMLInputElement | null>;
   canSubmit: boolean;
-  intent: ComposerIntent | null;
+  intent: ComposerWorkIntent | null;
   onAttachmentChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onClearIntent: () => void;
   onOpenFilePicker: () => void;
@@ -251,8 +252,8 @@ function QuickActionsPortal({
   skillCreatorMode,
   slot,
 }: {
-  activeIntentId: IntentId | null;
-  onIntentClick: (intentId: IntentId) => void;
+  activeIntentId: ComposerWorkIntentId | null;
+  onIntentClick: (intentId: ComposerWorkIntentId) => void;
   onSkillCreatorPick: (text: string) => void;
   skillCreatorMode: boolean;
   slot: HTMLElement | null | undefined;
@@ -311,7 +312,7 @@ function HomeIntentChip({
   intent,
   onClear,
 }: {
-  intent: ComposerIntent | null;
+  intent: ComposerWorkIntent | null;
   onClear: () => void;
 }) {
   if (!intent) {

--- a/apps/web/src/components/home/home-composer.types.ts
+++ b/apps/web/src/components/home/home-composer.types.ts
@@ -1,0 +1,8 @@
+export type ComposerWorkIntentId =
+  | "data"
+  | "documents"
+  | "media"
+  | "mobile-app"
+  | "research"
+  | "slides"
+  | "web-app";

--- a/apps/web/src/components/home/home-computer-pane.tsx
+++ b/apps/web/src/components/home/home-computer-pane.tsx
@@ -8,7 +8,7 @@ import { ConsoleStrip } from "@/components/preview/console-strip";
 import { PreviewUrlBar } from "@/components/preview/preview-url-bar";
 import { SandboxIdeTab } from "@/components/preview/sandbox-ide-tab";
 import { CheatcodeTooltip } from "@/components/ui/cheatcode-tooltip";
-import type { PreviewTab } from "@/lib/store/app-store";
+import type { ComputerTab } from "@/lib/store/app-store";
 import { cn } from "@/lib/ui/cn";
 
 /** The user-scoped Computer shown on home before a chat or project is selected. */
@@ -21,7 +21,7 @@ export function HomeComputerPane({
   onClose: () => void;
   onOpen: () => void;
 }) {
-  const [activeTab, setActiveTab] = useState<PreviewTab>("files");
+  const [activeTab, setActiveTab] = useState<ComputerTab>("files");
 
   return (
     <>
@@ -42,10 +42,10 @@ function HomeComputerAside({
   onClose,
   setActiveTab,
 }: {
-  activeTab: PreviewTab;
+  activeTab: ComputerTab;
   computerOpen: boolean;
   onClose: () => void;
-  setActiveTab: (tab: PreviewTab) => void;
+  setActiveTab: (tab: ComputerTab) => void;
 }) {
   return (
     <aside
@@ -70,19 +70,19 @@ function HomeComputerBody({
   onClose,
   setActiveTab,
 }: {
-  activeTab: PreviewTab;
+  activeTab: ComputerTab;
   computerOpen: boolean;
   onClose: () => void;
-  setActiveTab: (tab: PreviewTab) => void;
+  setActiveTab: (tab: ComputerTab) => void;
 }) {
   return (
     <div className="flex h-full max-h-full w-full min-w-0 flex-col gap-2 overflow-hidden bg-background">
       <ComputerPanelTabs
-        activePreviewTab={activeTab}
+        activeComputerTab={activeTab}
         deliverableCount={0}
         projectId={null}
         projectName={null}
-        setActivePreviewTab={setActiveTab}
+        setActiveComputerTab={setActiveTab}
         setPreviewPanelOpen={(open) => {
           if (!open) onClose();
         }}
@@ -102,7 +102,7 @@ function HomeComputerTabContent({
   activeTab,
   computerOpen,
 }: {
-  activeTab: PreviewTab;
+  activeTab: ComputerTab;
   computerOpen: boolean;
 }) {
   return (
@@ -114,7 +114,7 @@ function HomeComputerTabContent({
           threadId={null}
         />
       </Activity>
-      <Activity mode={activeTab === "app" ? "visible" : "hidden"}>
+      <Activity mode={activeTab === "browser" ? "visible" : "hidden"}>
         <HomeBrowserEmpty />
       </Activity>
     </div>

--- a/apps/web/src/components/home/home-workspace.tsx
+++ b/apps/web/src/components/home/home-workspace.tsx
@@ -62,7 +62,7 @@ export function HomeWorkspace() {
           }
           computerOpen={computerVisible}
           content={<HomeContentPane computerOpen={computerVisible} />}
-          hasPreviewSurface={hasComputer}
+          hasComputer={hasComputer}
         />
       </SidebarContentFrame>
     </main>

--- a/apps/web/src/components/home/use-home-composer-selection.ts
+++ b/apps/web/src/components/home/use-home-composer-selection.ts
@@ -3,12 +3,16 @@
 import type { IntegrationName } from "@cheatcode/types";
 import type { ProjectSummary } from "@cheatcode/types/api";
 import { useCallback, useState } from "react";
-import { COMPOSER_INTENTS, type IntentId } from "@/components/home/home-composer-intents";
+import type { ComposerWorkIntentId } from "@/components/home/home-composer.types";
+import { COMPOSER_WORK_INTENTS } from "@/components/home/home-composer-intents";
 import { resolveInitialSkill } from "@/components/home/use-initial-skill";
+import type { AppBuildTarget } from "@/lib/app-build-target";
 
 interface InitialSelection {
+  appBuildTarget: AppBuildTarget | null;
   initialSkill: ReturnType<typeof resolveInitialSkill>;
   initialTool: IntegrationName | null;
+  repoUrl: string | null;
   skillCreator: boolean;
 }
 
@@ -31,13 +35,15 @@ export function useHomeComposerSelection(initial: InitialSelection, focusTextare
 }
 
 function useHomeSelectionState(initial: InitialSelection) {
-  const [intentId, setIntentId] = useState<IntentId | null>(initial.initialSkill.intent);
+  const [intentId, setIntentId] = useState<ComposerWorkIntentId | null>(
+    initial.initialSkill.intent ?? appBuildTargetIntent(initial.appBuildTarget),
+  );
   const [skillChip, setSkillChip] = useState<string | null>(initial.initialSkill.chip);
   const [toolChip, setToolChip] = useState<IntegrationName | null>(initial.initialTool);
   const [selectedProject, setSelectedProject] = useState<ProjectSummary | null>(null);
-  const [repoUrl, setRepoUrl] = useState<string | null>(null);
+  const [repoUrl, setRepoUrl] = useState<string | null>(initial.repoUrl);
   const [skillCreatorMode, setSkillCreatorMode] = useState(initial.skillCreator);
-  const intent = COMPOSER_INTENTS.find((candidate) => candidate.id === intentId) ?? null;
+  const intent = COMPOSER_WORK_INTENTS.find((candidate) => candidate.id === intentId) ?? null;
   return {
     intent,
     intentId,
@@ -61,8 +67,8 @@ function useIntentSelectionActions(
 ) {
   const { intent, intentId, repoUrl, setIntentId, setRepoUrl, setSkillChip, skillChip } = state;
   const toggleIntent = useCallback(
-    (nextId: IntentId) => {
-      const nextIntent = COMPOSER_INTENTS.find((candidate) => candidate.id === nextId) ?? null;
+    (nextId: ComposerWorkIntentId) => {
+      const nextIntent = COMPOSER_WORK_INTENTS.find((candidate) => candidate.id === nextId) ?? null;
       const isClearing = intentId === nextId;
       setIntentId(isClearing ? null : nextId);
       setSkillChip(isClearing ? null : (nextIntent?.skill ?? null));
@@ -82,13 +88,18 @@ function useIntentSelectionActions(
   }, [focusTextarea, intent, setIntentId, setSkillChip, skillChip]);
 
   const selectQuickIntent = useCallback(
-    (nextId: IntentId) => {
+    (nextId: ComposerWorkIntentId) => {
       toggleIntent(nextId);
       window.requestAnimationFrame(focusTextarea);
     },
     [focusTextarea, toggleIntent],
   );
   return { clearIntent, selectQuickIntent, toggleIntent };
+}
+
+function appBuildTargetIntent(target: AppBuildTarget | null): ComposerWorkIntentId | null {
+  if (target === "mobile") return "mobile-app";
+  return target === "web" ? "web-app" : null;
 }
 
 function useResourceSelectionActions(state: ReturnType<typeof useHomeSelectionState>) {

--- a/apps/web/src/components/home/use-home-composer-submission.ts
+++ b/apps/web/src/components/home/use-home-composer-submission.ts
@@ -5,25 +5,23 @@ import type { ProjectSummary, RunIntent } from "@cheatcode/types/api";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
 import { composePromptWithComposerContext } from "@/components/composer/composer-context-chips";
-import type {
-  BuildSurface,
-  ComposerIntent,
-  IntentId,
-} from "@/components/home/home-composer-intents";
+import type { ComposerWorkIntentId } from "@/components/home/home-composer.types";
+import type { ComposerWorkIntent } from "@/components/home/home-composer-intents";
 import {
-  resolveSubmitBuildSurface,
+  resolveSubmitAppBuildTarget,
   resolveSubmitSkill,
 } from "@/components/home/home-composer-intents";
 import { buildLaunchParams } from "@/components/home/home-composer-prompt-state";
 import { type AgentModelId, agentModelRequestValue } from "@/lib/agent-models";
 import { buildExistingProjectParams, launchIntoProject } from "@/lib/api/home-launch";
-import { buildSurfaceToMode, createChat, threadTitle } from "@/lib/api/project-thread";
+import { createChat, threadTitle } from "@/lib/api/project-thread";
+import { type AppBuildTarget, appBuildTargetToProjectMode } from "@/lib/app-build-target";
 import { assertUserMessageWithinLimit } from "@/lib/input/prompt-attachments";
 
 interface HomeSubmissionState {
   agentModelId: AgentModelId;
-  intent: ComposerIntent | null;
-  intentId: IntentId | null;
+  intent: ComposerWorkIntent | null;
+  intentId: ComposerWorkIntentId | null;
   repoUrl: string | null;
   selectedProject: ProjectSummary | null;
   skillChip: string | null;
@@ -33,7 +31,7 @@ interface HomeSubmissionState {
 }
 
 interface HomeSubmissionSnapshot {
-  buildSurface: BuildSurface | null;
+  appBuildTarget: AppBuildTarget | null;
   intent: RunIntent | null;
   model: null | string;
   project: ProjectSummary | null;
@@ -98,7 +96,7 @@ function buildSubmissionSnapshot(state: HomeSubmissionState): HomeSubmissionSnap
     return null;
   }
   return {
-    buildSurface: resolveSubmitBuildSurface(
+    appBuildTarget: resolveSubmitAppBuildTarget(
       state.repoUrl,
       state.intentId,
       state.intent,
@@ -157,7 +155,7 @@ async function startNewChat(
     const thread = await createChat(runtime.getToken, {
       initialPrompt: snapshot.prompt,
       title: threadTitle(snapshot.prompt),
-      mode: buildSurfaceToMode(snapshot.buildSurface),
+      mode: appBuildTargetToProjectMode(snapshot.appBuildTarget),
       ...(snapshot.repoUrl ? { importRepoUrl: snapshot.repoUrl } : {}),
       ...(snapshot.model ? { defaultModel: snapshot.model } : {}),
     });
@@ -178,7 +176,7 @@ function preservePromptForSignIn(
       model: snapshot.model,
       prompt: snapshot.prompt,
       repo: snapshot.repoUrl,
-      buildSurface: snapshot.buildSurface,
+      appBuildTarget: snapshot.appBuildTarget,
     });
     runtime.setAuthRedirectTo(`/?${params.toString()}`);
   } catch (error) {

--- a/apps/web/src/components/home/use-initial-skill.ts
+++ b/apps/web/src/components/home/use-initial-skill.ts
@@ -1,17 +1,24 @@
 import { SKILL_MANIFEST } from "@cheatcode/skills/manifest";
+import type { ComposerWorkIntentId } from "@/components/home/home-composer.types";
+import type { AppBuildTarget } from "@/lib/app-build-target";
 
-type SkillIntent = "data" | "research" | "slides";
-export type SkillBuildSurface = "mobile" | "web";
+type SkillIntent = Extract<
+  ComposerWorkIntentId,
+  "data" | "documents" | "media" | "research" | "slides"
+>;
 
-// Skills that map onto an existing intent pill (the design's slide/research/data lanes).
+// Skills that map onto an existing composer work-intent choice.
 const SKILL_TO_INTENT: Record<string, SkillIntent> = {
   "csv-analyst": "data",
   "deep-research": "research",
+  docx: "documents",
+  "generate-media": "media",
+  pdf: "documents",
   "pitch-deck": "slides",
 };
 
-// Skills that fix the build surface but have no intent pill.
-const SKILL_TO_BUILD_SURFACE: Record<string, SkillBuildSurface> = {
+// Skills that imply an app runtime target without becoming a durable project mode themselves.
+const SKILL_TO_APP_BUILD_TARGET: Record<string, AppBuildTarget> = {
   "mobile-app": "mobile",
 };
 
@@ -39,6 +46,6 @@ export function resolveInitialSkill(skill: string | null | undefined): InitialSk
   return { chip: skill, intent: null };
 }
 
-export function skillBuildSurface(skill: string | null): SkillBuildSurface | null {
-  return skill ? (SKILL_TO_BUILD_SURFACE[skill] ?? null) : null;
+export function skillAppBuildTarget(skill: string | null): AppBuildTarget | null {
+  return skill ? (SKILL_TO_APP_BUILD_TARGET[skill] ?? null) : null;
 }

--- a/apps/web/src/components/preview/computer-panel-tabs.tsx
+++ b/apps/web/src/components/preview/computer-panel-tabs.tsx
@@ -14,39 +14,39 @@ import {
 } from "@/components/ui";
 import { CheatcodeTooltip } from "@/components/ui/cheatcode-tooltip";
 import { downloadProjectArchive } from "@/lib/api/project-thread";
-import type { PreviewTab } from "@/lib/store/app-store";
+import type { ComputerTab } from "@/lib/store/app-store";
 import { cn } from "@/lib/ui/cn";
 import { useDismissable } from "@/lib/ui/use-dismissable";
 import { ComputerToggleButton } from "./computer-toggle-button";
 import type { BrowserTakeoverController } from "./use-browser-takeover";
 
-const TABS: ReadonlyArray<{ label: string; value: PreviewTab }> = [
+const TABS: ReadonlyArray<{ label: string; value: ComputerTab }> = [
   { label: "Files", value: "files" },
-  { label: "Browser", value: "app" },
+  { label: "Browser", value: "browser" },
 ];
 
 interface ComputerPanelTabsProps {
-  activePreviewTab: PreviewTab;
+  activeComputerTab: ComputerTab;
   browserTakeover?: BrowserTakeoverController;
   deliverableCount: number;
   projectId: string | null;
   projectName: string | null;
-  setActivePreviewTab: (tab: PreviewTab) => void;
+  setActiveComputerTab: (tab: ComputerTab) => void;
   setPreviewPanelOpen: (open: boolean) => void;
 }
 
 export function ComputerPanelTabs({
-  activePreviewTab,
+  activeComputerTab,
   browserTakeover,
   deliverableCount,
   projectId,
   projectName,
-  setActivePreviewTab,
+  setActiveComputerTab,
   setPreviewPanelOpen,
 }: ComputerPanelTabsProps) {
   return (
     <div className="relative z-20 hidden h-12 w-full shrink-0 items-center overflow-visible md:flex">
-      <ComputerTabSelector activeTab={activePreviewTab} onSelect={setActivePreviewTab} />
+      <ComputerTabSelector activeTab={activeComputerTab} onSelect={setActiveComputerTab} />
       <ComputerPanelActions
         {...(browserTakeover ? { browserTakeover } : {})}
         deliverableCount={deliverableCount}
@@ -62,8 +62,8 @@ function ComputerTabSelector({
   activeTab,
   onSelect,
 }: {
-  activeTab: PreviewTab;
-  onSelect: (tab: PreviewTab) => void;
+  activeTab: ComputerTab;
+  onSelect: (tab: ComputerTab) => void;
 }) {
   return (
     <div
@@ -234,7 +234,7 @@ function DeliverablesButton({ count }: { count: number }) {
   );
 }
 
-function computerTabStyle(activeTab: PreviewTab): CSSProperties {
+function computerTabStyle(activeTab: ComputerTab): CSSProperties {
   return {
     "--active-tab-left": activeTab === "files" ? "3px" : "57.664px",
     "--active-tab-width": activeTab === "files" ? "52.664px" : "75.383px",

--- a/apps/web/src/components/preview/preview-side-panel.tsx
+++ b/apps/web/src/components/preview/preview-side-panel.tsx
@@ -18,7 +18,7 @@ import { Monitor } from "@/components/ui";
 import { CheatcodeLoader } from "@/components/ui/cheatcode-loader";
 import { CheatcodeTooltip } from "@/components/ui/cheatcode-tooltip";
 import { RecoveryCard } from "@/components/ui/recovery-card";
-import type { PreviewDevice, PreviewTab } from "@/lib/store/app-store";
+import type { ComputerTab, PreviewDevice } from "@/lib/store/app-store";
 import { useAppStore } from "@/lib/store/app-store";
 import { emitFirstPreviewOpened } from "@/lib/telemetry/user-events";
 import { cn } from "@/lib/ui/cn";
@@ -88,15 +88,15 @@ function usePreviewPanelController(
   const browserTakeover = useBrowserTakeover(activeRunId, threadId);
   useEffect(() => {
     if (!browserTakeover.session) return;
-    store.setActivePreviewTab("app");
+    store.setActiveComputerTab("browser");
     store.setPreviewPanelOpen(true);
-  }, [browserTakeover.session, store.setActivePreviewTab, store.setPreviewPanelOpen]);
+  }, [browserTakeover.session, store.setActiveComputerTab, store.setPreviewPanelOpen]);
   return { ...store, browserTakeover, isMobile, isRunActive, previewLive };
 }
 
 function usePreviewPanelStore() {
   return {
-    activePreviewTab: useAppStore((state) => normalizeComputerTab(state.activePreviewTab)),
+    activeComputerTab: useAppStore((state) => state.activeComputerTab),
     appPreviewStatus: useAppStore((state) => state.appPreviewStatus),
     expoUrl: useAppStore((state) => state.expoUrl),
     previewDevice: useAppStore((state) => state.previewDevice),
@@ -105,7 +105,7 @@ function usePreviewPanelStore() {
     previewReloadToken: useAppStore((state) => state.previewReloadToken),
     previewUrl: useAppStore((state) => state.previewUrl),
     sandboxStatus: useAppStore((state) => state.sandboxStatus),
-    setActivePreviewTab: useAppStore((state) => state.setActivePreviewTab),
+    setActiveComputerTab: useAppStore((state) => state.setActiveComputerTab),
     setPreviewPanelOpen: useAppStore((state) => state.setPreviewPanelOpen),
   };
 }
@@ -192,16 +192,16 @@ function PreviewPanelAside({
     >
       <div className="flex h-full max-h-full w-full min-w-0 flex-col gap-2 overflow-hidden bg-background">
         <ComputerPanelTabs
-          activePreviewTab={controller.activePreviewTab}
+          activeComputerTab={controller.activeComputerTab}
           deliverableCount={deliverableCount}
           projectId={project?.id ?? null}
           projectName={project?.name ?? null}
           browserTakeover={controller.browserTakeover}
-          setActivePreviewTab={controller.setActivePreviewTab}
+          setActiveComputerTab={controller.setActiveComputerTab}
           setPreviewPanelOpen={controller.setPreviewPanelOpen}
         />
         <ComputerSurfaceFrame
-          consoleStrip={previewConsoleStrip(controller.activePreviewTab, project, threadId)}
+          consoleStrip={previewConsoleStrip(controller.activeComputerTab, project, threadId)}
         >
           <PanelBody {...panelBodyProps(controller, project, threadId)} />
         </ComputerSurfaceFrame>
@@ -220,7 +220,7 @@ function previewPanelClass(isOpen: boolean): string {
 }
 
 function previewConsoleStrip(
-  activeTab: PreviewTab,
+  activeTab: ComputerTab,
   project: ProjectSummary | null,
   threadId: string,
 ) {
@@ -235,7 +235,7 @@ function panelBodyProps(
   threadId: string,
 ): PanelBodyProps {
   return {
-    activePreviewTab: controller.activePreviewTab,
+    activeComputerTab: controller.activeComputerTab,
     appPreviewStatus: controller.appPreviewStatus,
     computerOpen: controller.previewPanelOpen,
     device: controller.previewDevice,
@@ -256,7 +256,7 @@ function panelBodyProps(
 }
 
 interface PanelBodyProps {
-  activePreviewTab: PreviewTab;
+  activeComputerTab: ComputerTab;
   appPreviewStatus: ReturnType<typeof useAppStore.getState>["appPreviewStatus"];
   computerOpen: boolean;
   device: PreviewDevice;
@@ -276,7 +276,7 @@ interface PanelBodyProps {
 }
 
 function PanelBody({
-  activePreviewTab,
+  activeComputerTab,
   appPreviewStatus,
   computerOpen,
   device,
@@ -296,7 +296,7 @@ function PanelBody({
 }: PanelBodyProps) {
   return (
     <div className="h-full min-h-0">
-      <Activity mode={activePreviewTab === "app" ? "visible" : "hidden"}>
+      <Activity mode={activeComputerTab === "browser" ? "visible" : "hidden"}>
         {browserTakeover.session ? (
           <BrowserTakeoverSurface browserTakeover={browserTakeover} />
         ) : (
@@ -317,9 +317,9 @@ function PanelBody({
           />
         )}
       </Activity>
-      <Activity mode={activePreviewTab === "files" ? "visible" : "hidden"}>
+      <Activity mode={activeComputerTab === "files" ? "visible" : "hidden"}>
         <SandboxIdeTab
-          active={computerOpen && activePreviewTab === "files"}
+          active={computerOpen && activeComputerTab === "files"}
           previewReloadToken={previewReloadToken}
           threadId={threadId}
         />
@@ -330,7 +330,7 @@ function PanelBody({
 
 type AppTabProps = Omit<
   PanelBodyProps,
-  "activePreviewTab" | "browserTakeover" | "computerOpen" | "threadId"
+  "activeComputerTab" | "browserTakeover" | "computerOpen" | "threadId"
 >;
 
 function AppTab({
@@ -529,10 +529,6 @@ function requestedPreviewIframeUrl(
   previewReloadToken: number,
 ): string | null {
   return previewUrl ? buildPreviewIframeSrc(previewUrl, previewPath, previewReloadToken) : null;
-}
-
-function normalizeComputerTab(tab: PreviewTab): PreviewTab {
-  return tab === "files" ? "files" : "app";
 }
 
 function PreviewWakeError({ onRetry }: { onRetry: () => Promise<void> }) {

--- a/apps/web/src/components/preview/use-ensure-preview-live.ts
+++ b/apps/web/src/components/preview/use-ensure-preview-live.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getSandboxPreviewStatus, wakeSandboxPreview } from "@/lib/api/project-thread";
-import { type PreviewTab, useAppStore } from "@/lib/store/app-store";
+import { type ComputerTab, useAppStore } from "@/lib/store/app-store";
 
 export type PreviewLivePhase = "booting" | "error" | "live";
 
@@ -34,7 +34,7 @@ interface PreviewRefreshAttempt {
 interface PreviewRefreshDependencies {
   bumpPreviewReloadToken: () => void;
   getToken: () => Promise<null | string>;
-  setActivePreviewTab: (tab: PreviewTab) => void;
+  setActiveComputerTab: (tab: ComputerTab) => void;
   setExpoUrl: (url: string | null) => void;
   setPreviewUrl: (url: string | null) => void;
   threadId: null | string;
@@ -68,7 +68,7 @@ export function useEnsurePreviewLive(
   active: boolean,
   sandboxStatus: string,
 ): PreviewLiveState {
-  const setActivePreviewTab = useAppStore((state) => state.setActivePreviewTab);
+  const setActiveComputerTab = useAppStore((state) => state.setActiveComputerTab);
   const bumpPreviewReloadToken = useAppStore((state) => state.bumpPreviewReloadToken);
   const setPreviewUrl = useAppStore((state) => state.setPreviewUrl);
   const setExpoUrl = useAppStore((state) => state.setExpoUrl);
@@ -76,7 +76,7 @@ export function useEnsurePreviewLive(
   const runtime = usePreviewLiveRuntime(
     bumpPreviewReloadToken,
     getToken,
-    setActivePreviewTab,
+    setActiveComputerTab,
     setExpoUrl,
     setPreviewUrl,
     threadId,
@@ -97,7 +97,7 @@ export function useEnsurePreviewLive(
 function usePreviewLiveRuntime(
   bumpPreviewReloadToken: PreviewRefreshDependencies["bumpPreviewReloadToken"],
   getToken: PreviewRefreshDependencies["getToken"],
-  setActivePreviewTab: PreviewRefreshDependencies["setActivePreviewTab"],
+  setActiveComputerTab: PreviewRefreshDependencies["setActiveComputerTab"],
   setExpoUrl: PreviewRefreshDependencies["setExpoUrl"],
   setPreviewUrl: PreviewRefreshDependencies["setPreviewUrl"],
   threadId: string | null,
@@ -106,7 +106,7 @@ function usePreviewLiveRuntime(
     deps: {
       bumpPreviewReloadToken,
       getToken,
-      setActivePreviewTab,
+      setActiveComputerTab,
       setExpoUrl,
       setPreviewUrl,
       threadId,
@@ -121,12 +121,12 @@ function usePreviewLiveRuntime(
     runtimeRef.current.deps = {
       bumpPreviewReloadToken,
       getToken,
-      setActivePreviewTab,
+      setActiveComputerTab,
       setExpoUrl,
       setPreviewUrl,
       threadId,
     };
-  }, [bumpPreviewReloadToken, getToken, setActivePreviewTab, setExpoUrl, setPreviewUrl, threadId]);
+  }, [bumpPreviewReloadToken, getToken, setActiveComputerTab, setExpoUrl, setPreviewUrl, threadId]);
   return runtimeRef.current;
 }
 
@@ -362,12 +362,12 @@ function applyPreviewRefreshResult(
     deps.setPreviewUrl(result.url);
     deps.setExpoUrl(result.expoUrl ?? null);
     if (shouldActivateApp) {
-      deps.setActivePreviewTab("app");
+      deps.setActiveComputerTab("browser");
     }
   } else {
     deps.setPreviewUrl(null);
     deps.setExpoUrl(null);
-    deps.setActivePreviewTab("files");
+    deps.setActiveComputerTab("files");
     setPhase("live");
     return PREVIEW_SESSION_REFRESH_MS;
   }

--- a/apps/web/src/components/projects/projects-shell.tsx
+++ b/apps/web/src/components/projects/projects-shell.tsx
@@ -29,10 +29,7 @@ import { useAppStore } from "@/lib/store/app-store";
 
 const PROMPT_URL_STATE = {
   intent: parseAsString,
-  model: parseAsString,
   promptKey: parseAsString,
-  repo: parseAsString,
-  surface: parseAsString,
 } as const;
 
 export function ProjectsShell({ threadId: threadIdProp }: { threadId?: string }) {
@@ -70,7 +67,7 @@ function useProjectsShell(threadIdProp: string | undefined) {
   const hasProject = projectId !== null;
   const previewPanelOpen = useAppStore((state) => state.previewPanelOpen);
   const sandboxStatus = useAppStore((state) => state.sandboxStatus);
-  const hasPreviewSurface = hasProject || sandboxStatus !== "cold";
+  const hasComputer = hasProject || sandboxStatus !== "cold";
   const deliverableCount = countDeliverables(initialMessages);
   const loadOlderMessages = useOlderThreadMessagesLoader(initialMessagesQuery);
 
@@ -89,7 +86,7 @@ function useProjectsShell(threadIdProp: string | undefined) {
       initialMessagesQuery.hasTranscriptIntegrityError ||
       projectQuery.isError ||
       threadQuery.isError,
-    hasPreviewSurface,
+    hasComputer,
     initialMessages,
     initialMessagesQuery,
     isRetrying: retry.isRetrying,
@@ -180,7 +177,7 @@ function ProjectsWorkspace({
           threadId={threadId}
         />
       }
-      hasPreviewSurface={shell.hasPreviewSurface}
+      hasComputer={shell.hasComputer}
     />
   );
 }
@@ -221,10 +218,7 @@ function useInitialChatPrompt(
     }
     void setUrlState({
       intent: null,
-      model: null,
       promptKey: null,
-      repo: null,
-      surface: null,
     });
   }, [setUrlState, urlState]);
   return { clearPromptParams, prompt, runIntent };
@@ -251,9 +245,7 @@ function useRefreshThreadProjectOnSandboxChange(input: {
 function hasPromptUrlState(
   urlState: Record<keyof typeof PROMPT_URL_STATE, null | string>,
 ): boolean {
-  return Boolean(
-    urlState.intent ?? urlState.model ?? urlState.promptKey ?? urlState.repo ?? urlState.surface,
-  );
+  return Boolean(urlState.intent ?? urlState.promptKey);
 }
 
 function useThreadQuery(getToken: () => Promise<null | string>, threadId: null | string) {

--- a/apps/web/src/components/shell/app-chrome.tsx
+++ b/apps/web/src/components/shell/app-chrome.tsx
@@ -71,7 +71,7 @@ function MobileRouteHeader({ pathname }: { pathname: string }) {
         <Link
           aria-label="Create skill"
           className="ml-auto flex size-8 items-center justify-center rounded-full text-fg-secondary transition-colors hover:bg-secondary hover:text-foreground"
-          href="/?mode=skill-creator"
+          href="/?intent=skill-creator"
         >
           <Plus aria-hidden="true" className="size-4" />
         </Link>

--- a/apps/web/src/components/skills/integration-skills-controls.tsx
+++ b/apps/web/src/components/skills/integration-skills-controls.tsx
@@ -31,7 +31,7 @@ export function SkillsHeader({
         <SkillsSearch onSearch={onSearch} search={search} />
         <Link
           className="relative hidden h-8 shrink-0 items-center justify-center overflow-hidden rounded-full bg-foreground px-4 py-2 font-medium text-background text-sm shadow-[inset_0_1px_0_rgba(255,255,255,.15),0_1px_3px_rgba(0,0,0,.2)] transition-transform duration-200 ease-out before:absolute before:inset-0 before:bg-gradient-to-b before:from-white/20 before:opacity-50 before:transition-opacity hover:before:opacity-0 active:scale-[.99] md:inline-flex"
-          href="/?mode=skill-creator"
+          href="/?intent=skill-creator"
         >
           Create skill
         </Link>

--- a/apps/web/src/components/workspace/workspace-run-layout.tsx
+++ b/apps/web/src/components/workspace/workspace-run-layout.tsx
@@ -20,7 +20,7 @@ type WorkspaceStyle = CSSProperties & { "--cc-chat-pane-size": string };
 /**
  * The canonical "computer open" workspace shell shared by the chat/projects view
  * and the home page. A flex container (`.cc-agent-run-layout`) whose flex-basis
- * rules live in `globals.css` (`data-preview-surface` + `data-computer-open`):
+ * rules live in `effects.css` (`data-computer-available` + `data-computer-open`):
  *
  *   [ .cc-agent-chat-pane (content) ] [ .cc-agent-run-divider ] [ .cc-agent-computer-pane (computer) ]
  *
@@ -33,27 +33,27 @@ export function WorkspaceRunLayout({
   computer,
   computerOpen,
   content,
-  hasPreviewSurface,
+  hasComputer,
 }: {
   computer: ReactNode;
   computerOpen: boolean;
   content: ReactNode;
-  hasPreviewSurface: boolean;
+  hasComputer: boolean;
 }) {
   const pane = useWorkspacePaneSize();
 
   return (
     <div
-      className={workspaceRunLayoutClass(hasPreviewSurface)}
+      className={workspaceRunLayoutClass(hasComputer)}
+      data-computer-available={hasComputer ? "true" : "false"}
       data-computer-open={computerOpen ? "true" : "false"}
-      data-preview-surface={hasPreviewSurface ? "true" : "false"}
       ref={pane.layoutRef}
       style={pane.style}
     >
-      <section className={workspaceChatPaneClass(hasPreviewSurface)}>{content}</section>
+      <section className={workspaceChatPaneClass(hasComputer)}>{content}</section>
       <RunPanelDivider
         computerOpen={computerOpen}
-        hasPreviewSurface={hasPreviewSurface}
+        hasComputer={hasComputer}
         onReset={pane.reset}
         onResize={pane.resizeFromClientX}
         value={pane.value}
@@ -81,18 +81,15 @@ function panePercentFromClientX(element: HTMLDivElement | null, clientX: number)
   return clampPanePercent(((clientX - bounds.left) / bounds.width) * 100);
 }
 
-function workspaceRunLayoutClass(hasPreviewSurface: boolean): string {
+function workspaceRunLayoutClass(hasComputer: boolean): string {
   return cn(
     "cc-agent-run-layout flex min-h-0 min-w-0 flex-1",
-    hasPreviewSurface ? "flex-col motion-reduce:transition-none md:flex-row" : null,
+    hasComputer ? "flex-col motion-reduce:transition-none md:flex-row" : null,
   );
 }
 
-function workspaceChatPaneClass(hasPreviewSurface: boolean): string {
-  return cn(
-    "cc-agent-chat-pane flex min-w-0 flex-1 flex-col",
-    hasPreviewSurface ? "min-h-0" : null,
-  );
+function workspaceChatPaneClass(hasComputer: boolean): string {
+  return cn("cc-agent-chat-pane flex min-w-0 flex-1 flex-col", hasComputer ? "min-h-0" : null);
 }
 
 function stopPanelResize(event: PointerEvent<HTMLHRElement>) {
@@ -105,7 +102,7 @@ function stopPanelResize(event: PointerEvent<HTMLHRElement>) {
 
 interface RunPanelDividerProps {
   computerOpen: boolean;
-  hasPreviewSurface: boolean;
+  hasComputer: boolean;
   onReset: () => void;
   onResize: (clientX: number) => void;
   value: number;
@@ -113,12 +110,12 @@ interface RunPanelDividerProps {
 
 function RunPanelDivider({
   computerOpen,
-  hasPreviewSurface,
+  hasComputer,
   onReset,
   onResize,
   value,
 }: RunPanelDividerProps) {
-  if (!hasPreviewSurface) {
+  if (!hasComputer) {
     return null;
   }
   return (

--- a/apps/web/src/lib/api/home-launch.ts
+++ b/apps/web/src/lib/api/home-launch.ts
@@ -32,8 +32,9 @@ export async function launchIntoProject(
 /**
  * Builds the opaque `?promptKey=…` handoff query for routing into a chat
  * (`/chats/{threadId}`) so the workspace auto-runs the first message. The chat id
- * rides the path, not the query. Carries no `surface`/`model` — the chat's launch
- * intent owns the build surface and a per-run model choice rides the zustand store.
+ * rides the path, not the query. App target, repository import, and default model
+ * are already persisted on the newly created chat; this handoff carries only the
+ * prompt and constrained run intent consumed by the chat workspace.
  */
 export function buildExistingProjectParams(
   prompt: string,

--- a/apps/web/src/lib/api/project-thread.ts
+++ b/apps/web/src/lib/api/project-thread.ts
@@ -3,7 +3,6 @@
 import { CHEATCODE_DATA_SCHEMAS, type CheatcodeUIMessage, toAgentRunId } from "@cheatcode/types";
 import {
   Paginated,
-  type ProjectMode,
   type ProjectSummary,
   ProjectSummarySchema,
   RecentThreadsResponseSchema,
@@ -478,14 +477,6 @@ function uiMessageRole(value: string): CheatcodeUIMessage["role"] | null {
     return value;
   }
   return null;
-}
-
-/** Maps the composer's preview/runtime choice to the persisted project mode. */
-export function buildSurfaceToMode(buildSurface: string | null): ProjectMode {
-  if (buildSurface === "mobile") {
-    return "app-builder-mobile";
-  }
-  return buildSurface === "web" ? "app-builder" : "general";
 }
 
 /** Derives a chat's title from its first prompt; an empty/absent prompt reads "New chat". */

--- a/apps/web/src/lib/app-build-target.ts
+++ b/apps/web/src/lib/app-build-target.ts
@@ -1,0 +1,15 @@
+import type { ProjectMode } from "@cheatcode/types/api";
+
+export type AppBuildTarget = "mobile" | "web";
+
+export function isAppBuildTarget(value: unknown): value is AppBuildTarget {
+  return value === "mobile" || value === "web";
+}
+
+/** Maps a runtime-specific app target to the persisted project topology. */
+export function appBuildTargetToProjectMode(target: AppBuildTarget | null): ProjectMode {
+  if (target === "mobile") {
+    return "app-builder-mobile";
+  }
+  return target === "web" ? "app-builder" : "general";
+}

--- a/apps/web/src/lib/store/app-store.ts
+++ b/apps/web/src/lib/store/app-store.ts
@@ -7,7 +7,7 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import { type AgentModelId, DEFAULT_AGENT_MODEL_ID, isAgentModelId } from "@/lib/agent-models";
 import { type ConsoleLine, mergeConsoleLines } from "@/lib/preview/console";
 
-export type PreviewTab = "app" | "files";
+export type ComputerTab = "browser" | "files";
 export type PreviewDevice = "desktop" | "tablet" | "phone";
 type ConnectionState = "online" | "offline";
 
@@ -30,7 +30,7 @@ export interface FilesOpenRequest {
 const PREVIEW_PATH_HISTORY_MAX = 50;
 
 interface AppStoreState {
-  activePreviewTab: PreviewTab;
+  activeComputerTab: ComputerTab;
   agentModelId: AgentModelId;
   appPreviewStatus: AppPreviewState;
   connectionState: ConnectionState;
@@ -72,7 +72,7 @@ interface AppStoreActions {
   resetPreviewNavigation: () => void;
   requestFileOpen: (threadId: string, path: string) => void;
   requestPreviewReload: () => void;
-  setActivePreviewTab: (tab: PreviewTab) => void;
+  setActiveComputerTab: (tab: ComputerTab) => void;
   setAgentModelId: (modelId: AgentModelId) => void;
   setAppPreviewStatus: (status: AppPreviewState) => void;
   setConnectionState: (state: ConnectionState) => void;
@@ -92,7 +92,7 @@ interface AppStore extends AppStoreState, AppStoreActions {}
 
 type PersistedAppStore = Pick<
   AppStore,
-  "activePreviewTab" | "agentModelId" | "previewDevice" | "sidebarCollapsed"
+  "activeComputerTab" | "agentModelId" | "previewDevice" | "sidebarCollapsed"
 >;
 
 export const useAppStore = create<AppStore>()(
@@ -102,7 +102,7 @@ export const useAppStore = create<AppStore>()(
     // Preview and Expo URLs are bearer capabilities. They must remain memory-only and are
     // reacquired from authenticated endpoints whenever the corresponding panel opens.
     partialize: (state): PersistedAppStore => ({
-      activePreviewTab: state.activePreviewTab,
+      activeComputerTab: state.activeComputerTab,
       agentModelId: state.agentModelId,
       previewDevice: state.previewDevice,
       sidebarCollapsed: state.sidebarCollapsed,
@@ -126,7 +126,7 @@ function createAppStore(set: AppStoreSet): AppStore {
 
 function initialAppStoreState(): AppStoreState {
   return {
-    activePreviewTab: "app",
+    activeComputerTab: "browser",
     agentModelId: DEFAULT_AGENT_MODEL_ID,
     appPreviewStatus: "idle",
     connectionState: "online",
@@ -213,7 +213,7 @@ function createPreviewActions(set: AppStoreSet) {
       }),
     requestPreviewReload: () =>
       set((state) => ({ previewReloadRequestToken: state.previewReloadRequestToken + 1 })),
-    setActivePreviewTab: (activePreviewTab: PreviewTab) => set({ activePreviewTab }),
+    setActiveComputerTab: (activeComputerTab: ComputerTab) => set({ activeComputerTab }),
     setAppPreviewStatus: (appPreviewStatus: AppPreviewState) => set({ appPreviewStatus }),
     setExpoUrl: (expoUrl: string | null) => set({ expoUrl }),
     setPreviewDevice: (previewDevice: PreviewDevice) => set({ previewDevice }),
@@ -259,10 +259,10 @@ function mergePersistedAppStore(persisted: unknown, current: AppStore): AppStore
   }
   return {
     ...current,
-    activePreviewTab:
-      persisted["activePreviewTab"] === "app" || persisted["activePreviewTab"] === "files"
-        ? persisted["activePreviewTab"]
-        : current.activePreviewTab,
+    activeComputerTab:
+      persisted["activeComputerTab"] === "browser" || persisted["activeComputerTab"] === "files"
+        ? persisted["activeComputerTab"]
+        : current.activeComputerTab,
     agentModelId: isAgentModelId(persisted["agentModelId"])
       ? persisted["agentModelId"]
       : current.agentModelId,


### PR DESCRIPTION
## Summary
- separates composer work intent, app runtime target, and Computer view state so unrelated concerns cannot leak into project topology
- adds Documents and Media composer entry points while keeping non-app work in general projects
- restores validated build target, model, repository, prompt, and run intent after authentication
- replaces the legacy persisted app tab with the user-facing Browser/Files vocabulary

## Architecture
The composer now resolves a typed ComposerWorkIntentId independently from AppBuildTarget. Only web and mobile targets map to app-builder project modes; research, data, slides, documents, and media remain general work. ComputerTab independently controls Browser or Files rendering, while artifact kind and MIME type continue to own output presentation.

## Decisions Made
| Decision | Choice | Reasoning |
|---|---|---|
| Non-app work | Keep general project mode | Research, data, documents, slides, and media share workspace lifecycle and do not need distinct sandbox topology. |
| Documents shortcut | Do not force a skill | The user may want DOCX, PDF, or another document format; prompt classification selects the correct capability. |
| Launch handoff | Validate and restore buildTarget/model/repo | Signed-out launches must create the same project and model choice after authentication. |
| Computer state | Use browser/files | UI navigation is independent from app runtime and artifact type. |
| Compatibility | Remove surface and app aliases | This is a clean implementation with one canonical vocabulary. |

## Edge Cases Handled
- imported repositories default to web unless Mobile app is explicitly selected
- invalid build targets, models, and repository URLs are discarded at the browser trust boundary
- model restoration waits for Zustand hydration so persisted state cannot overwrite the launch choice
- DOCX/PDF skill deep links activate Documents; media generation activates Media
- existing research, data, slides, web, and mobile choices retain their prior capabilities

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (passes with four pre-existing Knip configuration hints)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- direct invariant probe for general/web/mobile mode mapping and document/media/research skill mapping

Production browser QA will run after the merged revision is deployed.