### PR TITLE
fix(agent): canonicalize research report failures

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -93,7 +93,8 @@ and explicit retry policy. Sandbox failures may also include bounded command out
 managed-process logs. The next model turn can therefore correct a retriable failure once while
 treating plan, permission, validation, and other non-retriable failures as terminal for that
 operation instead of looping. Those internal diagnostics are not promoted into user-facing
-assistant text.
+assistant text. Repository-owned API errors retain that classification even after Mastra wraps or
+serializes a nested workflow failure; unknown thrown values still collapse to the generic tool error.
 Tool steps resolve only the credentials required by the invoked capability: ordinary data, file,
 code, and document work does not open research-key or connected-app database transactions. User
 skill packages are restored lazily when a skill is invoked instead of being projected into the

--- a/apps/agent-worker/src/durable-objects/agent-run-tool-error-support.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-tool-error-support.ts
@@ -1,4 +1,4 @@
-import { APIError } from "@cheatcode/observability";
+import { findAPIError } from "@cheatcode/observability";
 import { ErrorCodeSchema } from "@cheatcode/types";
 import { z } from "zod";
 
@@ -22,7 +22,8 @@ export type AgentToolErrorOutput = z.infer<typeof AgentToolErrorOutputSchema>;
 
 /** Preserves retry policy and bounded, user-scoped diagnostics for the model's next turn. */
 export function agentToolErrorOutput(error: unknown): AgentToolErrorOutput {
-  if (!(error instanceof APIError)) {
+  const apiError = findAPIError(error);
+  if (!apiError) {
     return AgentToolErrorOutputSchema.parse({
       code: "tool_execution_failed",
       message: clamp(
@@ -32,15 +33,15 @@ export function agentToolErrorOutput(error: unknown): AgentToolErrorOutput {
       retriable: false,
     });
   }
-  const diagnostics = SANDBOX_DIAGNOSTIC_CODES.has(error.code)
-    ? sandboxDiagnosticLines(error.opts.details).join("\n")
+  const diagnostics = SANDBOX_DIAGNOSTIC_CODES.has(apiError.code)
+    ? sandboxDiagnosticLines(apiError.opts.details).join("\n")
     : "";
   return AgentToolErrorOutputSchema.parse({
-    code: error.code,
+    code: apiError.code,
     ...(diagnostics ? { diagnostics: clamp(diagnostics, MAX_TOOL_ERROR_CHARACTERS) } : {}),
-    ...(error.opts.hint ? { hint: clamp(error.opts.hint, MAX_TOOL_ERROR_CHARACTERS) } : {}),
-    message: clamp(error.message, MAX_TOOL_ERROR_CHARACTERS),
-    retriable: error.retriable,
+    ...(apiError.opts.hint ? { hint: clamp(apiError.opts.hint, MAX_TOOL_ERROR_CHARACTERS) } : {}),
+    message: clamp(apiError.message, MAX_TOOL_ERROR_CHARACTERS),
+    retriable: apiError.retriable,
   });
 }
 

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -106,8 +106,10 @@ Firecrawl extraction of its primary result. Provider-owned IDs, URLs, excerpts, 
 the durable claim map are assembled deterministically instead of asking a model to
 reproduce citation identifiers. The sole tool-free model call writes only the canonical
 Markdown report from those byte-bounded evidence packs. Before publication, the workflow
-rejects truncated generations and validates the heading structure, citation URLs, and the
-one-to-one relationship between inline citations and the final Sources list. It has an
+rejects truncated generations and validates the heading structure and citation URLs. It
+then deterministically replaces the model-authored Sources tail with one canonical list
+derived from the validated inline citations, avoiding a second probabilistic generation
+for presentation-only list differences while preserving the evidence boundary. It has an
 operational timeout and one in-memory retry for transient provider or invalid Markdown
 failures; request cancellation always wins and no secret-bearing state is snapshotted.
 Prose URL scraping is not an accepted provenance boundary.

--- a/packages/agent-core/src/mastra/tool-defs/research-tools.ts
+++ b/packages/agent-core/src/mastra/tool-defs/research-tools.ts
@@ -1,3 +1,4 @@
+import { APIError, findAPIError } from "@cheatcode/observability";
 import { createTool, type ToolExecutionContext } from "@mastra/core/tools";
 import { z } from "zod/v4";
 import { executeGenerateMarkdownPdf } from "../../tools/docs/execute";
@@ -93,9 +94,14 @@ async function runResearchWorkflow({
     await cancellation.assertNotCanceled();
     const result = WorkflowResultSchema.parse(workflowResult);
     if (result.status !== "success" || !result.result) {
-      const message =
-        result.error instanceof Error ? result.error.message : `${workflowName} workflow failed.`;
-      throw new Error(message);
+      const workflowError = findAPIError(result.error);
+      if (workflowError) {
+        throw workflowError;
+      }
+      throw new APIError(502, "upstream_provider_outage", "Research workflow failed", {
+        cause: result.error,
+        retriable: true,
+      });
     }
     return ResearchReportSchema.parse(result.result);
   } finally {

--- a/packages/agent-core/src/mastra/workflows/research-markdown.ts
+++ b/packages/agent-core/src/mastra/workflows/research-markdown.ts
@@ -1,4 +1,4 @@
-import { APIError } from "@cheatcode/observability";
+import { APIError, createLogger } from "@cheatcode/observability";
 import { lexer, type Token, type Tokens } from "marked";
 import { z } from "zod/v4";
 import type { ResearchSource } from "./research-schemas";
@@ -12,19 +12,17 @@ interface ParseResearchMarkdownOptions {
   value: unknown;
 }
 
-/** Validates the complete, evidence-bound Markdown contract before artifact publication. */
+/** Validates evidence-bound prose and deterministically canonicalizes its Sources section. */
 export function parseResearchMarkdown(options: ParseResearchMarkdownOptions): string {
   if (options.finishReason && REJECTED_FINISH_REASONS.has(options.finishReason)) {
-    throw invalidResearchMarkdown();
+    throw invalidResearchMarkdown("incomplete_generation");
   }
   const parsed = ResearchMarkdownSchema.safeParse(options.value);
   if (!parsed.success) {
-    throw invalidResearchMarkdown();
+    throw invalidResearchMarkdown("document_shape");
   }
   const tokens = lexer(parsed.data, { gfm: true });
-  validateHeadingStructure(tokens);
-  validateCitationStructure(tokens, options.sources);
-  return parsed.data;
+  return canonicalizeCitationStructure(tokens, options.sources);
 }
 
 function validateHeadingStructure(tokens: Token[]): void {
@@ -34,43 +32,40 @@ function validateHeadingStructure(tokens: Token[]): void {
     (token) => isHeadingToken(token) && token.depth === 1,
   );
   if (!first || !isHeadingToken(first) || first.depth !== 1 || levelOneHeadings.length !== 1) {
-    throw invalidResearchMarkdown();
+    throw invalidResearchMarkdown("heading_structure");
   }
 }
 
-function validateCitationStructure(tokens: Token[], sources: ResearchSource[]): void {
-  const sourceHeadingIndexes = tokens.flatMap((token, index) =>
-    isHeadingToken(token) && token.depth === 2 && token.text.trim().toLowerCase() === "sources"
-      ? [index]
-      : [],
+function canonicalizeCitationStructure(tokens: Token[], sources: ResearchSource[]): string {
+  const sourceHeadingIndex = tokens.findIndex(
+    (token) =>
+      isHeadingToken(token) && token.depth === 2 && token.text.trim().toLowerCase() === "sources",
   );
-  if (sourceHeadingIndexes.length !== 1) {
-    throw invalidResearchMarkdown();
+  const bodyTokens = sourceHeadingIndex < 0 ? tokens : tokens.slice(0, sourceHeadingIndex);
+  validateHeadingStructure(bodyTokens);
+  if (containsUnparsedMarkdownLink(bodyTokens)) {
+    throw invalidResearchMarkdown("malformed_link");
   }
-  const sourceHeadingIndex = sourceHeadingIndexes[0];
-  if (sourceHeadingIndex === undefined) {
-    throw invalidResearchMarkdown();
+  const allowedSources = new Map(
+    sources.map((source) => [canonicalHttpUrl(source.url), source] as const),
+  );
+  const citedUrls = validateAllowedLinks(bodyTokens, new Set(allowedSources.keys()));
+  if (citedUrls.size === 0) {
+    throw invalidResearchMarkdown("missing_inline_citation");
   }
-  const sourceBlocks = tokens
-    .slice(sourceHeadingIndex + 1)
-    .filter((token) => token.type !== "space");
-  const sourceList = sourceBlocks[0];
-  if (
-    sourceBlocks.length !== 1 ||
-    !isListToken(sourceList) ||
-    sourceList.ordered ||
-    sourceList.items.length === 0 ||
-    containsUnparsedMarkdownLink(tokens)
-  ) {
-    throw invalidResearchMarkdown();
-  }
-
-  const allowedUrls = new Set(sources.map((source) => canonicalHttpUrl(source.url)));
-  const bodyUrls = validateAllowedLinks(tokens.slice(0, sourceHeadingIndex), allowedUrls);
-  const listedUrls = validateSourceList(sourceList, allowedUrls);
-  if (bodyUrls.size === 0 || !setsEqual(bodyUrls, listedUrls)) {
-    throw invalidResearchMarkdown();
-  }
+  const body = bodyTokens
+    .map((token) => token.raw)
+    .join("")
+    .trimEnd();
+  const sourceList = [...citedUrls].map((url) => {
+    const source = allowedSources.get(url);
+    if (!source) {
+      throw invalidResearchMarkdown("uncollected_source");
+    }
+    const label = markdownLinkLabel(source.title ?? source.url);
+    return `- [${label}](<${source.url}>)`;
+  });
+  return `${body}\n\n## Sources\n\n${sourceList.join("\n")}`;
 }
 
 function validateAllowedLinks(tokens: Token[], allowedUrls: Set<string>): Set<string> {
@@ -78,23 +73,7 @@ function validateAllowedLinks(tokens: Token[], allowedUrls: Set<string>): Set<st
   for (const link of collectLinks(tokens)) {
     const url = canonicalHttpUrl(link.href);
     if (!allowedUrls.has(url)) {
-      throw invalidResearchMarkdown();
-    }
-    urls.add(url);
-  }
-  return urls;
-}
-
-function validateSourceList(sourceList: Tokens.List, allowedUrls: Set<string>): Set<string> {
-  const urls = new Set<string>();
-  for (const item of sourceList.items) {
-    const links = collectLinks(item.tokens);
-    if (links.length !== 1 || textOutsideLinks(item.tokens).trim()) {
-      throw invalidResearchMarkdown();
-    }
-    const url = canonicalHttpUrl(links[0]?.href);
-    if (!allowedUrls.has(url) || urls.has(url)) {
-      throw invalidResearchMarkdown();
+      throw invalidResearchMarkdown("uncollected_source");
     }
     urls.add(url);
   }
@@ -114,21 +93,6 @@ function collectLinks(tokens: Token[]): Tokens.Link[] {
     }
   }
   return links;
-}
-
-function textOutsideLinks(tokens: Token[]): string {
-  return tokens
-    .map((token) => {
-      if (token.type === "link" || token.type === "space") {
-        return "";
-      }
-      const children = childTokens(token);
-      if (children.length > 0) {
-        return textOutsideLinks(children);
-      }
-      return "text" in token && typeof token.text === "string" ? token.text : "";
-    })
-    .join("");
 }
 
 function containsUnparsedMarkdownLink(tokens: Token[]): boolean {
@@ -184,27 +148,47 @@ function canonicalHttpUrl(value: string | undefined): string {
   try {
     const url = new URL(value ?? "");
     if (url.protocol !== "http:" && url.protocol !== "https:") {
-      throw invalidResearchMarkdown();
+      throw invalidResearchMarkdown("invalid_url");
+    }
+    url.hash = "";
+    if (url.pathname.length > 1 && url.pathname.endsWith("/")) {
+      url.pathname = url.pathname.slice(0, -1);
     }
     return url.href;
   } catch (error) {
     if (error instanceof APIError) {
       throw error;
     }
-    throw invalidResearchMarkdown();
+    throw invalidResearchMarkdown("invalid_url");
   }
 }
 
-function setsEqual(left: Set<string>, right: Set<string>): boolean {
-  return left.size === right.size && [...left].every((value) => right.has(value));
+function markdownLinkLabel(value: string): string {
+  return value
+    .replace(/\s+/gu, " ")
+    .trim()
+    .replaceAll("\\", "\\\\")
+    .replaceAll("[", "\\[")
+    .replaceAll("]", "\\]");
 }
 
-function invalidResearchMarkdown(): APIError {
+type ResearchMarkdownValidationReason =
+  | "document_shape"
+  | "heading_structure"
+  | "incomplete_generation"
+  | "invalid_url"
+  | "malformed_link"
+  | "missing_inline_citation"
+  | "uncollected_source";
+
+function invalidResearchMarkdown(reason: ResearchMarkdownValidationReason): APIError {
+  createLogger().warn("research_markdown_validation_failed", { reason });
   return new APIError(
     502,
     "upstream_provider_outage",
     "Research synthesis returned invalid Markdown",
     {
+      details: { reason },
       retriable: true,
     },
   );

--- a/packages/observability/README.md
+++ b/packages/observability/README.md
@@ -24,6 +24,9 @@ positions.
 - `createLogger` and the `Logger` contract
 - `redactSecrets`
 - `APIError`
+- `findAPIError` and `toAPIError` recover repository-owned error codes, status,
+  retry policy, and bounded messages after framework wrapping or serialization;
+  unrecognized exceptions remain internal errors
 - `safeErrorTelemetry` for allowlisted error metadata (`name`, `code`,
   `constraint`, `status`, and `retriable`) without messages, stacks, SQL, or
   query parameters

--- a/packages/observability/src/errors.ts
+++ b/packages/observability/src/errors.ts
@@ -1,4 +1,4 @@
-import type { ErrorCode } from "@cheatcode/types";
+import { type ErrorCode, ErrorCodeSchema } from "@cheatcode/types";
 
 const RETRIABLE_CODES = new Set<ErrorCode>([
   "rate_limit_exceeded",
@@ -110,13 +110,70 @@ export function safeErrorTelemetry(error: unknown): SafeErrorTelemetry {
 }
 
 export function toAPIError(error: unknown): APIError {
-  if (error instanceof APIError) {
-    return error;
+  return (
+    findAPIError(error) ??
+    new APIError(500, "internal_service_error", "Internal error", {
+      hint: "Retry the request. If it persists, check Workers Logs with the request_id.",
+      retriable: true,
+    })
+  );
+}
+
+/** Recovers repository-owned API errors after framework serialization or wrapping. */
+export function findAPIError(error: unknown): APIError | undefined {
+  for (const candidate of errorChain(error)) {
+    if (candidate instanceof APIError) {
+      return candidate;
+    }
+    const reconstructed = serializedAPIError(candidate);
+    if (reconstructed) {
+      return reconstructed;
+    }
   }
-  return new APIError(500, "internal_service_error", "Internal error", {
-    hint: "Retry the request. If it persists, check Workers Logs with the request_id.",
-    retriable: true,
+  return undefined;
+}
+
+function serializedAPIError(record: Record<string, unknown>): APIError | undefined {
+  const code = ErrorCodeSchema.safeParse(readProperty(record, "code"));
+  const status = readStatus(record);
+  const message = boundedErrorText(readProperty(record, "message"), 8_000);
+  if (!code.success || status === undefined || message === undefined) {
+    return undefined;
+  }
+  const options = readRecord(record, "opts");
+  const retriable = readRetriable(record, options);
+  const hint = boundedErrorText(options ? readProperty(options, "hint") : undefined, 2_000);
+  return new APIError(status, code.data, message, {
+    cause: record,
+    ...(hint ? { hint } : {}),
+    ...(retriable === undefined ? {} : { retriable }),
   });
+}
+
+function errorChain(error: unknown): Record<string, unknown>[] {
+  if (!isRecord(error)) {
+    return [];
+  }
+  const chain: Record<string, unknown>[] = [];
+  const seen = new Set<object>();
+  let candidate: unknown = error;
+  while (isRecord(candidate) && chain.length <= MAX_CAUSE_DEPTH && !seen.has(candidate)) {
+    seen.add(candidate);
+    chain.push(candidate);
+    candidate = readProperty(candidate, "cause");
+  }
+  return chain;
+}
+
+function boundedErrorText(value: unknown, maximum: number): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > maximum || trimmed.includes("\0")) {
+    return undefined;
+  }
+  return trimmed;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -5,7 +5,7 @@ export {
   emitPerformanceMetric,
   emitUserEvent,
 } from "./analytics";
-export { APIError, safeErrorTelemetry, toAPIError } from "./errors";
+export { APIError, findAPIError, safeErrorTelemetry, toAPIError } from "./errors";
 export {
   readBoundedRequestBytes,
   readBoundedRequestText,


### PR DESCRIPTION
## Why

A clean production Research run made the intended single `research_deep` call, but a transient provider error followed by a cosmetically non-canonical Sources section caused the entire report to fail. Mastra serialized the nested workflow error, and the caller replaced the real domain failure with a generic message because it only recognized in-memory `Error` instances.

## What changed

- validate the evidence-bound report body and deterministically rebuild its final Sources list from validated inline citations
- preserve the exact resulting Markdown as the shared chat and PDF source
- recover repository-owned `APIError` classifications through bounded framework wrapping and serialization
- propagate nested Research workflow failures with their stable status, code, retry policy, and bounded message
- document the updated research and error-boundary contracts

## Architecture and data effects

- no database schema or migration changes
- no new environment variables or vendors
- generated artifact ownership and storage remain unchanged
- unknown thrown values still collapse to the generic internal/tool error boundary

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (configuration hints only)
- `pnpm architecture:check`
- `pnpm turbo skills:build --force`
- `git diff --check`
- exercised Markdown canonicalization with a malformed model-authored Sources tail
- exercised wrapped serialized API-error recovery with status, code, hint, and retry policy
- production Research replay will be completed after merge and exact-SHA deployment
