### PR TITLE
chore(sandbox): promote deterministic browser image

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-6305819f07bc-31418301622",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-524842b2b711-31581198909",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable sandbox candidate that contains the deterministic observation-bound browser action contract, updated web-app verification skills, and the Debian NSS security refresh.

## Candidate provenance

- Candidate: `cheatcode-sandbox-viewer-bundle-524842b2b711-31581198909`
- Source main SHA: `524842b2b711e57e30e8509188ca447d893e4757`
- Protected build: https://github.com/cheatcode-ai/cheatcode/actions/runs/31581198909
- Image build, configuration scan, vulnerability scan, secret scan, runtime smoke suite, immutable publication, and candidate identity verification all succeeded

## Verification

- Local AMD64 image build succeeded
- Local image contains fixed `libnss3` `2:3.87.1-1+deb12u4`
- Local Trivy 0.72 vulnerability scan succeeded
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `pnpm db:migrate -- --dry-run`

After merge, the protected Cloudflare release preflight will independently revalidate snapshot uniqueness, shape, resources, source ancestry, unchanged image inputs, the shared workspace volume, and canonical sandbox identities before deployment.
