### PR TITLE
fix(agent): streamline slides and tool failure recovery

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -88,9 +88,12 @@ provider keys and sandbox capabilities are reacquired inside the active step and
 Workflow storage. A Worker isolate or Durable Object eviction therefore resumes from the last
 completed step instead of losing an in-memory coroutine. Transcript publication uses deterministic
 event keys and an atomic SQLite receipt, so Workflow step replay cannot duplicate visible parts.
-Failed sandbox tools return a bounded model-facing projection of their exit code, hint, command
-output, and managed-process logs, so the next model turn can correct the failure instead of
-retrying blind. Those internal diagnostics are not promoted into user-facing assistant text.
+Failed tools return a bounded structured model-facing error with its stable code, message, hint,
+and explicit retry policy. Sandbox failures may also include bounded command output and
+managed-process logs. The next model turn can therefore correct a retriable failure once while
+treating plan, permission, validation, and other non-retriable failures as terminal for that
+operation instead of looping. Those internal diagnostics are not promoted into user-facing
+assistant text.
 Tool steps resolve only the credentials required by the invoked capability: ordinary data, file,
 code, and document work does not open research-key or connected-app database transactions. User
 skill packages are restored lazily when a skill is invoked instead of being projected into the

--- a/apps/agent-worker/package.json
+++ b/apps/agent-worker/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "wrangler deploy --dry-run",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/agent-core": "workspace:*",

--- a/apps/agent-worker/src/durable-objects/agent-run-research-response-support.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-research-response-support.ts
@@ -11,7 +11,7 @@ interface ToolCallLike {
 }
 
 interface ToolResultLike {
-  error?: string | undefined;
+  error?: unknown;
   output?: unknown;
   toolCall: ToolCallLike;
 }

--- a/apps/agent-worker/src/durable-objects/agent-run-tool-error-support.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-tool-error-support.ts
@@ -1,4 +1,6 @@
 import { APIError } from "@cheatcode/observability";
+import { ErrorCodeSchema } from "@cheatcode/types";
+import { z } from "zod";
 
 const MAX_TOOL_ERROR_CHARACTERS = 8_000;
 const MAX_TOOL_ERROR_OUTPUT_CHARACTERS = 3_000;
@@ -8,17 +10,38 @@ const SANDBOX_DIAGNOSTIC_CODES = new Set([
   "upstream_sandbox_timeout",
 ]);
 
