### PR TITLE
fix(agent): terminalize research workflows

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -114,10 +114,12 @@ The Worker pins Cloudflare's paid-plan maximum subrequest allowance because exte
 Daytona, Hyperdrive, R2, and Durable Object requests share one Workflow-instance budget. That
 platform transport budget must accommodate the configured 25,000 durable steps rather than become
 an earlier, workload-dependent product limit.
-Successful deep-research tools are terminal response producers: the Workflow suppresses the model's
-pre-tool narration, publishes the tool's validated canonical Markdown directly as the assistant text,
-and completes without asking a second model turn to copy or summarize it. The same Markdown is the
-input to the PDF renderer, so chat and deliverable content cannot diverge by model behavior.
+Deep-research tools are terminal response producers. On success, the Workflow suppresses the
+model's pre-tool narration, publishes the tool's validated canonical Markdown directly as the
+assistant text, and completes without asking a second model turn to copy or summarize it. A failed
+research tool also ends that semantic run with its structured error instead of allowing the model
+to repeat an expensive, non-idempotent workflow or substitute workspace probing. The same Markdown
+is the input to the PDF renderer, so chat and deliverable content cannot diverge by model behavior.
 
 The run-keyed Durable Object is the authoritative status, cancellation, transcript, and stream
 store. It validates every Workflow callback against the stored input hash and deterministic

--- a/apps/agent-worker/src/durable-objects/agent-run-workflow.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-workflow.ts
@@ -224,9 +224,7 @@ async function runAgentLoop(
       ...state,
       messages: [...state.messages, workflowJsonValue(toolResultMessage(toolTurn.results))],
     });
-    if (toolTurn.results.some((result) => canonicalResearchReport(result) !== undefined)) {
-      return;
-    }
+    if (researchToolTurnIsTerminal(toolTurn.results)) return;
     if (
       state.input.runIntent === "skill-creator" &&
       toolTurn.results.some(
@@ -237,6 +235,31 @@ async function runAgentLoop(
       return;
     }
   }
+}
+
+function researchToolTurnIsTerminal(results: WorkflowToolStepResult[]): boolean {
+  const result = results.find((candidate) => isResearchReportTool(candidate.toolCall.toolName));
+  if (!result) return false;
+  if (canonicalResearchReport(result) !== undefined) return true;
+  throw terminalResearchToolError(result);
+}
+
+function terminalResearchToolError(result: WorkflowToolStepResult): APIError {
+  const error = result.error;
+  if (!error) {
+    return new APIError(502, "tool_execution_failed", "Research did not produce a report.", {
+      retriable: true,
+    });
+  }
+  return new APIError(
+    error.code === "permission_plan_required" ? 403 : 502,
+    error.code,
+    error.message,
+    {
+      ...(error.hint ? { hint: error.hint } : {}),
+      retriable: error.retriable,
+    },
+  );
 }
 
 function continueTruncatedModelTurn(state: WorkflowAgentState): WorkflowAgentState {

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -111,14 +111,14 @@ one-to-one relationship between inline citations and the final Sources list. It 
 operational timeout and one in-memory retry for transient provider or invalid Markdown
 failures; request cancellation always wins and no secret-bearing state is snapshotted.
 Prose URL scraping is not an accepted provenance boundary.
-Successful top-level deep-research and fan-out tools render the validated report's
+Top-level deep-research and fan-out tools resolve their project workspace before
+making provider calls, so plan or project-capacity failures cannot consume a research run.
+Successful tools render the validated report's
 canonical GitHub-flavored Markdown directly into a PDF artifact. The chat response
 and PDF therefore preserve the same headings, prose, lists, tables, links, citations,
 and ordering; only print-safe pagination and document chrome differ. Multi-line list
 rows retain their intrinsic height so consecutive Markdown items cannot overlap in
-the rendered document. The project
-workspace is resolved only after remote research succeeds;
-the PDF is then stored both in the live project files and the durable
+the rendered document. The PDF is stored both in the live project files and the durable
 generated-output store. Sandbox renderers write binary output to a bounded staging
 file and delimit only its small metadata object with an internal stdout marker. The
 host validates that path, reads the bytes through the sandbox file boundary, uploads

--- a/packages/agent-core/src/mastra/tool-defs/research-tools.ts
+++ b/packages/agent-core/src/mastra/tool-defs/research-tools.ts
@@ -260,12 +260,13 @@ export const mastraDeepResearch = createTool({
   outputSchema: ResearchReportArtifactSchema,
   execute: async (input, context) => {
     const parsedInput = DeepResearchInputSchema.parse(input);
+    const workspaceRuntime = await workspaceRuntimeFromContext(context);
     const report = await runResearchWorkflow({
       context,
       inputData: parsedInput,
       workflowName: "deepResearch",
     });
-    return createResearchReportArtifact(report, parsedInput.topic, context);
+    return createResearchReportArtifact(report, parsedInput.topic, context, workspaceRuntime);
   },
 });
 
@@ -277,12 +278,13 @@ export const mastraResearchFanout = createTool({
   outputSchema: ResearchReportArtifactSchema,
   execute: async (input, context) => {
     const parsedInput = DeepResearchFanoutInputSchema.parse(input);
+    const workspaceRuntime = await workspaceRuntimeFromContext(context);
     const report = await runResearchWorkflow({
       context,
       inputData: parsedInput,
       workflowName: "deepResearchFanout",
     });
-    return createResearchReportArtifact(report, parsedInput.goal, context);
+    return createResearchReportArtifact(report, parsedInput.goal, context, workspaceRuntime);
   },
 });
 
@@ -290,11 +292,12 @@ async function createResearchReportArtifact(
   report: ResearchReport,
   topic: string,
   context: ToolExecutionContext,
+  workspaceRuntime: Awaited<ReturnType<typeof workspaceRuntimeFromContext>>,
 ) {
   context.abortSignal?.throwIfAborted();
   const artifact = await executeGenerateMarkdownPdf(
     buildResearchMarkdownPdfInput(report.report, topic),
-    await workspaceRuntimeFromContext(context),
+    workspaceRuntime,
   );
   return ResearchReportArtifactSchema.parse({ artifact, report: report.report });
 }


### PR DESCRIPTION
## Summary
- Resolve the project workspace before any remote research provider work, so project-capacity failures are immediate and free.
- Treat research tools as terminal response producers on both success and structured failure.
- Prevent models from retrying failed research workflows or probing the workspace after a non-retriable error.

## Architecture
The research tool now acquires its request-scoped workspace runtime before Exa, Firecrawl, or synthesis work. The Cloudflare Workflow owner inspects the first research result: successful canonical Markdown completes the run; a structured failure is rethrown with its stable code, message, hint, and retry policy so the run fails once.

## Decisions Made
| Decision | Choice | Reasoning |
|---|---|---|
| Capacity ordering | Workspace before providers | Admission failures must not consume paid provider work. |
| Terminal behavior | Workflow-owned, not prompt-owned | Durable control flow must enforce exactly-once semantics across model turns. |
| Failure fidelity | Preserve structured tool error | The UI and Continue behavior need the original error code and retry policy. |

## Edge Cases Handled
| Scenario | Handling |
|---|---|
| Project limit reached | Fails before research provider calls. |
| Research provider or rendering failure | Ends the run once with the structured error. |
| Successful report | Publishes canonical Markdown and matching PDF, then completes without another model turn. |

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build --force`
- `git diff --check`
- Production failure traced through the retained Cloudflare Workflow instance; repeated calls all reported `permission_plan_required` / `Active project limit reached`.