### PR TITLE
fix(web): reset cached new-chat composer

### DIFF
--- a/apps/web/src/components/home/home-composer-from-search-params.tsx
+++ b/apps/web/src/components/home/home-composer-from-search-params.tsx
@@ -6,6 +6,7 @@ import { GitHubRepoUrlSchema } from "@cheatcode/types/api";
 import { useEffect, useState } from "react";
 import { type AgentModelId, isAgentModelId } from "@/lib/agent-models";
 import { type AppBuildTarget, isAppBuildTarget } from "@/lib/app-build-target";
+import { useAppStore } from "@/lib/store/app-store";
 import { HomeComposer } from "./home-composer";
 
 type InitialComposerParams = {
@@ -24,6 +25,7 @@ export function HomeComposerFromSearchParams({
   quickActionsSlot?: HTMLElement | null | undefined;
 }) {
   const [params, setParams] = useState<InitialComposerParams | null>(null);
+  const resetToken = useAppStore((state) => state.homeComposerResetToken);
 
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search);
@@ -39,7 +41,7 @@ export function HomeComposerFromSearchParams({
   }, []);
 
   if (!params) {
-    return <HomeComposer quickActionsSlot={quickActionsSlot} />;
+    return <HomeComposer key={resetToken} quickActionsSlot={quickActionsSlot} />;
   }
 
   return (
@@ -50,7 +52,7 @@ export function HomeComposerFromSearchParams({
       initialRepoUrl={params.repoUrl}
       initialSkill={params.skill}
       initialTool={params.tool}
-      key={`${params.promptKey ?? ""}:${params.skill ?? ""}:${params.tool ?? ""}:${params.appBuildTarget ?? ""}:${params.model ?? ""}:${params.repoUrl ?? ""}:${params.skillCreator ? "sc" : ""}`}
+      key={`${resetToken}:${params.promptKey ?? ""}:${params.skill ?? ""}:${params.tool ?? ""}:${params.appBuildTarget ?? ""}:${params.model ?? ""}:${params.repoUrl ?? ""}:${params.skillCreator ? "sc" : ""}`}
       quickActionsSlot={quickActionsSlot}
       skillCreator={params.skillCreator}
     />

--- a/apps/web/src/components/home/use-home-composer-submission.ts
+++ b/apps/web/src/components/home/use-home-composer-submission.ts
@@ -135,7 +135,7 @@ async function launchExistingProject(
       runtime.endSubmitting();
       return;
     }
-    navigateToChat(runtime.router, result.threadId, snapshot.prompt, snapshot.intent);
+    navigateToChat(runtime, result.threadId, snapshot.prompt, snapshot.intent);
   } catch (error) {
     toast.error(error instanceof Error ? error.message : "Could not open that project.");
     runtime.endSubmitting();
@@ -159,7 +159,7 @@ async function startNewChat(
       ...(snapshot.repoUrl ? { importRepoUrl: snapshot.repoUrl } : {}),
       ...(snapshot.model ? { defaultModel: snapshot.model } : {}),
     });
-    navigateToChat(runtime.router, thread.id, snapshot.prompt, snapshot.intent);
+    navigateToChat(runtime, thread.id, snapshot.prompt, snapshot.intent);
   } catch (error) {
     toast.error(error instanceof Error ? error.message : "Could not start that chat.");
     runtime.endSubmitting();
@@ -186,11 +186,15 @@ function preservePromptForSignIn(
 }
 
 function navigateToChat(
-  router: SubmissionRuntime["router"],
+  runtime: SubmissionRuntime,
   threadId: string,
   prompt: string,
   intent: RunIntent | null,
 ): void {
   const handoff = buildExistingProjectParams(prompt, intent).toString();
-  router.push(`/chats/${encodeURIComponent(threadId)}?${handoff}`);
+  // A soft navigation may preserve this page in the Next.js route cache. Release
+  // the submission lock before leaving so restoring the page can never revive a
+  // permanently disabled composer.
+  runtime.endSubmitting();
+  runtime.router.push(`/chats/${encodeURIComponent(threadId)}?${handoff}`);
 }

--- a/apps/web/src/components/shell/sidebar-expanded-navigation.tsx
+++ b/apps/web/src/components/shell/sidebar-expanded-navigation.tsx
@@ -21,6 +21,7 @@ import {
 import { ProjectList } from "@/components/shell/sidebar-project-list";
 import { ChevronDown } from "@/components/ui";
 import { isNavItemActive, type NavItem } from "@/lib/navigation/nav-model";
+import { useAppStore } from "@/lib/store/app-store";
 import { cn } from "@/lib/ui/cn";
 
 const PRIMARY_SIDEBAR_NAV = PRIMARY_NAV.filter((item) => item.id !== "projects");
@@ -161,6 +162,7 @@ function SidebarCollapseRegion({ children, open }: { children: ReactNode; open: 
 }
 
 function SidebarNavRow({ item, pathname }: { item: NavItem; pathname: string }) {
+  const resetHomeComposer = useAppStore((state) => state.resetHomeComposer);
   if (item.target.kind !== "route") return null;
   const active = isNavItemActive(item, pathname);
   return (
@@ -173,6 +175,7 @@ function SidebarNavRow({ item, pathname }: { item: NavItem; pathname: string }) 
           : "text-fg-secondary hover:bg-background hover:text-foreground dark:hover:bg-white/5",
       )}
       href={item.target.href}
+      {...(item.id === "new-task" ? { onClick: resetHomeComposer } : {})}
     >
       <span className="flex h-4 w-4 shrink-0 items-center justify-center">
         <item.icon aria-hidden="true" className="h-3.5 w-3.5" />

--- a/apps/web/src/components/shell/sidebar-rail-navigation.tsx
+++ b/apps/web/src/components/shell/sidebar-rail-navigation.tsx
@@ -9,6 +9,7 @@ import {
 import { PRIMARY_NAV, WORKSPACE_SECTION_NAV } from "@/components/shell/sidebar-navigation-model";
 import { CheatcodeTooltip } from "@/components/ui/cheatcode-tooltip";
 import { isNavItemActive, type NavItem } from "@/lib/navigation/nav-model";
+import { useAppStore } from "@/lib/store/app-store";
 import { cn } from "@/lib/ui/cn";
 
 const NEW_TASK_ITEM = PRIMARY_NAV.find((item) => item.id === "new-task");
@@ -111,6 +112,7 @@ export function SidebarRailLink({
   onNavigate?: () => void;
   pathname: string;
 }) {
+  const resetHomeComposer = useAppStore((state) => state.resetHomeComposer);
   if (item.target.kind !== "route") return null;
   const active = isNavItemActive(item, pathname);
   return (
@@ -125,7 +127,10 @@ export function SidebarRailLink({
             : "text-fg-secondary hover:bg-background hover:text-foreground dark:hover:bg-white/5",
         )}
         href={item.target.href}
-        {...(onNavigate ? { onClick: onNavigate } : {})}
+        onClick={() => {
+          if (item.id === "new-task") resetHomeComposer();
+          onNavigate?.();
+        }}
       >
         <item.icon
           aria-hidden="true"

--- a/apps/web/src/lib/store/app-store.ts
+++ b/apps/web/src/lib/store/app-store.ts
@@ -42,6 +42,7 @@ interface AppStoreState {
   draftByThread: Record<string, string>;
   expoUrl: string | null;
   filesOpenRequest: FilesOpenRequest | null;
+  homeComposerResetToken: number;
   previewDevice: PreviewDevice;
   previewPanelOpen: boolean;
   previewPath: string;
@@ -68,6 +69,7 @@ interface AppStoreActions {
   goBackPreviewPath: () => void;
   navigatePreviewPath: (path: string) => void;
   resetConsole: () => void;
+  resetHomeComposer: () => void;
   resetIdentityState: () => void;
   resetPreviewNavigation: () => void;
   requestFileOpen: (threadId: string, path: string) => void;
@@ -138,6 +140,7 @@ function initialAppStoreState(): AppStoreState {
     draftByThread: {},
     expoUrl: null,
     filesOpenRequest: null,
+    homeComposerResetToken: 0,
     previewDevice: "desktop",
     previewPanelOpen: false,
     previewPath: "/",
@@ -244,6 +247,8 @@ function navigatePreviewPath(state: AppStore, path: string): Partial<AppStore> {
 function createUiActions(set: AppStoreSet) {
   return {
     resetIdentityState: () => set(identityScopedInitialState()),
+    resetHomeComposer: () =>
+      set((state) => ({ homeComposerResetToken: state.homeComposerResetToken + 1 })),
     setAgentModelId: (agentModelId: AgentModelId) => set({ agentModelId }),
     setConnectionState: (connectionState: ConnectionState) => set({ connectionState }),
     setSandboxStatus: (sandboxStatus: SandboxState) => set({ sandboxStatus }),


### PR DESCRIPTION
## Summary
- release the home submission lock before soft-navigation to a newly created chat
- make the New chat navigation explicitly remount transient composer state
- prevent Next.js route-cache restoration from reviving stale prompts or disabled Send state

## Architecture
The existing in-memory UI store owns a non-persisted reset token. Both expanded and rail New chat links increment it, and the home composer uses it as its React identity. Successful submission also returns its state machine to idle before navigation instead of relying on unmount behavior.

## Decisions Made
| Decision | Choice | Reasoning |
|---|---|---|
| Reset scope | Non-persisted UI token | Composer state is transient and must not survive a deliberate New chat action |
| Submission lifecycle | End before navigation | Page unmount is not guaranteed when Next.js caches route segments |
| Navigation coverage | Expanded and rail sidebars | Both entry points must have identical semantics |

## Edge Cases Handled
- returning to a cached home route after a successful submission
- selecting New chat while the home route is already active
- collapsed and expanded sidebar navigation
- persisted UI preferences remain untouched

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- production reproduction confirmed the stale prompt and disabled Send state before this fix