### PR TITLE
fix(web): keep non-app work on Files surface

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -55,11 +55,12 @@ the same mark in place until the final document has loaded. Preview wake and cap
 paused during fresh scaffold generation; readiness acquires a new one-minute handoff immediately
 before the iframe mounts and exchanges it for the renewable ten-minute host cookie. Existing project
 edits remain visible and continue hot-reloading normally.
-When the agent completes a browser-open action, the Browser panel requests one authenticated reload
-so the user sees the same freshly verified build. The preview owner first renews the short-lived
-handoff capability and only then remounts the entry document; an old capability is never reused.
-Read-only extraction, screenshots, and browser interactions still open the panel without repeatedly
-resetting the user's live preview state.
+When the agent completes a browser-open action for an app-builder project, the Browser panel requests
+one authenticated reload so the user sees the same freshly verified build. The preview owner first
+renews the short-lived handoff capability and only then remounts the entry document; an old capability
+is never reused. Read-only extraction, screenshots, and browser interactions in app-builder projects
+still open the panel without repeatedly resetting the user's live preview state. Internal browser work
+in a general project never displaces its Files workspace; explicit browser takeover remains visible.
 
 ## Public exports
 
@@ -93,10 +94,11 @@ The composer keeps three independent product concepts separate:
   non-app work intent remains a `general` project and can still create typed
   Deliverables.
 - `ComputerTab` is only the visible workspace view: `browser` or `files`.
-  Artifact kind and MIME type decide how an output renders. A generated artifact selects Files,
-  while an actual browser action selects Browser; the latest real activity wins when a transcript
-  is restored. Neither work intent nor app target guesses the Computer tab, and the selected tab is
-  not persisted across unrelated chats.
+  Artifact kind and MIME type decide how an output renders. A generated artifact selects Files.
+  Browser actions automatically select Browser only for web/mobile app project modes, where that
+  surface is the product result; browser tools used internally by a general project do not steal
+  focus from Files. Explicit browser takeover still selects Browser. The selected tab is not persisted
+  across unrelated chats.
 
 Signed-out launch handoff validates and restores `buildTarget`, model, and
 public GitHub repository state before chat creation. The opaque prompt and

