### PR TITLE
fix(agent): enforce research font contract

### DIFF
--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -106,7 +106,9 @@ Firecrawl extraction of its primary result. Provider-owned IDs, URLs, excerpts, 
 the durable claim map are assembled deterministically instead of asking a model to
 reproduce citation identifiers. The sole tool-free model call writes only the canonical
 Markdown report from those byte-bounded evidence packs. Before publication, the workflow
-rejects truncated generations and validates the heading structure and citation URLs. It
+rejects truncated generations, emoji presentation characters that the document font contract
+cannot preserve, and invalid heading or citation structure. The synthesis prompt requires the
+same plain-text contract, so a nonconforming model response is retried before publication. It
 then deterministically replaces the model-authored Sources tail with one canonical list
 derived from the validated inline citations, avoiding a second probabilistic generation
 for presentation-only list differences while preserving the evidence boundary. It has an

--- a/packages/agent-core/src/mastra/workflows/deep-research-workflow.ts
+++ b/packages/agent-core/src/mastra/workflows/deep-research-workflow.ts
@@ -274,6 +274,7 @@ function researchSynthesisPrompt(
     "Start with one level-one heading. The returned Markdown is displayed unchanged in chat and rendered unchanged into the PDF.",
     "Keep the report focused and complete within 1,200 words while retaining actionable findings and citations.",
     "Write report as polished GitHub-flavored Markdown for direct display and PDF rendering. Preserve a clear heading hierarchy, lists, and comparison tables where useful.",
+    "Use plain text and standard punctuation only. Do not emit emoji characters or pictographic status markers; write their meaning as words instead.",
     "Cite factual claims with descriptive Markdown links to the exact source URLs in the evidence.",
     "Finish with exactly one level-two Sources heading. Under it, include one bullet per cited URL, formatted only as a descriptive Markdown link. Every inline citation must appear in that list, and every listed source must be cited inline.",
   ]

--- a/packages/agent-core/src/mastra/workflows/research-markdown.ts
+++ b/packages/agent-core/src/mastra/workflows/research-markdown.ts
@@ -5,6 +5,7 @@ import type { ResearchSource } from "./research-schemas";
 
 const ResearchMarkdownSchema = z.string().trim().min(1).max(20_000).startsWith("# ");
 const REJECTED_FINISH_REASONS = new Set(["content-filter", "error", "length", "tool-calls"]);
+const EMOJI_PRESENTATION_PATTERN = /\p{Emoji_Presentation}|\p{Emoji}\uFE0F/u;
 
 interface ParseResearchMarkdownOptions {
   finishReason: string | undefined;
@@ -20,6 +21,9 @@ export function parseResearchMarkdown(options: ParseResearchMarkdownOptions): st
   const parsed = ResearchMarkdownSchema.safeParse(options.value);
   if (!parsed.success) {
     throw invalidResearchMarkdown("document_shape");
+  }
+  if (EMOJI_PRESENTATION_PATTERN.test(parsed.data)) {
+    throw invalidResearchMarkdown("unsupported_character");
   }
   const tokens = lexer(parsed.data, { gfm: true });
   return canonicalizeCitationStructure(tokens, options.sources);
@@ -179,6 +183,7 @@ type ResearchMarkdownValidationReason =
   | "invalid_url"
   | "malformed_link"
   | "missing_inline_citation"
+  | "unsupported_character"
   | "uncollected_source";
 
 function invalidResearchMarkdown(reason: ResearchMarkdownValidationReason): APIError {


### PR DESCRIPTION
## Why

Production PDF inspection found that emoji status markers emitted by a synthesis model were not representable by the sandbox's deterministic Liberation font contract. The chat rendered the emoji, but React-PDF emitted replacement glyphs in prose and tables, violating report parity.

## What changed

- require deep-research synthesis to express status and emphasis as plain words instead of emoji
- reject emoji-presentation characters at the validated Markdown publication boundary so the existing bounded synthesis retry can recover before any artifact is published
- preserve ordinary Unicode punctuation and technical symbols that the document fonts support
- document the shared chat/PDF character contract

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (only existing configuration hints)
- `pnpm architecture:check`
- `pnpm turbo skills:build --force`
- `git diff --check`
- confirmed the Unicode property predicate rejects colored status circles, emoji sequences, flags, and keycaps while allowing copyright/trademark marks, check marks, arrows, and em dashes
- production QA evidence: the pre-fix report routed through one deep-research tool and rendered as a two-page PDF, exposing the emoji replacement-glyph defect this boundary now prevents
