### PR TITLE
fix(ci): verify successful release checks reliably

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -55,8 +55,7 @@ jobs:
             --field event=push \
             --field head_sha="$GITHUB_SHA" \
             --field per_page=1 \
-            --field status=success \
-            --jq '.total_count')"
+            --jq '[.workflow_runs[] | select(.conclusion == "success")] | length')"
           if [ "$successful_runs" -lt 1 ]; then
             echo "Static Checks has not succeeded for $GITHUB_SHA on main." >&2
             exit 1

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -31,8 +31,7 @@ jobs:
             --field event=push \
             --field head_sha="$GITHUB_SHA" \
             --field per_page=1 \
-            --field status=success \
-            --jq '.total_count')"
+            --jq '[.workflow_runs[] | select(.conclusion == "success")] | length')"
           if [ "$successful_runs" -lt 1 ]; then
             echo "Static Checks has not succeeded for $GITHUB_SHA on main." >&2
             exit 1


### PR DESCRIPTION
## Why

The protected snapshot and Cloudflare release guards filtered GitHub workflow runs with `status=success`. GitHub returned no runs for that query even when the exact main SHA had a completed successful Static Checks run, causing valid releases to fail closed.

## Change

Fetch the exact main SHA's push run without the unreliable status filter and explicitly count only runs whose `conclusion` is `success`. The release remains fail-closed for missing, pending, failed, canceled, or skipped checks.

## Verification

- Reproduced the old query returning zero for successful main run `31580761268`
- Verified the corrected query returns exactly one successful run for SHA `48fedf67142a62488a47dc35ed87c39f6a4c2092`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `pnpm db:migrate -- --dry-run`

No deployment permission, environment, or migration change.
