### PR TITLE
fix(agent): fail over timed-out auto model turns

### DIFF
--- a/apps/agent-worker/src/durable-objects/llm-provider.ts
+++ b/apps/agent-worker/src/durable-objects/llm-provider.ts
@@ -119,9 +119,42 @@ export function shouldFallbackToOpenAI(
     message.includes("insufficient");
   const opaqueProviderStreamFailure =
     message === "unknown mastra stream error." || message === "mastra stream error.";
+  const providerTimeout = isProviderTimeout(error);
   return (
-    (providerFailure || opaqueProviderStreamFailure) &&
-    (statusCode === null || [400, 401, 403, 429].includes(statusCode))
+    ((providerFailure || opaqueProviderStreamFailure) &&
+      (statusCode === null || [400, 401, 403, 429].includes(statusCode))) ||
+    (providerTimeout &&
+      (statusCode === null || statusCode === 408 || (statusCode >= 500 && statusCode <= 504)))
+  );
+}
+
+function isProviderTimeout(error: unknown): boolean {
+  const pending: unknown[] = [error];
+  const seen = new Set<unknown>();
+  while (pending.length > 0 && seen.size < 12) {
+    const candidate = pending.shift();
+    if (candidate === undefined || candidate === null || seen.has(candidate)) continue;
+    seen.add(candidate);
+    if (timeoutSignal(candidate)) return true;
+    if (!isRecord(candidate)) continue;
+    pending.push(candidate["cause"], candidate["lastError"]);
+    const nested = candidate["errors"];
+    if (Array.isArray(nested)) pending.push(...nested.slice(0, 4));
+  }
+  return false;
+}
+
+function timeoutSignal(error: unknown): boolean {
+  if (!isRecord(error)) return false;
+  const name = typeof error["name"] === "string" ? error["name"].toLowerCase() : "";
+  const code = typeof error["code"] === "string" ? error["code"].toLowerCase() : "";
+  const message = typeof error["message"] === "string" ? error["message"].toLowerCase() : "";
+  return (
+    name === "timeouterror" ||
+    code === "etimedout" ||
+    code.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("timeout")
   );
 }
 


### PR DESCRIPTION
## Why

A production Auto app-builder run completed its scaffold and file write, then an Anthropic continuation exceeded the model-step deadline. The workflow retried the same provider turn repeatedly, leaving the run in Working for more than ten minutes even though a configured OpenAI fallback was available.

## What changed

- classify timeout signals across provider wrapper cause/error chains
- allow Auto Anthropic turns to use the existing OpenAI fallback for genuine timeout responses
- preserve explicit model selection and user cancellation behavior
- keep existing balance, rate-limit, and opaque-stream fallback policy unchanged

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (existing configuration hints only)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `pnpm db:migrate -- --dry-run`
- production reproduction: Auto app-builder run reached a successful file write, then stayed in the same continuation for 10+ minutes with healthy Workflow/DO alarms and no sandbox exception

Production acceptance will be repeated after the exact merged SHA is deployed.