### PR TITLE
fix(agent): honor project-limit overrides in workspaces

### DIFF
--- a/apps/agent-worker/src/durable-objects/agent-run-workspace.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-workspace.ts
@@ -1,4 +1,4 @@
-import { entitlementValuesForTier } from "@cheatcode/billing";
+import { entitlementCacheFromValues } from "@cheatcode/billing";
 import { materializeThreadProject, withUserDb, workspacePathForSlug } from "@cheatcode/db";
 import { APIError, type createLogger } from "@cheatcode/observability";
 import type {
@@ -6,7 +6,7 @@ import type {
   WorkspaceBinding,
   WorkspaceResolver,
 } from "@cheatcode/sandbox-contracts";
-import { BillingTierSchema, toThreadId, toUserId } from "@cheatcode/types";
+import { toThreadId, toUserId } from "@cheatcode/types";
 import type { UIMessageChunk } from "ai";
 import type { AgentRunEnv } from "./agent-run-env";
 import type { StartRunInput } from "./agent-run-schemas";
@@ -83,9 +83,7 @@ async function materializeWorkspaceProject(input: WorkspaceResolverInput) {
           threadId: toThreadId(input.input.threadId),
           userId,
         },
-        (entitlement) =>
-          entitlementValuesForTier(BillingTierSchema.parse(entitlement?.tier ?? "free"))
-            .maxProjects,
+        (entitlement) => entitlementCacheFromValues(entitlement ?? { tier: "free" }).maxProjects,
       ),
     );
   });

--- a/packages/billing/README.md
+++ b/packages/billing/README.md
@@ -13,7 +13,6 @@ plan catalog, and resource-entitlement helpers.
 - `getPolarCustomerState`
 - `updateCustomerProfile`
 - `entitlementCacheFromValues`
-- `entitlementValuesForTier`
 - `PLAN_CATALOG`
 - sandbox-hour quota helpers
 - `@cheatcode/billing/quota-runtime`: worker-only `QuotaTrackerRuntime`; this

--- a/packages/billing/src/catalog.ts
+++ b/packages/billing/src/catalog.ts
@@ -3,7 +3,7 @@ import type { BillingTier } from "@cheatcode/types/billing";
 /**
  * Single source of truth for plan tier id, display name, monthly price, the
  * user-facing sandbox-hour allowance, and every operational `TierLimits` field.
- * `TIER_LIMITS` / `entitlementValuesForTier` in ./index derive from this.
+ * `TIER_LIMITS` / `defaultEntitlementValuesForTier` in ./index derive from this.
  *
  * Sandbox tenancy is a product invariant: every account has one shared private
  * computer, so it is not represented as a plan entitlement.

--- a/packages/billing/src/index.ts
+++ b/packages/billing/src/index.ts
@@ -34,7 +34,7 @@ interface TierLimits {
   quotaSandboxHours: number | null;
 }
 
-export interface EntitlementValues {
+interface EntitlementValues {
   maxProjects: number;
   quotaComposioCalls: number;
   quotaSandboxHours: string;
@@ -316,7 +316,7 @@ function tierLimits(tier: BillingTier): TierLimits {
   return TIER_LIMITS[tier];
 }
 
-export function entitlementValuesForTier(tier: BillingTier): EntitlementValues {
+function defaultEntitlementValuesForTier(tier: BillingTier): EntitlementValues {
   const limits = tierLimits(tier);
   return {
     maxProjects: integerLimit(limits.maxProjects),
@@ -328,7 +328,7 @@ export function entitlementValuesForTier(tier: BillingTier): EntitlementValues {
 
 export function entitlementCacheFromValues(input: EntitlementCacheInput): EntitlementCache {
   const tier = parseTier(input.tier);
-  const defaults = entitlementValuesForTier(tier);
+  const defaults = defaultEntitlementValuesForTier(tier);
   return EntitlementCacheSchema.parse({
     currentPeriodEnd: isoDateOrNull(input.currentPeriodEnd),
     currentPeriodStart: isoDateOrNull(input.currentPeriodStart),


### PR DESCRIPTION
## Why

Lazy workspace materialization resolved the active-project limit directly from the plan tier. That bypassed the canonical effective-entitlement projection, so an operator-granted `max_projects_override` was ignored even though gateway project creation honored it.

## What changed

- resolve the lazy workspace project ceiling through `entitlementCacheFromValues`
- remove the now-unused public tier-default resolver and type
- keep the billing package README aligned with its actual public surface

This leaves one canonical path for tier defaults plus per-account overrides.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build --force`
- `pnpm db:migrate -- --dry-run`
- `git diff --check`

Production acceptance will be repeated after merge and exact-SHA Cloudflare deployment by creating a project beyond the previous 50-project ceiling with an ordinary web-app prompt.