--- a/apps/web/src/components/chat/chat-panel-controller.ts
+++ b/apps/web/src/components/chat/chat-panel-controller.ts
@@ -67,6 +67,7 @@ function useChatPanelRuntime(input: ChatPanelProps) {
   const store = useChatPanelStore(input.threadId);
   const viewApplier = useComputerViewApplier({
     projectId: input.project?.id ?? null,
+    projectMode: input.project?.mode ?? null,
     requestPreviewReload: store.requestPreviewReload,
     setActiveComputerTab: store.setActiveComputerTab,
     setAppPreviewStatus: store.setAppPreviewStatus,

--- a/apps/web/src/components/chat/use-computer-view-sync.ts
+++ b/apps/web/src/components/chat/use-computer-view-sync.ts
@@ -4,7 +4,7 @@ import {
   reconstructedTranscriptUIMessage,
   type SandboxState,
 } from "@cheatcode/types";
-import type { ProjectSummary } from "@cheatcode/types/api";
+import type { ProjectMode, ProjectSummary } from "@cheatcode/types/api";
 import type { ChatStatus } from "ai";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { type ComputerTab, useAppStore } from "@/lib/store/app-store";
@@ -55,6 +55,7 @@ export interface ComputerViewApplier {
 
 interface ComputerViewApplierInput extends ComputerViewActions {
   projectId: string | null;
+  projectMode: ProjectMode | null;
   threadId: string;
 }
 
@@ -70,7 +71,7 @@ interface HydratedComputerViewCommands {
 }
 
 export function useComputerViewApplier(input: ComputerViewApplierInput): ComputerViewApplier {
-  const scopeKey = `${input.threadId}:${input.projectId ?? ""}`;
+  const scopeKey = `${input.threadId}:${input.projectId ?? ""}:${input.projectMode ?? ""}`;
   const stateRef = useRef<ComputerViewCommandState>(createComputerViewCommandState(scopeKey));
   if (stateRef.current.scopeKey !== scopeKey) {
     stateRef.current = createComputerViewCommandState(scopeKey);
@@ -93,8 +94,14 @@ export function useComputerViewApplier(input: ComputerViewApplierInput): Compute
   );
   const apply = useCallback(
     (command: ComputerViewCommand) =>
-      applyComputerViewCommand(command, input.threadId, stateRef.current, actions),
-    [actions, input.threadId],
+      applyComputerViewCommand(
+        command,
+        input.threadId,
+        input.projectMode,
+        stateRef.current,
+        actions,
+      ),
+    [actions, input.projectMode, input.threadId],
   );
   const reset = useCallback(() => {
     stateRef.current = createComputerViewCommandState(scopeKey);
@@ -103,7 +110,10 @@ export function useComputerViewApplier(input: ComputerViewApplierInput): Compute
 }
 
 export function useSandboxComputerSync(input: SandboxComputerSyncInput): void {
-  const commands = useMemo(() => hydratedComputerViewCommands(input.messages), [input.messages]);
+  const commands = useMemo(
+    () => hydratedComputerViewCommands(input.messages, input.project?.mode ?? null),
+    [input.messages, input.project?.mode],
+  );
   const status = commands.status?.kind === "status" ? commands.status.status : null;
   const defaultedProjectFilesRef = useRef<string | null>(null);
   const previousStatusRef = useRef(input.chatStatus);
@@ -229,6 +239,7 @@ function useCompletionPreview(
 
 function hydratedComputerViewCommands(
   messages: readonly CheatcodeUIMessage[],
+  projectMode: ProjectMode | null,
 ): HydratedComputerViewCommands {
   const commands: HydratedComputerViewCommands = { preview: null, status: null, surface: null };
   for (let messageIndex = 0; messageIndex < messages.length; messageIndex += 1) {
@@ -242,7 +253,7 @@ function hydratedComputerViewCommands(
       if (!part) {
         continue;
       }
-      recordHydratedComputerViewCommand(commands, computerViewEffect(part));
+      recordHydratedComputerViewCommand(commands, computerViewEffect(part), projectMode);
     }
   }
   return commands;
@@ -251,7 +262,11 @@ function hydratedComputerViewCommands(
 function recordHydratedComputerViewCommand(
   commands: HydratedComputerViewCommands,
   command: ComputerViewCommand | null,
+  projectMode: ProjectMode | null,
 ): void {
+  if (!shouldApplyComputerViewCommand(command, projectMode)) {
+    return;
+  }
   if (command?.kind === "status") {
     commands.status = command;
   } else if (command?.kind === "preview-status") {
@@ -266,6 +281,7 @@ function recordHydratedComputerViewCommand(
 function applyComputerViewCommand(
   command: ComputerViewCommand,
   threadId: string,
+  projectMode: ProjectMode | null,
   state: ComputerViewCommandState,
   actions: ComputerViewActions,
 ): void {
@@ -279,6 +295,9 @@ function applyComputerViewCommand(
     if (useAppStore.getState().appPreviewStatus !== command.status) {
       actions.setAppPreviewStatus(command.status);
     }
+    return;
+  }
+  if (!shouldApplyComputerViewCommand(command, projectMode)) {
     return;
   }
   const surfaceId = command.kind === "open-files" ? command.artifactId : command.toolCallId;
@@ -297,6 +316,13 @@ function applyComputerViewCommand(
   }
   actions.setActiveComputerTab("browser");
   actions.setPreviewPanelOpen(true);
+}
+
+function shouldApplyComputerViewCommand(
+  command: ComputerViewCommand | null,
+  projectMode: ProjectMode | null,
+): boolean {
+  return command !== null && (command.kind !== "open-browser-preview" || projectMode !== "general");
 }
 
 function createComputerViewCommandState(scopeKey: string): ComputerViewCommandState {


### PR DESCRIPTION
## Why

A general-project Media run generated its image artifact, then used `browser_open` internally to inspect it. Transcript hydration treated that later tool call as the user's final workspace surface, so Browser displaced Files even though the durable output was the result.

## What changed

- include project mode in Computer-view arbitration and its scope identity
- ignore automatic browser-surface commands for `general` projects during both live streaming and transcript hydration
- retain automatic Browser selection for web/mobile app projects
- leave explicit browser takeover behavior unchanged
- document the mode-aware Computer semantics

This keeps research, data, documents, slides, and media on Files while preserving live previews for app builders.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build --force`
- `pnpm db:migrate -- --dry-run`
- `git diff --check`

Production acceptance will reload the existing Media transcript whose post-artifact `browser_open` reproduced the issue, then exercise fresh app and non-app prompts.
