### PR TITLE
fix(platform): recover streams and support quota overrides

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -226,6 +226,8 @@ before executing against a user-connected OAuth account.
 ProjectSandbox records elapsed sandbox-hours to the same `QuotaTracker` as a soft
 meter so Settings can show real monthly sandbox consumption without blocking
 sandbox file/process work.
+Lazy workspace materialization resolves the effective project ceiling from the authoritative
+entitlement row, including an operator-granted override when present, before creating a project.
 
 Agent code reaches `QuotaTracker` through its local namespace. External quota
 access is split across named, property-validated WorkerEntrypoints:

--- a/apps/gateway-worker/README.md
+++ b/apps/gateway-worker/README.md
@@ -27,7 +27,9 @@ finish before a short RLS transaction begins or start after it commits; they
 are never parallelized across an open transaction. Read paths resolve the
 entitlement cache outside Postgres, while project and BYOK writes read the
 authoritative entitlement row under the same per-user advisory-lock order as
-entitlement reconciliation.
+entitlement reconciliation. A nullable operator-granted project-limit override is resolved after
+the plan catalog in that same transaction, so account-specific capacity does not bypass locking or
+tenant isolation.
 
 The agent Worker owns `QuotaTracker`. Gateway usage, activity, and limit-sync
 routes hold a named `GatewayQuotaEntrypoint` Service Binding that exposes only

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -13,6 +13,9 @@ two seconds in the visible tab. The event stream remains the primary delivery pa
 refresh only reconciles a silently lost connection or a browser restored after the backend became
 terminal. When the run pointer clears, the client stops any stale stream, refreshes the persisted
 transcript and sidebar state, and replaces the transient chat state with that durable result.
+An accepted run whose live response disconnects reconnects from its persisted sequence cursor with
+bounded exponential backoff while the tab is visible; reconnect failures never require a page reload
+and never start a second run.
 
 Deliverable parts contain durable output identity and presentation metadata, never an expiring
 URL. A download click calls the authenticated gateway mint endpoint, validates its bounded response,

--- a/apps/web/src/components/chat/use-chat-lifecycle.ts
+++ b/apps/web/src/components/chat/use-chat-lifecycle.ts
@@ -1,7 +1,7 @@
 import type { CheatcodeUIMessage } from "@cheatcode/types";
 import type { QueryClient } from "@tanstack/react-query";
 import type { ChatStatus } from "ai";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   type PendingSubmission,
   reconcileFailedSubmission,