-/** Preserves bounded, user-scoped execution diagnostics for the model's next turn. */
-export function agentToolErrorText(error: unknown): string {
+export const AgentToolErrorOutputSchema = z.strictObject({
+  code: ErrorCodeSchema,
+  diagnostics: z.string().optional(),
+  hint: z.string().optional(),
+  message: z.string(),
+  retriable: z.boolean(),
+});
+
+export type AgentToolErrorOutput = z.infer<typeof AgentToolErrorOutputSchema>;
+
+/** Preserves retry policy and bounded, user-scoped diagnostics for the model's next turn. */
+export function agentToolErrorOutput(error: unknown): AgentToolErrorOutput {
   if (!(error instanceof APIError)) {
-    return error instanceof Error ? error.message : "Tool execution failed.";
+    return AgentToolErrorOutputSchema.parse({
+      code: "tool_execution_failed",
+      message: clamp(
+        error instanceof Error ? error.message : "Tool execution failed.",
+        MAX_TOOL_ERROR_CHARACTERS,
+      ),
+      retriable: false,
+    });
   }
-  const lines = [`${error.code}: ${error.message}`];
-  if (error.opts.hint) lines.push(`Hint: ${error.opts.hint}`);
-  if (SANDBOX_DIAGNOSTIC_CODES.has(error.code)) {
-    lines.push(...sandboxDiagnosticLines(error.opts.details));
-  }
-  return clamp(lines.join("\n"), MAX_TOOL_ERROR_CHARACTERS);
+  const diagnostics = SANDBOX_DIAGNOSTIC_CODES.has(error.code)
+    ? sandboxDiagnosticLines(error.opts.details).join("\n")
+    : "";
+  return AgentToolErrorOutputSchema.parse({
+    code: error.code,
+    ...(diagnostics ? { diagnostics: clamp(diagnostics, MAX_TOOL_ERROR_CHARACTERS) } : {}),
+    ...(error.opts.hint ? { hint: clamp(error.opts.hint, MAX_TOOL_ERROR_CHARACTERS) } : {}),
+    message: clamp(error.message, MAX_TOOL_ERROR_CHARACTERS),
+    retriable: error.retriable,
+  });
 }
 
 function sandboxDiagnosticLines(details: Record<string, unknown> | undefined): string[] {

--- a/apps/agent-worker/src/durable-objects/agent-run-workflow-runtime.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-workflow-runtime.ts
@@ -36,7 +36,7 @@ import {
 import { finalizeAppBuilderRun, prepareAppBuilderRun } from "./agent-run-path";
 import { type StartRunInput, StartRunInputSchema } from "./agent-run-schemas";
 import { guardSkillRuntimeCapabilities } from "./agent-run-skill-runtime";
-import { agentToolErrorText } from "./agent-run-tool-error-support";
+import { AgentToolErrorOutputSchema, agentToolErrorOutput } from "./agent-run-tool-error-support";
 import {
   AGENT_RUN_WORKFLOW_MAX_RESPONSE_BYTES,
   type AgentRunWorkflowCallbackInput,
@@ -97,7 +97,7 @@ export const WorkflowModelStepResultSchema = z.strictObject({
 
 export const WorkflowToolStepResultSchema = z.strictObject({
   durationMs: z.number().int().nonnegative(),
-  error: z.string().optional(),
+  error: AgentToolErrorOutputSchema.optional(),
   input: StartRunInputSchema,
   output: WorkflowJsonValueSchema.optional(),
   toolCall: WorkflowToolCallSchema,
@@ -321,7 +321,7 @@ async function executePreparedWorkflowTool(input: {
   } catch (error) {
     return WorkflowToolStepResultSchema.parse({
       durationMs: Date.now() - startedAt,
-      error: agentToolErrorText(error),
+      error: agentToolErrorOutput(error),
       input: input.input,
       toolCall: input.toolCall,
     });

--- a/apps/agent-worker/src/durable-objects/agent-run-workflow.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-workflow.ts
@@ -543,7 +543,7 @@ function toolResultMessage(results: WorkflowToolStepResult[]): ModelMessage {
 }
 
 function toolModelOutput(result: WorkflowToolStepResult): ToolResultPart["output"] {
-  if (result.error) return { type: "error-text", value: result.error };
+  if (result.error) return { type: "error-json", value: result.error };
   if (typeof result.output === "string") return { type: "text", value: result.output };
   return { type: "json", value: JsonValueSchema.parse(result.output ?? null) };
 }

--- a/apps/gateway-worker/package.json
+++ b/apps/gateway-worker/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "wrangler deploy --dry-run",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/auth": "workspace:*",

--- a/apps/preview-proxy/package.json
+++ b/apps/preview-proxy/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "wrangler deploy --dry-run",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/auth": "workspace:*",

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -81,7 +81,9 @@ The composer keeps three independent product concepts separate:
 - `ComposerWorkIntentId` describes what the user wants to accomplish. Web app,
   mobile app, slides, research, data, documents, and media are discoverable
   composer choices. These choices guide prompt context; they are not all project
-  modes.
+  modes. The generic Slides choice activates the general PPTX workflow, never the
+  fundraising-specific pitch-deck skill. Explicit PPTX and pitch-deck skill deep
+  links both select the Slides intent while preserving the skill the user chose.
 - `AppBuildTarget` is only the runtime topology for generated applications:
   `web` or `mobile`. It maps to `app-builder` or `app-builder-mobile`; every
   non-app work intent remains a `general` project and can still create typed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "build": "next build",
     "dev": "next dev --webpack",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@ai-sdk/react": "catalog:",

--- a/apps/web/src/components/home/home-composer-intents.ts
+++ b/apps/web/src/components/home/home-composer-intents.ts
@@ -37,7 +37,7 @@ export const COMPOSER_WORK_INTENTS: readonly ComposerWorkIntent[] = [
     id: "slides",
     label: "Slides",
     placeholder: "What's the deck about? Audience and key points help",
-    skill: "pitch-deck",
+    skill: "pptx",
   },
   {
     appBuildTarget: null,

--- a/apps/web/src/components/home/use-initial-skill.ts
+++ b/apps/web/src/components/home/use-initial-skill.ts
@@ -15,6 +15,7 @@ const SKILL_TO_INTENT: Record<string, SkillIntent> = {
   "generate-media": "media",
   pdf: "documents",
   "pitch-deck": "slides",
+  pptx: "slides",
 };
 
 // Skills that imply an app runtime target without becoming a durable project mode themselves.
@@ -25,7 +26,7 @@ const SKILL_TO_APP_BUILD_TARGET: Record<string, AppBuildTarget> = {
 export interface InitialSkillResolution {
   /** The selected skill chip shown in the composer. */
   chip: string | null;
-  /** Intent pill to pre-activate (pitch-deck/deep-research/csv-analyst). */
+  /** Intent pill represented by the selected bundled skill. */
   intent: SkillIntent | null;
 }
 

--- a/apps/webhooks-worker/package.json
+++ b/apps/webhooks-worker/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "wrangler deploy --dry-run",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/auth": "workspace:*",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "catalog:",

--- a/packages/agent-core/src/mastra/system-prompt.ts
+++ b/packages/agent-core/src/mastra/system-prompt.ts
@@ -163,7 +163,7 @@ const CORE_INSTRUCTIONS = [
 
 A Linux sandbox is available when the task genuinely needs it. Ordinary conversation, answers, lookups, browser-only work, and throwaway calculations do not need a project. A project is attached lazily when you first choose a workspace-backed file, document, or chart tool; do not call one merely to create a project. A shell command with no cwd is projectless and is only for browser/skill CLIs or environment inspection. When a shell command reads, creates, or changes persistent project files, set its cwd to \`/workspace\`; that explicit intent attaches the project and maps \`/workspace\` to its persistent folder. Never use shell_terminal for browser or skill CLI commands; use projectless shell_exec argv calls, then fall back to the native browser tools if a browser CLI is unavailable. Browser tools use the sandbox without attaching a project unless the requested outcome also needs persistent files. Once a project is attached, its folder under /workspace is persistent across turns. The sandbox already has:
 - Node.js 24 (node, pnpm) and Python 3 (python3, pip3) — use pnpm for JavaScript dependencies and install anything else you need from the shell.
-- LibreOffice (headless) plus preinstalled Node libraries for deliverables: pptxgenjs (slides), docx, exceljs, @react-pdf/renderer, recharts, arquero.
+- LibreOffice (headless) plus preinstalled Node libraries for deliverables: pptxgenjs (slides), docx, exceljs, @react-pdf/renderer, and recharts.
 - A headed Chromium browser you drive to test what you build and to browse the web.
 - A dev server you expose with code_start_dev_server. Request port 5173 normally; the tool restores missing pnpm dependencies, binds the project to its allocated host/port, and reuses an identical healthy server. Do not run pnpm install merely to start an unchanged app. Never launch a user-facing app with shell_exec, shell_terminal, or shell_start_process because those processes are not registered as the project preview and cannot recover after sandbox idle stops.
 Use the computer when the requested outcome needs it. Do the work there instead of describing work you could just do, and never claim you did something you didn't run.`,
@@ -188,6 +188,7 @@ Match the depth of your work to the request. A quick question ("what's the total
   `## Tools
 
 Speak in plain language, never tool names — say "I'll install the dependencies", not "I'll run shell_exec".
+- Tool failures include a \`retriable\` field. When it is false, do not repeat the same operation or describe it as transient; follow its hint when possible, then explain the blocking condition once. When it is true, retry at most once unless new evidence justifies a different operation.
 - Files & code: fs_apply for focused or multi-section changes to existing text files and fs_write only for new files, binary files, or a genuinely intentional whole-file rewrite under /workspace (fs_read / fs_list / fs_search to inspect). If fs_apply reports an infrastructure or stale-file error, re-read and retry it; never bypass that error by sending the existing file through fs_write. Use the shell (shell_exec, argv form) to install packages, run builds, and execute scripts. Reach for code_run only for a tiny throwaway calculation — inline, no packages, no saved files — so it is never how you build a project.
 - Finished files: document, chart, research, and media generators publish their own final output. When you create a requested output file with fs_write or the shell instead, verify it and call deliverable_publish exactly once for that finished file. A workspace file is not a user Deliverable until that call succeeds; never claim an unpublished file is ready to download.
 - A token like \`/uploads/report.pdf\` or \`/deliverables/<output-id>/report.pdf\` in a user message is a project-file reference. Resolve it beneath the project workspace named above and inspect it with the appropriate file or shell tools before acting. Referenced deliverables are restored to that exact path before your turn starts.
@@ -222,7 +223,7 @@ This project is scaffolded at the workspace root and its dev server + live previ
 
 const DOCS_MODULE = `## Building documents & slides
 
-Build decks and docs from scratch with the preinstalled libraries — pptxgenjs for .pptx, docx, @react-pdf/renderer, exceljs — when you want full control and visual QA, or use docs_generate_slides / docs_generate_docx / docs_generate_pdf / docs_generate_xlsx for a fast structured deliverable. Either way, verify by looking: convert to PDF and render each page to an image, check every page for faint text, overflow, and placeholder text, fix and re-render, then scan for anything unfilled. The file lands in the Deliverables automatically — refer to it naturally ("your deck is ready below"), don't paste a download link.`;
+Build decks and docs from scratch with the preinstalled libraries — pptxgenjs for .pptx, docx, @react-pdf/renderer, exceljs — when the request needs custom layout control, or use docs_generate_slides / docs_generate_docx / docs_generate_pdf / docs_generate_xlsx for a fast structured deliverable. Preserve exact requested counts and scope. Verify proportionately: for a structured generated deck or document, confirm the returned page or slide count and inspect one representative render; inspect every page when the user requests full visual QA, the layout is custom or high-stakes, or the representative check reveals a defect. Check for faint text, overflow, placeholder text, and unfilled sections; fix and re-render only affected pages. The file lands in the Deliverables automatically — refer to it naturally ("your deck is ready below"), don't paste a download link.`;
 
 const DATA_MODULE = `## Data & analysis
 
@@ -241,7 +242,7 @@ const GENERALIST_MODULE = `## Choosing your approach
 
 Pick the path that fits and load the matching skill (skill_invoke) for its full playbook:
 - Web or mobile app → build it in the sandbox (React / Next.js, or Expo for mobile), start the dev server, and verify it in the browser; the running app shows in the Computer panel.
-- Slides or documents → build with pptxgenjs / docx / @react-pdf / exceljs (or docs_generate_*), then render and eyeball every page; the file lands in the Deliverables.
+- Slides or documents → use the fast structured generator when it fits, or the document libraries for custom control; preserve exact counts and verify proportionately before finishing. The file lands in the Deliverables.
 - Data → profile it (data_analyze_csv, or pandas / Node) and chart it (data_chart) when it adds insight; verify the numbers.
 - Image or video → load generate-media, then use generate_or_edit_media; the asset lands in the project and Deliverables.
 - Research → gather and cross-check real sources (search_web / firecrawl_* / research_deep); cite everything, and use the deep-research workflow when the user asks for a report so its PDF is delivered automatically.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/observability": "workspace:*",

--- a/packages/billing/package.json
+++ b/packages/billing/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/durable-storage": "workspace:*",

--- a/packages/byok/package.json
+++ b/packages/byok/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/db": "workspace:*",

--- a/packages/composio/package.json
+++ b/packages/composio/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/observability": "workspace:*",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -20,7 +20,7 @@
     "build": "tsc -p tsconfig.json",
     "db:generate": "drizzle-kit generate",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/env": "workspace:*",

--- a/packages/durable-storage/package.json
+++ b/packages/durable-storage/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "devDependencies": {
     "@cheatcode/tsconfig": "workspace:*",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@t3-oss/env-nextjs": "catalog:",

--- a/packages/morph/package.json
+++ b/packages/morph/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/observability": "workspace:*",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/types": "workspace:*"

--- a/packages/preview-bridge/package.json
+++ b/packages/preview-bridge/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "devDependencies": {
     "@cheatcode/tsconfig": "workspace:*",

--- a/packages/sandbox-contracts/package.json
+++ b/packages/sandbox-contracts/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "@cheatcode/types": "workspace:*",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -20,7 +20,7 @@
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
     "skills:build": "tsx ../../scripts/build-skills.ts",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "devDependencies": {
     "@cheatcode/tsconfig": "workspace:*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "lint": "biome check .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit --incremental false"
   },
   "dependencies": {
     "ai": "catalog:",

--- a/skills/pptx/SKILL.md
+++ b/skills/pptx/SKILL.md
@@ -9,7 +9,8 @@ compatibility: Requires the snapshot-bundled Python Office scripts, OOXML schema
 
 # PPTX Skill
 
-Before using this skill, always install the required dependencies first or verify they are already installed.
+The presentation runtime and its document dependencies are preinstalled. Do not install or upgrade
+packages unless an actual missing-dependency error proves the runtime is incomplete.
 
 ## Quick Reference
 
@@ -18,6 +19,18 @@ Before using this skill, always install the required dependencies first or verif
 | Read/analyze content | `python -m markitdown presentation.pptx` |
 | Edit or create from template | Read [editing.md](editing.md) |
 | Create from scratch | Read [pptxgenjs.md](pptxgenjs.md) |
+
+## Choose the Right Production Path
+
+- For a concise presentation with ordinary text, callouts, and simple structure, use
+  `docs_generate_slides`. Preserve the user's exact requested slide count. Its returned
+  `slideCount` is the authoritative structural check.
+- For a custom visual system, complex diagrams, a supplied template, or detailed layout control,
+  use the sandbox workflow described below.
+- Do not add research, extra sections, speaker notes, or a title slide unless the user asks for
+  them or they are necessary to satisfy the stated outcome.
+- Do not convert a general presentation into an investor pitch. Load the `pitch-deck` skill only
+  when the user explicitly asks for a fundraising, investor, seed, or demo-day deck.
 
 ---
 
@@ -143,11 +156,19 @@ Choose colors that match your topic — don't default to generic blue. Use these
 
 ---
 
-## QA (Required)
+## QA
 
-**Assume there are problems. Your job is to find them.**
+Match verification effort to how the deck was made and the risk of the request.
 
-Your first render is almost never correct. Approach QA as a bug hunt, not a confirmation step. If you found zero issues on first inspection, you weren't looking hard enough.
+- For `docs_generate_slides`, confirm its returned `slideCount`, convert the deck to PDF, and render
+  one representative slide. If the count is exact and that render has no clipping, overlap,
+  placeholder text, or contrast problem, finish.
+- Inspect every slide when the deck uses custom or template-driven layout, is high-stakes, the user
+  asks for exhaustive visual QA, or the representative render reveals a defect.
+- After a defect is fixed, re-render only the affected slide unless the change alters a shared
+  theme or layout.
+- A clean first inspection is a valid pass. Never invent a defect or perform a cosmetic rewrite
+  solely to create a fix-and-verify cycle.
 
 ### Content QA
 
@@ -166,8 +187,6 @@ python -m markitdown output.pptx | grep -iE "xxxx|lorem|ipsum|this.*(page|slide)
 If grep returns results, fix them before declaring success.
 
 ### Visual QA
-
-**⚠️ USE SUBAGENTS** — even for 2-3 slides. You've been staring at the code and will see what you expect, not what's there. Subagents have fresh eyes.
 
 Convert slides to images (see [Converting to Images](#converting-to-images)), then use this prompt:
 
@@ -188,7 +207,7 @@ Look for:
 - Text boxes too narrow causing excessive wrapping
 - Leftover placeholder content
 
-For each slide, list issues or areas of concern, even if minor.
+Report concrete issues only. A slide that passes does not need a fabricated concern.
 
 Read and analyze these images:
 1. /path/to/slide-01.jpg (Expected: [brief description])
@@ -200,12 +219,9 @@ Report ALL issues found, including minor ones.
 ### Verification Loop
 
 1. Generate slides → Convert to images → Inspect
-2. **List issues found** (if none found, look again more critically)
-3. Fix issues
-4. **Re-verify affected slides** — one fix often creates another problem
-5. Repeat until a full pass reveals no new issues
-
-**Do not declare success until you've completed at least one fix-and-verify cycle.**
+2. If there are concrete issues, list and fix them
+3. Re-verify affected slides
+4. Finish when the required structural and visual checks pass
 
 ---
 


### PR DESCRIPTION
## Why

Natural production QA found that the generic Slides surface injected the fundraising-only pitch-deck workflow. A three-slide status deck therefore performed investor-deck work and exhaustive per-slide verification. The same QA also showed non-retryable project-plan failures being retried because the model-facing tool result discarded retry policy.

The forced gate then exposed a TypeScript build-state collision: no-emit typechecks and emitting builds shared one incremental file, allowing stale JavaScript to survive a source change.

## What changed

- route the generic Slides surface to the general PPTX workflow while keeping explicit pitch-deck selection intact
- make presentation generation preserve exact requested counts and scale visual QA to the generation path and risk
- return structured model-facing tool errors with code, hint, bounded diagnostics, and retriable policy
- tell the agent to stop repeated operations after non-retryable failures
- isolate all package no-emit typechecks from emitting TypeScript incremental state
- remove the obsolete Arquero runtime claim

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (passes with four existing Knip configuration hints)
- `pnpm architecture:check`
- `pnpm turbo skills:build --force`
- `git diff --check`
- direct model-error projection probe for plan-limit and sandbox-timeout errors
- agent Worker Wrangler dry-run after rebuilding agent-core output

Production browser acceptance will run against the exact merged deployment.