### PR TITLE
fix(sandbox): refresh Debian security snapshot

### DIFF
--- a/infra/containers/sandbox/Dockerfile
+++ b/infra/containers/sandbox/Dockerfile
@@ -2,7 +2,7 @@ FROM node:24.18.0-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd3
 
 ARG CODE_SERVER_VERSION=4.128.0
 ARG CODE_SERVER_SHA256=79ba26bf186e5268a22b7c17b30a5f288a16c37791f0b86c27859e8fef103188
-ARG DEBIAN_SNAPSHOT=20260801T000000Z
+ARG DEBIAN_SNAPSHOT=20260812T000000Z
 
 # Daytona injects its own daemon (host-mounted, PID 1) and overrides ENTRYPOINT,
 # so we do NOT bake a sandbox daemon. Headed Chromium uses Xvfb, which the


### PR DESCRIPTION
## Why

The immutable sandbox build for the deterministic browser-action release correctly failed its vulnerability gate because the pinned 2026-08-01 Debian snapshot provides vulnerable `libnss3` `2:3.87.1-1+deb12u3`. Debian has fixed CVE-2026-16389 in `2:3.87.1-1+deb12u4`.

## Change

Advance the reviewed Debian package snapshot to `20260812T000000Z`. The base image digest and every other sandbox dependency remain pinned.

## Verification

- Confirmed the pinned snapshot resolves `libnss3` to `2:3.87.1-1+deb12u4` from `bookworm-security`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `pnpm db:migrate -- --dry-run`
- Full AMD64 sandbox image build is running locally; the protected snapshot workflow will repeat the build, vulnerability/secret/config scans, runtime smoke tests, and immutable publication before promotion

No migration or runtime environment-contract change.