@@ -29,19 +29,46 @@ export function useVisibleStreamResume(input: {
   resumeStream: () => Promise<void>;
   status: ChatStatus;
 }): void {
+  const [retryAttempt, setRetryAttempt] = useState(0);
   useEffect(() => {
-    const resumeVisibleStream = () => {
-      const canResume = input.activeRunId !== null && input.status === "ready";
-      if (document.visibilityState === "visible" && canResume) {
-        void input.resumeStream();
+    if (input.activeRunId === null) {
+      if (retryAttempt !== 0) {
+        setRetryAttempt(0);
       }
+      return;
+    }
+    if (input.status === "streaming" || input.status === "submitted") {
+      if (retryAttempt !== 0) {
+        setRetryAttempt(0);
+      }
+      return;
+    }
+    const resumeVisibleStream = () => {
+      const canResume = input.status === "ready" || input.status === "error";
+      if (document.visibilityState === "visible" && canResume) {
+        const delay = input.status === "error" ? reconnectDelay(retryAttempt) : 0;
+        const timeout = window.setTimeout(() => {
+          void input.resumeStream().finally(() => setRetryAttempt((attempt) => attempt + 1));
+        }, delay);
+        return () => window.clearTimeout(timeout);
+      }
+      return undefined;
     };
-    resumeVisibleStream();
-    document.addEventListener("visibilitychange", resumeVisibleStream);
+    let cancelPendingResume = resumeVisibleStream();
+    const handleVisibilityChange = () => {
+      cancelPendingResume?.();
+      cancelPendingResume = resumeVisibleStream();
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => {
-      document.removeEventListener("visibilitychange", resumeVisibleStream);
+      cancelPendingResume?.();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [input.activeRunId, input.resumeStream, input.status]);
+  }, [input.activeRunId, input.resumeStream, input.status, retryAttempt]);
+}
+
+function reconnectDelay(attempt: number): number {
+  return Math.min(1_000 * 2 ** Math.min(attempt, 4), 15_000);
 }
 
 export function useTerminalRunReconciliation(input: {

--- a/apps/webhooks-worker/README.md
+++ b/apps/webhooks-worker/README.md
@@ -15,6 +15,8 @@ separate retryable Workflow steps, and an equal-version Clerk replay reapplies
 the idempotent Polar projection so a database commit immediately before a lost
 Workflow checkpoint cannot suppress it. Analytics carries the provider event ID
 for append-only deduplication.
+Polar reconciliation preserves operator-granted project-limit overrides and applies over-quota
+resource policy from the effective limit rather than the catalog default.
 Composio ingress is V3-only: it accepts the current `composio.trigger.message` and
 `composio.connected_account.expired` envelopes, requires the documented event-specific identity
 fields, and verifies only exact `v1,<base64>` signature tokens (including provider key-rotation

--- a/apps/webhooks-worker/src/polar.ts
+++ b/apps/webhooks-worker/src/polar.ts
@@ -1,5 +1,5 @@
 import {
-  entitlementValuesForTier,
+  entitlementCacheFromValues,
   getPolarCustomerState,
   type PolarCustomerStateSubscription,
   type PolarServer,
@@ -200,7 +200,10 @@ async function writeEntitlement(
 ): Promise<BillingTier> {
   const previous = await findEntitlementByUserId(db, input.userId);
   const previousTier = parseTier(previous?.tier);
-  const values = entitlementValuesForTier(input.tier);
+  const maxProjects = entitlementCacheFromValues({
+    ...(previous ? { maxProjectsOverride: previous.maxProjectsOverride } : {}),
+    tier: input.tier,
+  }).maxProjects;
   await upsertEntitlement(db, {
     cancelAtPeriodEnd: input.cancelAtPeriodEnd ?? false,
     currentPeriodEnd: input.currentPeriodEnd ?? null,
@@ -211,7 +214,7 @@ async function writeEntitlement(
     userId: input.userId,
   });
   await applyEntitlementResourceLimits(db, {
-    ...entitlementResourcePolicy(values.maxProjects),
+    ...entitlementResourcePolicy(maxProjects),
     userId: input.userId,
   });
   return previousTier;

--- a/packages/billing/README.md
+++ b/packages/billing/README.md
@@ -22,6 +22,8 @@ plan catalog, and resource-entitlement helpers.
 
 Current tiers are `free`, `pro`, and `premium`. Entitlements
 cover sandbox hours, active projects, BYOK provider slots, and Composio calls.
+The effective project ceiling may include a nullable operator-granted override stored on the
+entitlement row; plan reconciliation preserves that override.
 Tier values, validation, and ordering come from the neutral
 `@cheatcode/types/billing` contract; this package owns only plan catalog and
 billing-provider behavior.

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -57,6 +57,7 @@ export type EntitlementCache = z.infer<typeof EntitlementCacheSchema>;
 export interface EntitlementCacheInput {
   currentPeriodEnd?: Date | null;
   currentPeriodStart?: Date | null;
+  maxProjectsOverride?: number | null;
   subscriptionStatus?: string;
   tier?: string;
   updatedAt?: Date | null;
@@ -331,7 +332,7 @@ export function entitlementCacheFromValues(input: EntitlementCacheInput): Entitl
   return EntitlementCacheSchema.parse({
     currentPeriodEnd: isoDateOrNull(input.currentPeriodEnd),
     currentPeriodStart: isoDateOrNull(input.currentPeriodStart),
-    maxProjects: defaults.maxProjects,
+    maxProjects: input.maxProjectsOverride ?? defaults.maxProjects,
     quotaComposioCalls: defaults.quotaComposioCalls,
     quotaSandboxHours: numericQuota(defaults.quotaSandboxHours),
     subscriptionStatus: input.subscriptionStatus ?? "none",

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -55,6 +55,9 @@ identity but is excluded from project Deliverables and file references.
 - Assistant transcript segments are unique by run and segment, with one final
   segment marker.
 - Provider-key rows contain Vault references and non-secret fingerprints only.
+- Nullable project-limit overrides live with the entitlement row, are applied after the plan
+  catalog, and survive Polar reconciliation so operator-granted capacity cannot be downgraded by
+  an unrelated subscription webhook.
 - Generated outputs are immutable after publication. Upload intents bind user,
   run, and project ownership while the per-user project-mutation advisory lock
   serializes reservation and finalization.

--- a/packages/db/drizzle/0001_entitlement_project_limit_override.sql
+++ b/packages/db/drizzle/0001_entitlement_project_limit_override.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "v2_entitlements" ADD COLUMN "max_projects_override" integer;--> statement-breakpoint
+ALTER TABLE "v2_entitlements" ADD CONSTRAINT "v2_entitlements_max_projects_override_check" CHECK ("v2_entitlements"."max_projects_override" is null or "v2_entitlements"."max_projects_override" > 0);--> statement-breakpoint
+GRANT SELECT (max_projects_override) ON TABLE public.v2_entitlements TO app_agent;

--- a/packages/db/drizzle/meta/0001_snapshot.json
+++ b/packages/db/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,2718 @@
+{
+  "id": "e1561fe1-cff0-4306-8d52-450ad2ee03e1",
+  "prevId": "ffb42b0c-fd24-4077-8be0-3cc4e0570492",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.v2_agent_runs": {
+      "name": "v2_agent_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key_hash": {
+          "name": "idempotency_key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body_hash": {
+          "name": "request_body_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skill_runtime_capabilities": {
+          "name": "skill_runtime_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_agent_runs_user_idempotency_key_unique": {
+          "name": "v2_agent_runs_user_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_agent_runs_user_started_idx": {
+          "name": "v2_agent_runs_user_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "first"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_agent_runs_user_finished_idx": {
+          "name": "v2_agent_runs_user_finished_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "finished_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2_agent_runs\".\"finished_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_agent_runs_user_delete_page_idx": {
+          "name": "v2_agent_runs_user_delete_page_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_agent_runs_thread_delete_page_idx": {
+          "name": "v2_agent_runs_thread_delete_page_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_agent_runs_user_id_v2_users_id_fk": {
+          "name": "v2_agent_runs_user_id_v2_users_id_fk",
+          "tableFrom": "v2_agent_runs",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_agent_runs_id_user_id_key": {
+          "name": "v2_agent_runs_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "v2_agent_runs_idempotency_key_hash_check": {
+          "name": "v2_agent_runs_idempotency_key_hash_check",
+          "value": "\"v2_agent_runs\".\"idempotency_key_hash\" is null or \"v2_agent_runs\".\"idempotency_key_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "v2_agent_runs_request_body_hash_check": {
+          "name": "v2_agent_runs_request_body_hash_check",
+          "value": "\"v2_agent_runs\".\"request_body_hash\" is null or \"v2_agent_runs\".\"request_body_hash\" ~ '^[0-9a-f]{64}$'"
+        },
+        "v2_agent_runs_skill_runtime_capabilities_array_check": {
+          "name": "v2_agent_runs_skill_runtime_capabilities_array_check",
+          "value": "jsonb_typeof(\"v2_agent_runs\".\"skill_runtime_capabilities\") = 'array'"
+        },
+        "v2_agent_runs_skill_runtime_capabilities_size_check": {
+          "name": "v2_agent_runs_skill_runtime_capabilities_size_check",
+          "value": "octet_length(\"v2_agent_runs\".\"skill_runtime_capabilities\"::text) <= 16384"
+        },
+        "v2_agent_runs_model_id_canonical_check": {
+          "name": "v2_agent_runs_model_id_canonical_check",
+          "value": "char_length(\"v2_agent_runs\".\"model_id\") <= 200 and \"v2_agent_runs\".\"model_id\" ~ '^(anthropic|deepseek|google|openai|openrouter)/[^[:space:]]+$'"
+        },
+        "v2_agent_runs_status_check": {
+          "name": "v2_agent_runs_status_check",
+          "value": "\"v2_agent_runs\".\"status\" in ('pending', 'running', 'completed', 'failed', 'canceled')"
+        },
+        "v2_agent_runs_finished_order_check": {
+          "name": "v2_agent_runs_finished_order_check",
+          "value": "\"v2_agent_runs\".\"finished_at\" is null or \"v2_agent_runs\".\"finished_at\" >= \"v2_agent_runs\".\"started_at\""
+        },
+        "v2_agent_runs_terminal_timestamp_check": {
+          "name": "v2_agent_runs_terminal_timestamp_check",
+          "value": "(\"v2_agent_runs\".\"status\" in ('completed', 'failed', 'canceled')) = (\"v2_agent_runs\".\"finished_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_artifact_upload_intents": {
+      "name": "v2_artifact_upload_intents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cleanup_not_before": {
+          "name": "cleanup_not_before",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quiesced_at": {
+          "name": "quiesced_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_artifact_upload_intents_cleanup_idx": {
+          "name": "v2_artifact_upload_intents_cleanup_idx",
+          "columns": [
+            {
+              "expression": "cleanup_not_before",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "quiesced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2_artifact_upload_intents\".\"quiesced_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_artifact_upload_intents_user_idx": {
+          "name": "v2_artifact_upload_intents_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_artifact_upload_intents_project_idx": {
+          "name": "v2_artifact_upload_intents_project_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_artifact_upload_intents_run_idx": {
+          "name": "v2_artifact_upload_intents_run_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_artifact_upload_intents_project_user_fk": {
+          "name": "v2_artifact_upload_intents_project_user_fk",
+          "tableFrom": "v2_artifact_upload_intents",
+          "tableTo": "v2_projects",
+          "columnsFrom": [
+            "project_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "v2_artifact_upload_intents_agent_run_user_fk": {
+          "name": "v2_artifact_upload_intents_agent_run_user_fk",
+          "tableFrom": "v2_artifact_upload_intents",
+          "tableTo": "v2_agent_runs",
+          "columnsFrom": [
+            "agent_run_id",
+            "user_id"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_artifact_upload_intents_r2_key_unique": {
+          "name": "v2_artifact_upload_intents_r2_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "r2_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "v2_artifact_upload_intents_r2_identity_check": {
+          "name": "v2_artifact_upload_intents_r2_identity_check",
+          "value": "\"v2_artifact_upload_intents\".\"r2_key\" like \"v2_artifact_upload_intents\".\"user_id\"::text || '/' || \"v2_artifact_upload_intents\".\"project_id\"::text || '/' || \"v2_artifact_upload_intents\".\"agent_run_id\"::text || '/' || \"v2_artifact_upload_intents\".\"id\"::text || '-%'\n        and strpos(substr(\"v2_artifact_upload_intents\".\"r2_key\", length(\"v2_artifact_upload_intents\".\"user_id\"::text || '/' || \"v2_artifact_upload_intents\".\"project_id\"::text || '/' || \"v2_artifact_upload_intents\".\"agent_run_id\"::text || '/' || \"v2_artifact_upload_intents\".\"id\"::text || '-') + 1), '/') = 0\n        and octet_length(\"v2_artifact_upload_intents\".\"r2_key\") <= 512"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_audit_log": {
+      "name": "v2_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_audit_log_action_created_idx": {
+          "name": "v2_audit_log_action_created_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_audit_log_created_brin_idx": {
+          "name": "v2_audit_log_created_brin_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "brin",
+          "with": {}
+        },
+        "v2_audit_log_user_created_idx": {
+          "name": "v2_audit_log_user_created_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.v2_deleted_clerk_identities": {
+      "name": "v2_deleted_clerk_identities",
+      "schema": "",
+      "columns": {
+        "clerk_identity_hash": {
+          "name": "clerk_identity_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_deleted_clerk_identities_hash_check": {
+          "name": "v2_deleted_clerk_identities_hash_check",
+          "value": "\"v2_deleted_clerk_identities\".\"clerk_identity_hash\" ~ '^[0-9a-f]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_entitlements": {
+      "name": "v2_entitlements",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "max_projects_override": {
+          "name": "max_projects_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polar_subscription_id": {
+          "name": "polar_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_entitlements_polar_subscription_uidx": {
+          "name": "v2_entitlements_polar_subscription_uidx",
+          "columns": [
+            {
+              "expression": "polar_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2_entitlements\".\"polar_subscription_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_entitlements_user_id_v2_users_id_fk": {
+          "name": "v2_entitlements_user_id_v2_users_id_fk",
+          "tableFrom": "v2_entitlements",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_entitlements_tier_check": {
+          "name": "v2_entitlements_tier_check",
+          "value": "\"v2_entitlements\".\"tier\" in ('free','pro','premium')"
+        },
+        "v2_entitlements_max_projects_override_check": {
+          "name": "v2_entitlements_max_projects_override_check",
+          "value": "\"v2_entitlements\".\"max_projects_override\" is null or \"v2_entitlements\".\"max_projects_override\" > 0"
+        },
+        "v2_entitlements_period_order_check": {
+          "name": "v2_entitlements_period_order_check",
+          "value": "\"v2_entitlements\".\"current_period_start\" is null or \"v2_entitlements\".\"current_period_end\" is null or \"v2_entitlements\".\"current_period_start\" <= \"v2_entitlements\".\"current_period_end\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_generated_outputs": {
+      "name": "v2_generated_outputs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_generated_outputs_agent_run_idx": {
+          "name": "v2_generated_outputs_agent_run_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_generated_outputs_user_id_v2_users_id_fk": {
+          "name": "v2_generated_outputs_user_id_v2_users_id_fk",
+          "tableFrom": "v2_generated_outputs",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_generated_outputs_r2_key_unique": {
+          "name": "v2_generated_outputs_r2_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "r2_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "v2_generated_outputs_r2_identity_check": {
+          "name": "v2_generated_outputs_r2_identity_check",
+          "value": "\"v2_generated_outputs\".\"r2_key\" = \"v2_generated_outputs\".\"user_id\"::text || '/' || split_part(\"v2_generated_outputs\".\"r2_key\", '/', 2) || '/' || \"v2_generated_outputs\".\"agent_run_id\"::text || '/' || \"v2_generated_outputs\".\"id\"::text || '-' || \"v2_generated_outputs\".\"filename\"\n        and split_part(\"v2_generated_outputs\".\"r2_key\", '/', 2) ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'\n        and strpos(\"v2_generated_outputs\".\"filename\", '/') = 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_messages": {
+      "name": "v2_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_run_id": {
+          "name": "agent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_run_segment": {
+          "name": "agent_run_segment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "agent_run_segment_final": {
+          "name": "agent_run_segment_final",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_messages_thread_page_idx": {
+          "name": "v2_messages_thread_page_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_run_segment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_messages_agent_run_scope_idx": {
+          "name": "v2_messages_agent_run_scope_idx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_messages_agent_run_segment_assistant_uidx": {
+          "name": "v2_messages_agent_run_segment_assistant_uidx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_run_segment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2_messages\".\"agent_run_id\" is not null and \"v2_messages\".\"role\" = 'assistant'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_messages_agent_run_final_assistant_uidx": {
+          "name": "v2_messages_agent_run_final_assistant_uidx",
+          "columns": [
+            {
+              "expression": "agent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2_messages\".\"agent_run_id\" is not null and \"v2_messages\".\"role\" = 'assistant' and \"v2_messages\".\"agent_run_segment_final\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_messages_user_id_v2_users_id_fk": {
+          "name": "v2_messages_user_id_v2_users_id_fk",
+          "tableFrom": "v2_messages",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_messages_agent_run_segment_check": {
+          "name": "v2_messages_agent_run_segment_check",
+          "value": "\"v2_messages\".\"agent_run_segment\" >= 0"
+        },
+        "v2_messages_role_check": {
+          "name": "v2_messages_role_check",
+          "value": "\"v2_messages\".\"role\" in ('assistant', 'user')"
+        },
+        "v2_messages_agent_run_segment_scope_check": {
+          "name": "v2_messages_agent_run_segment_scope_check",
+          "value": "(\"v2_messages\".\"agent_run_segment\" = 0 and \"v2_messages\".\"agent_run_segment_final\") or (\"v2_messages\".\"role\" = 'assistant' and \"v2_messages\".\"agent_run_id\" is not null)"
+        },
+        "v2_messages_parts_array_check": {
+          "name": "v2_messages_parts_array_check",
+          "value": "jsonb_typeof(\"v2_messages\".\"parts\") = 'array'"
+        },
+        "v2_messages_parts_size_check": {
+          "name": "v2_messages_parts_size_check",
+          "value": "octet_length(\"v2_messages\".\"parts\"::text) <= 196608"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_projects": {
+      "name": "v2_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_slug": {
+          "name": "workspace_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "over_quota": {
+          "name": "over_quota",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archive_after": {
+          "name": "archive_after",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_projects_user_page_idx": {
+          "name": "v2_projects_user_page_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_projects_user_delete_idx": {
+          "name": "v2_projects_user_delete_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_projects_deletion_queue_idx": {
+          "name": "v2_projects_deletion_queue_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_projects_user_id_v2_users_id_fk": {
+          "name": "v2_projects_user_id_v2_users_id_fk",
+          "tableFrom": "v2_projects",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_projects_id_user_id_key": {
+          "name": "v2_projects_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "v2_projects_mode_check": {
+          "name": "v2_projects_mode_check",
+          "value": "\"v2_projects\".\"mode\" in ('app-builder', 'app-builder-mobile', 'general')"
+        },
+        "v2_projects_workspace_slug_canonical_check": {
+          "name": "v2_projects_workspace_slug_canonical_check",
+          "value": "octet_length(\"v2_projects\".\"workspace_slug\") between 38 and 64\n        and right(\"v2_projects\".\"workspace_slug\", 37) = '-' || \"v2_projects\".\"id\"::text\n        and left(\"v2_projects\".\"workspace_slug\", length(\"v2_projects\".\"workspace_slug\") - 37)\n          ~ '^[a-z0-9]+(-[a-z0-9]+)*$'"
+        },
+        "v2_projects_quota_archive_pair_check": {
+          "name": "v2_projects_quota_archive_pair_check",
+          "value": "\"v2_projects\".\"over_quota\" = (\"v2_projects\".\"archive_after\" is not null)"
+        },
+        "v2_projects_settings_object_check": {
+          "name": "v2_projects_settings_object_check",
+          "value": "jsonb_typeof(\"v2_projects\".\"settings\") = 'object'"
+        },
+        "v2_projects_settings_default_model_check": {
+          "name": "v2_projects_settings_default_model_check",
+          "value": "not (\"v2_projects\".\"settings\" ? 'defaultModel') or (\n        jsonb_typeof(\"v2_projects\".\"settings\" -> 'defaultModel') = 'string'\n        and char_length(\"v2_projects\".\"settings\" ->> 'defaultModel') <= 200\n        and \"v2_projects\".\"settings\" ->> 'defaultModel'\n          ~ '^(anthropic|deepseek|google|openai|openrouter)/[^[:space:]]+$'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_provider_keys": {
+      "name": "v2_provider_keys",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vault_secret_id": {
+          "name": "vault_secret_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_revalidated_at": {
+          "name": "last_revalidated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revalidation_claimed_at": {
+          "name": "revalidation_claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revalidation_lease_token": {
+          "name": "revalidation_lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_provider_keys_revalidation_lease_idx": {
+          "name": "v2_provider_keys_revalidation_lease_idx",
+          "columns": [
+            {
+              "expression": "last_revalidated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "first"
+            },
+            {
+              "expression": "revalidation_claimed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "first"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2_provider_keys\".\"disabled_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_provider_keys_vault_secret_uidx": {
+          "name": "v2_provider_keys_vault_secret_uidx",
+          "columns": [
+            {
+              "expression": "vault_secret_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_provider_keys_user_id_v2_users_id_fk": {
+          "name": "v2_provider_keys_user_id_v2_users_id_fk",
+          "tableFrom": "v2_provider_keys",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "v2_provider_keys_user_id_provider_pk": {
+          "name": "v2_provider_keys_user_id_provider_pk",
+          "columns": [
+            "user_id",
+            "provider"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_provider_keys_fingerprint_check": {
+          "name": "v2_provider_keys_fingerprint_check",
+          "value": "\"v2_provider_keys\".\"fingerprint\" ~ '^[0-9a-f]{12}$'"
+        },
+        "v2_provider_keys_disabled_pair_check": {
+          "name": "v2_provider_keys_disabled_pair_check",
+          "value": "(\"v2_provider_keys\".\"disabled_at\" is null and \"v2_provider_keys\".\"disabled_reason\" is null) or (\"v2_provider_keys\".\"disabled_at\" is not null and \"v2_provider_keys\".\"disabled_reason\" is not null)"
+        },
+        "v2_provider_keys_revalidation_lease_pair_check": {
+          "name": "v2_provider_keys_revalidation_lease_pair_check",
+          "value": "(\"v2_provider_keys\".\"revalidation_claimed_at\" is null and \"v2_provider_keys\".\"revalidation_lease_token\" is null) or (\"v2_provider_keys\".\"revalidation_claimed_at\" is not null and \"v2_provider_keys\".\"revalidation_lease_token\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_resource_deletion_jobs": {
+      "name": "v2_resource_deletion_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runs'"
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continuation": {
+          "name": "continuation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_resource_deletion_jobs_generation_uidx": {
+          "name": "v2_resource_deletion_jobs_generation_uidx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_resource_deletion_jobs_user_idx": {
+          "name": "v2_resource_deletion_jobs_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_resource_deletion_jobs_ready_idx": {
+          "name": "v2_resource_deletion_jobs_ready_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_resource_deletion_jobs_lease_idx": {
+          "name": "v2_resource_deletion_jobs_lease_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'leased'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_resource_deletion_jobs_user_id_v2_users_id_fk": {
+          "name": "v2_resource_deletion_jobs_user_id_v2_users_id_fk",
+          "tableFrom": "v2_resource_deletion_jobs",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_resource_deletion_jobs_kind_check": {
+          "name": "v2_resource_deletion_jobs_kind_check",
+          "value": "\"v2_resource_deletion_jobs\".\"kind\" in ('project-deletion', 'thread-deletion')"
+        },
+        "v2_resource_deletion_jobs_phase_check": {
+          "name": "v2_resource_deletion_jobs_phase_check",
+          "value": "\"v2_resource_deletion_jobs\".\"phase\" in ('runs', 'run-objects', 'workspace', 'outputs', 'prefix', 'pointer', 'finalize')"
+        },
+        "v2_resource_deletion_jobs_status_check": {
+          "name": "v2_resource_deletion_jobs_status_check",
+          "value": "\"v2_resource_deletion_jobs\".\"status\" in ('queued', 'leased', 'quarantined')"
+        },
+        "v2_resource_deletion_jobs_counter_check": {
+          "name": "v2_resource_deletion_jobs_counter_check",
+          "value": "\"v2_resource_deletion_jobs\".\"continuation\" >= 0 and \"v2_resource_deletion_jobs\".\"failure_count\" >= 0"
+        },
+        "v2_resource_deletion_jobs_lease_check": {
+          "name": "v2_resource_deletion_jobs_lease_check",
+          "value": "(\n        (\"v2_resource_deletion_jobs\".\"status\" = 'leased' and \"v2_resource_deletion_jobs\".\"lease_token\" is not null and \"v2_resource_deletion_jobs\".\"lease_expires_at\" is not null)\n        or\n        (\"v2_resource_deletion_jobs\".\"status\" <> 'leased' and \"v2_resource_deletion_jobs\".\"lease_token\" is null and \"v2_resource_deletion_jobs\".\"lease_expires_at\" is null)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_threads": {
+      "name": "v2_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "launch_intent": {
+          "name": "launch_intent",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_run_id": {
+          "name": "active_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_model_id": {
+          "name": "latest_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_threads_user_page_idx": {
+          "name": "v2_threads_user_page_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_threads_project_page_idx": {
+          "name": "v2_threads_project_page_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_threads_project_delete_idx": {
+          "name": "v2_threads_project_delete_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_threads_active_run_idx": {
+          "name": "v2_threads_active_run_idx",
+          "columns": [
+            {
+              "expression": "active_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2_threads\".\"active_run_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_threads_deletion_queue_idx": {
+          "name": "v2_threads_deletion_queue_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "deleted_at is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_threads_user_id_v2_users_id_fk": {
+          "name": "v2_threads_user_id_v2_users_id_fk",
+          "tableFrom": "v2_threads",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_threads_project_launch_intent_check": {
+          "name": "v2_threads_project_launch_intent_check",
+          "value": "\"v2_threads\".\"project_id\" is null or \"v2_threads\".\"launch_intent\" is null"
+        },
+        "v2_threads_launch_intent_object_check": {
+          "name": "v2_threads_launch_intent_object_check",
+          "value": "\"v2_threads\".\"launch_intent\" is null or jsonb_typeof(\"v2_threads\".\"launch_intent\") = 'object'"
+        },
+        "v2_threads_launch_default_model_check": {
+          "name": "v2_threads_launch_default_model_check",
+          "value": "\"v2_threads\".\"launch_intent\" is null or not (\"v2_threads\".\"launch_intent\" ? 'defaultModel') or (\n        jsonb_typeof(\"v2_threads\".\"launch_intent\" -> 'defaultModel') = 'string'\n        and char_length(\"v2_threads\".\"launch_intent\" ->> 'defaultModel') <= 200\n        and \"v2_threads\".\"launch_intent\" ->> 'defaultModel'\n          ~ '^(anthropic|deepseek|google|openai|openrouter)/[^[:space:]]+$'\n      )"
+        },
+        "v2_threads_latest_model_id_check": {
+          "name": "v2_threads_latest_model_id_check",
+          "value": "\"v2_threads\".\"latest_model_id\" is null or (\n        char_length(\"v2_threads\".\"latest_model_id\") <= 200\n        and \"v2_threads\".\"latest_model_id\"\n          ~ '^(anthropic|deepseek|google|openai|openrouter)/[^[:space:]]+$'\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_user_deletion_jobs": {
+      "name": "v2_user_deletion_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'runs'"
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "continuation": {
+          "name": "continuation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_user_deletion_jobs_generation_uidx": {
+          "name": "v2_user_deletion_jobs_generation_uidx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_user_deletion_jobs_ready_idx": {
+          "name": "v2_user_deletion_jobs_ready_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2_user_deletion_jobs\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_user_deletion_jobs_lease_idx": {
+          "name": "v2_user_deletion_jobs_lease_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2_user_deletion_jobs\".\"status\" = 'leased'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_user_deletion_jobs_user_id_v2_users_id_fk": {
+          "name": "v2_user_deletion_jobs_user_id_v2_users_id_fk",
+          "tableFrom": "v2_user_deletion_jobs",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_user_deletion_jobs_id_user_generation_key": {
+          "name": "v2_user_deletion_jobs_id_user_generation_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "user_id",
+            "generation"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "v2_user_deletion_jobs_phase_check": {
+          "name": "v2_user_deletion_jobs_phase_check",
+          "value": "\"v2_user_deletion_jobs\".\"phase\" in ('runs', 'sandbox', 'billing', 'quota', 'integrations', 'objects', 'archive', 'finalize')"
+        },
+        "v2_user_deletion_jobs_status_check": {
+          "name": "v2_user_deletion_jobs_status_check",
+          "value": "\"v2_user_deletion_jobs\".\"status\" in ('queued', 'leased', 'quarantined')"
+        },
+        "v2_user_deletion_jobs_counter_check": {
+          "name": "v2_user_deletion_jobs_counter_check",
+          "value": "\"v2_user_deletion_jobs\".\"continuation\" >= 0 and \"v2_user_deletion_jobs\".\"failure_count\" >= 0"
+        },
+        "v2_user_deletion_jobs_lease_check": {
+          "name": "v2_user_deletion_jobs_lease_check",
+          "value": "(\n        (\"v2_user_deletion_jobs\".\"status\" = 'leased' and \"v2_user_deletion_jobs\".\"lease_token\" is not null and \"v2_user_deletion_jobs\".\"lease_expires_at\" is not null)\n        or\n        (\"v2_user_deletion_jobs\".\"status\" <> 'leased' and \"v2_user_deletion_jobs\".\"lease_token\" is null and \"v2_user_deletion_jobs\".\"lease_expires_at\" is null)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_user_deletion_refund_intents": {
+      "name": "v2_user_deletion_refund_intents",
+      "schema": "",
+      "columns": {
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation": {
+          "name": "generation",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_refund_id": {
+          "name": "provider_refund_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_status": {
+          "name": "provider_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp (3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_user_deletion_refund_intents_idempotency_uidx": {
+          "name": "v2_user_deletion_refund_intents_idempotency_uidx",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_user_deletion_refund_intents_provider_uidx": {
+          "name": "v2_user_deletion_refund_intents_provider_uidx",
+          "columns": [
+            {
+              "expression": "provider_refund_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2_user_deletion_refund_intents\".\"provider_refund_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_user_deletion_refund_intents_unresolved_idx": {
+          "name": "v2_user_deletion_refund_intents_unresolved_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2_user_deletion_refund_intents\".\"provider_status\" is distinct from 'succeeded'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_user_deletion_refund_intents_job_identity_fk": {
+          "name": "v2_user_deletion_refund_intents_job_identity_fk",
+          "tableFrom": "v2_user_deletion_refund_intents",
+          "tableTo": "v2_user_deletion_jobs",
+          "columnsFrom": [
+            "job_id",
+            "user_id",
+            "generation"
+          ],
+          "columnsTo": [
+            "id",
+            "user_id",
+            "generation"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_user_deletion_refund_intents_amount_check": {
+          "name": "v2_user_deletion_refund_intents_amount_check",
+          "value": "\"v2_user_deletion_refund_intents\".\"amount\" > 0"
+        },
+        "v2_user_deletion_refund_intents_currency_check": {
+          "name": "v2_user_deletion_refund_intents_currency_check",
+          "value": "\"v2_user_deletion_refund_intents\".\"currency\" ~ '^[a-z]{3}$'"
+        },
+        "v2_user_deletion_refund_intents_order_check": {
+          "name": "v2_user_deletion_refund_intents_order_check",
+          "value": "length(btrim(\"v2_user_deletion_refund_intents\".\"order_id\")) > 0"
+        },
+        "v2_user_deletion_refund_intents_identity_check": {
+          "name": "v2_user_deletion_refund_intents_identity_check",
+          "value": "\"v2_user_deletion_refund_intents\".\"idempotency_key\" = 'cheatcode:user-deletion-refund:' || \"v2_user_deletion_refund_intents\".\"job_id\"::text"
+        },
+        "v2_user_deletion_refund_intents_provider_check": {
+          "name": "v2_user_deletion_refund_intents_provider_check",
+          "value": "(\n        (\"v2_user_deletion_refund_intents\".\"provider_refund_id\" is null and \"v2_user_deletion_refund_intents\".\"provider_status\" is null and \"v2_user_deletion_refund_intents\".\"reconciled_at\" is null)\n        or\n        (\"v2_user_deletion_refund_intents\".\"provider_refund_id\" is not null and length(btrim(\"v2_user_deletion_refund_intents\".\"provider_refund_id\")) > 0 and \"v2_user_deletion_refund_intents\".\"provider_status\" is not null and \"v2_user_deletion_refund_intents\".\"provider_status\" in ('pending', 'succeeded', 'failed', 'canceled') and \"v2_user_deletion_refund_intents\".\"reconciled_at\" is not null)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_user_integrations": {
+      "name": "v2_user_integrations",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composio_connection_id": {
+          "name": "composio_connection_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_user_integrations_one_default_idx": {
+          "name": "v2_user_integrations_one_default_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"v2_user_integrations\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_user_integrations_delete_page_idx": {
+          "name": "v2_user_integrations_delete_page_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "composio_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_user_integrations_user_toolkit_idx": {
+          "name": "v2_user_integrations_user_toolkit_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_user_integrations_user_id_v2_users_id_fk": {
+          "name": "v2_user_integrations_user_id_v2_users_id_fk",
+          "tableFrom": "v2_user_integrations",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_user_integrations_connection_id_check": {
+          "name": "v2_user_integrations_connection_id_check",
+          "value": "\"v2_user_integrations\".\"composio_connection_id\" = btrim(\"v2_user_integrations\".\"composio_connection_id\") and length(\"v2_user_integrations\".\"composio_connection_id\") between 1 and 256"
+        },
+        "v2_user_integrations_default_active_check": {
+          "name": "v2_user_integrations_default_active_check",
+          "value": "not \"v2_user_integrations\".\"is_default\" or lower(\"v2_user_integrations\".\"status\") in ('active', 'authorized', 'connected', 'enabled')"
+        },
+        "v2_user_integrations_integration_check": {
+          "name": "v2_user_integrations_integration_check",
+          "value": "\"v2_user_integrations\".\"integration\" ~ '^[a-z0-9_]{1,64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_user_profiles": {
+      "name": "v2_user_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_display_name": {
+          "name": "agent_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "global_memory": {
+          "name": "global_memory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_models": {
+          "name": "disabled_models",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_state": {
+          "name": "onboarding_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "v2_user_profiles_user_id_v2_users_id_fk": {
+          "name": "v2_user_profiles_user_id_v2_users_id_fk",
+          "tableFrom": "v2_user_profiles",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_user_profiles_disabled_models_array_check": {
+          "name": "v2_user_profiles_disabled_models_array_check",
+          "value": "jsonb_typeof(\"v2_user_profiles\".\"disabled_models\") = 'array'"
+        },
+        "v2_user_profiles_onboarding_state_object_check": {
+          "name": "v2_user_profiles_onboarding_state_object_check",
+          "value": "jsonb_typeof(\"v2_user_profiles\".\"onboarding_state\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_user_skills": {
+      "name": "v2_user_skills",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "v2_user_skills_user_name_idx": {
+          "name": "v2_user_skills_user_name_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "v2_user_skills_user_id_v2_users_id_fk": {
+          "name": "v2_user_skills_user_id_v2_users_id_fk",
+          "tableFrom": "v2_user_skills",
+          "tableTo": "v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "v2_user_skills_tags_array_check": {
+          "name": "v2_user_skills_tags_array_check",
+          "value": "jsonb_typeof(\"v2_user_skills\".\"tags\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.v2_users": {
+      "name": "v2_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "public.uuidv7()"
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_updated_at_ms": {
+          "name": "clerk_updated_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polar_customer_id": {
+          "name": "polar_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_artifact_at": {
+          "name": "first_artifact_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_fence": {
+          "name": "deletion_fence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "v2_users_activation_created_idx": {
+          "name": "v2_users_activation_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2_users\".\"deleted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "v2_users_deletion_due_idx": {
+          "name": "v2_users_deletion_due_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"v2_users\".\"deleted_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "v2_users_clerk_id_unique": {
+          "name": "v2_users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        },
+        "v2_users_polar_customer_id_unique": {
+          "name": "v2_users_polar_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "polar_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "v2_users_clerk_updated_at_ms_check": {
+          "name": "v2_users_clerk_updated_at_ms_check",
+          "value": "\"v2_users\".\"clerk_updated_at_ms\" between 0 and 9007199254740991"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1784981026716,
       "tag": "0000_current_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1786518344655,
+      "tag": "0001_entitlement_project_limit_override",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/billing.ts
+++ b/packages/db/src/billing.ts
@@ -24,6 +24,7 @@ export interface EntitlementRecord {
   cancelAtPeriodEnd: boolean;
   currentPeriodEnd: Date | null;
   currentPeriodStart: Date | null;
+  maxProjectsOverride: number | null;
   polarSubscriptionId: string | null;
   subscriptionStatus: string;
   tier: string;
@@ -33,7 +34,12 @@ export interface EntitlementRecord {
 
 export type AgentEntitlementRecord = Pick<
   EntitlementRecord,
-  "currentPeriodEnd" | "currentPeriodStart" | "subscriptionStatus" | "tier" | "updatedAt"
+  | "currentPeriodEnd"
+  | "currentPeriodStart"
+  | "maxProjectsOverride"
+  | "subscriptionStatus"
+  | "tier"
+  | "updatedAt"
 >;
 
 export interface EntitlementSubscriptionStateInput {
@@ -93,6 +99,7 @@ export async function findEntitlementByUserId(
         cancelAtPeriodEnd: row.cancelAtPeriodEnd,
         currentPeriodEnd: row.currentPeriodEnd,
         currentPeriodStart: row.currentPeriodStart,
+        maxProjectsOverride: row.maxProjectsOverride,
         polarSubscriptionId: row.polarSubscriptionId,
         subscriptionStatus: row.subscriptionStatus,
         tier: row.tier,
@@ -111,6 +118,7 @@ export async function findAgentEntitlementByUserId(
     columns: {
       currentPeriodEnd: true,
       currentPeriodStart: true,
+      maxProjectsOverride: true,
       subscriptionStatus: true,
       tier: true,
       updatedAt: true,

--- a/packages/db/src/schema/billing.ts
+++ b/packages/db/src/schema/billing.ts
@@ -1,5 +1,14 @@
 import { sql } from "drizzle-orm";
-import { boolean, check, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import {
+  boolean,
+  check,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
 import { v2TableName } from "./names";
 import { users } from "./users";
 
@@ -10,6 +19,7 @@ export const entitlements = pgTable(
       .primaryKey()
       .references(() => users.id, { onDelete: "cascade" }),
     tier: text("tier").notNull().default("free"),
+    maxProjectsOverride: integer("max_projects_override"),
     polarSubscriptionId: text("polar_subscription_id"),
     subscriptionStatus: text("subscription_status").notNull().default("none"),
     cancelAtPeriodEnd: boolean("cancel_at_period_end").notNull().default(false),
@@ -19,6 +29,10 @@ export const entitlements = pgTable(
   },
   (table) => [
     check("v2_entitlements_tier_check", sql`${table.tier} in ('free','pro','premium')`),
+    check(
+      "v2_entitlements_max_projects_override_check",
+      sql`${table.maxProjectsOverride} is null or ${table.maxProjectsOverride} > 0`,
+    ),
     uniqueIndex("v2_entitlements_polar_subscription_uidx")
       .on(table.polarSubscriptionId)
       .where(sql`${table.polarSubscriptionId} is not null`),


### PR DESCRIPTION
## Why

Production QA exposed two independent root causes:

- accepted agent runs could lose their live response and remain visually stuck because only pre-acceptance stream failures reconnected;
- the QA account was already Premium and had exactly 50 active projects, so another project could not materialize without an account-specific entitlement mechanism.

## What changed

- reconnect accepted active runs from their persisted sequence cursor with visibility-aware exponential backoff;
- add a nullable `max_projects_override` entitlement field and resolve it after the plan catalog in gateway and agent admission;
- preserve the override across Polar reconciliation and apply effective capacity to over-quota resource policy;
- grant the agent role least-privilege read access to the new column;
- document the stream and entitlement boundaries.

## Database

- adds forward migration `0001_entitlement_project_limit_override.sql`;
- migration dry-run and apply both passed against the approved production target;
- production schema contract passed after apply.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build --force`
- `pnpm db:migrate -- --dry-run`
- `git diff --check`
- production Worker release convergence verified before QA (`4b7b7e709e985a07084602d2c64b975fc141ef0c`)
- production account override written under the entitlement advisory lock and its KV cache entry invalidated

Fresh browser acceptance will run against the merged Vercel and Cloudflare release before this task is closed.