### PR TITLE
fix: keep file workflows on Files

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -36,9 +36,10 @@ persistent project-file browser and merges durable uploads with generated Delive
 Deliverable inserts its stable `/deliverables/<output-id>/<filename>` project reference;
 `@` is exclusively the user-skill picker. The file browser reads durable project-file metadata and
 does not create or wake Daytona merely because the user opens it.
-Computer preview wakeups rotate the preview session and reload the visible iframe
-once after an actual sandbox/process recovery. Silent capability rotation keeps the
-live iframe mounted so application state is preserved during ordinary use.
+Computer preview wakeups run only while Browser is selected; opening Files never revives an
+unrelated dev server or changes the selected surface. Browser wakeups rotate the preview session
+and reload the visible iframe once after an actual sandbox/process recovery. Silent capability
+rotation keeps the live iframe mounted so application state is preserved during ordinary use.
 Every user-requested preview navigation—reload, path entry, Back, or opening the
 preview externally—first acquires a fresh one-minute handoff from the authenticated
 wake boundary. The action proceeds only after renewal, so the client never reuses

--- a/apps/web/src/components/preview/preview-side-panel.tsx
+++ b/apps/web/src/components/preview/preview-side-panel.tsx
@@ -72,15 +72,18 @@ function usePreviewPanelController(
   const isMobile = project?.mode === "app-builder-mobile" || store.expoUrl !== null;
   const isRunActive = activeRunId !== null;
   const isFreshPreviewBuilding = store.appPreviewStatus === "building" && isRunActive;
-  // The authenticated wake endpoint is the only source of preview capabilities. Opening any
-  // project Computer panel asks it for a fresh handoff; projects without a dev server fall back to
-  // Files. Fresh scaffolds wait until generated content is ready so their one-minute handoff is
-  // minted immediately before the iframe mounts. Daytona idle-stops are revived through the same
-  // path.
+  // The authenticated wake endpoint is the only source of preview capabilities. Only an active
+  // Browser surface asks it for a fresh handoff; opening Files must never revive an unrelated dev
+  // server or race the artifact-driven tab selection. Fresh scaffolds wait until generated content
+  // is ready so their one-minute handoff is minted immediately before the iframe mounts. Daytona
+  // idle-stops are revived through the same path.
   const previewLive = useEnsurePreviewLive(
     threadId,
     getToken,
-    store.previewPanelOpen && project !== null && !isFreshPreviewBuilding,
+    store.previewPanelOpen &&
+      store.activeComputerTab === "browser" &&
+      project !== null &&
+      !isFreshPreviewBuilding,
     store.sandboxStatus,
   );
   useRequestedPreviewReload(store.previewReloadRequestToken, previewLive.reload);

--- a/apps/web/src/components/preview/use-ensure-preview-live.ts
+++ b/apps/web/src/components/preview/use-ensure-preview-live.ts
@@ -59,8 +59,9 @@ type PreviewRefreshMode = "authorize" | "recover" | "reload" | "rotate";
  * drives the panel's "Starting preview…" loading state.
  *
  * The authenticated wake response is the only source of preview capabilities. `active` should be
- * true while a project Computer panel is open, including before a URL has been acquired. A project
- * without a tracked dev server is switched to Files without retaining a stale capability.
+ * true only while a project's Browser surface is visible, including before a URL has been
+ * acquired. Files never wakes a preview. A Browser surface without a tracked dev server is
+ * switched to Files without retaining a stale capability.
  */
 export function useEnsurePreviewLive(
   threadId: string | null,
@@ -358,12 +359,8 @@ function applyPreviewRefreshResult(
   setPhase: (phase: PreviewLivePhase) => void,
 ): number {
   if (result.url) {
-    const shouldActivateApp = useAppStore.getState().previewUrl === null;
     deps.setPreviewUrl(result.url);
     deps.setExpoUrl(result.expoUrl ?? null);
-    if (shouldActivateApp) {
-      deps.setActiveComputerTab("browser");
-    }
   } else {
     deps.setPreviewUrl(null);
     deps.setExpoUrl(null);


### PR DESCRIPTION
## Summary

- Prevent Files from starting preview lifecycle work.
- Keep artifact-driven workflows on Files even when the project has an old tracked dev server.
- Preserve Browser wake and recovery when Browser is explicitly selected.

## Architecture

Surface selection remains owned by stream activity and user intent. Preview lifecycle now consumes that state instead of mutating it when a capability happens to exist.

## Decisions Made

| Decision | Choice | Reasoning |
|---|---|---|
| Preview activation | Run only while Browser is visible | Files should not wake Daytona or race artifact routing.
| Successful wake | Do not select Browser | A capability is transport state, not UI intent.
| Missing preview | Fall back to Files | Browser has nothing valid to display.

## Edge Cases Handled

- General projects with stale dev-server records stay on Files after creating documents, slides, data, research, or media.
- Explicit Browser selection still wakes stopped sandboxes and rotates preview capabilities.
- Browser projects without a tracked server still fall back to Files.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (four existing configuration hints only)
- `pnpm architecture:check`
- `pnpm turbo skills:build --force`
- `git diff --check`
- Production baseline: natural Slides request completed with one tool and generated `weekly-team-update.pptx`; reproduced the stale preview wake overriding Files before this fix.

## Production acceptance after merge

- Reopen the visible Slides chat and verify Computer remains on Files.
- Select Browser explicitly and verify preview wake still works.
- Run a natural Research request and verify its report opens in Files.