### PR TITLE
fix: stop Next preview configuration churn

### DIFF
--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -24,9 +24,9 @@ import {
 import {
   EXPO_TEMPLATE_DIR,
   NEXT_TEMPLATE_DIR,
-  projectLocalCacheDir,
   projectLocalModulesDir,
   projectLocalRuntimeDir,
+  projectLocalSourceDir,
 } from "./project-sandbox-package-runtime";
 
 export type ProjectSandboxStub = CodeRuntimeContext["sandbox"];
@@ -562,7 +562,6 @@ async function startAppBuilderDevServer(
     }),
     env: {
       CHEATCODE_APP_RUNTIME: "next",
-      CHEATCODE_NEXT_DIST_DIR: "../cache/next",
       CHOKIDAR_USEPOLLING: "true",
       WATCHPACK_POLLING: "1000",
     },
@@ -700,7 +699,7 @@ async function clearBuildCache(
   mobile: boolean,
 ): Promise<void> {
   const workspaceSlug = dir.slice(dir.lastIndexOf("/") + 1);
-  const cacheDir = mobile ? `${dir}/.expo` : `${projectLocalCacheDir(workspaceSlug)}/next`;
+  const cacheDir = mobile ? `${dir}/.expo` : `${projectLocalSourceDir(workspaceSlug)}/.next`;
   await executeShellExec(
     {
       command: ["rm", "-rf", cacheDir],

--- a/apps/agent-worker/src/durable-objects/app-builder-template.ts
+++ b/apps/agent-worker/src/durable-objects/app-builder-template.ts
@@ -77,7 +77,7 @@ export default function Home() {
 }
 
 export function appBuilderTypeScriptConfigSource(workspaceSlug: string): string {
-  const localModules = `/home/node/.cheatcode/projects/${workspaceSlug}/node_modules`;
+  const localModules = `/home/node/.cheatcode/projects/${workspaceSlug}/source/node_modules`;
   const runtimeModules = "/home/node/.cheatcode/app-runtimes/next/node_modules";
   return `${JSON.stringify(
     {
@@ -102,7 +102,14 @@ export function appBuilderTypeScriptConfigSource(workspaceSlug: string): string 
         target: "ES2017",
       },
       exclude: ["node_modules"],
-      include: ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "**/*.mts"],
+      include: [
+        "next-env.d.ts",
+        ".next/types/**/*.ts",
+        ".next/dev/types/**/*.ts",
+        "**/*.mts",
+        "**/*.ts",
+        "**/*.tsx",
+      ],
     },
     null,
     2,

--- a/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
+++ b/apps/agent-worker/src/durable-objects/project-sandbox-package-runtime.ts
@@ -23,12 +23,8 @@ export function projectLocalModulesDir(workspaceSlug: string): string {
   return `${projectLocalSourceDir(workspaceSlug)}/node_modules`;
 }
 
-function projectLocalSourceDir(workspaceSlug: string): string {
+export function projectLocalSourceDir(workspaceSlug: string): string {
   return `${projectLocalRuntimeDir(workspaceSlug)}/source`;
-}
-
-export function projectLocalCacheDir(workspaceSlug: string): string {
-  return `${projectLocalRuntimeDir(workspaceSlug)}/cache`;
 }
 
 export function projectLocalRuntimeDir(workspaceSlug: string): string {
@@ -114,7 +110,7 @@ function packageManagerName(value: string | undefined): string | null {
     : null;
 }
 
-/** Keeps generated dependencies and caches off persistent object-store FUSE. */
+/** Keeps generated dependencies off persistent object-store FUSE. */
 export function projectPackageEnvironment(
   cwd: string,
   requested: Record<string, string> | undefined,
@@ -123,12 +119,10 @@ export function projectPackageEnvironment(
   if (!workspaceSlug) return requested;
   const modulesDir = projectLocalModulesDir(workspaceSlug);
   const requestedNodePath = requested?.["NODE_PATH"];
-  const requestedNextDistDir = requested?.["CHEATCODE_NEXT_DIST_DIR"];
   const preferredRuntime = requested?.["CHEATCODE_APP_RUNTIME"] === "expo" ? "expo" : "next";
   const fallbackRuntime = preferredRuntime === "expo" ? "next" : "expo";
   return {
     ...requested,
-    CHEATCODE_NEXT_DIST_DIR: requestedNextDistDir ?? `${projectLocalCacheDir(workspaceSlug)}/next`,
     NODE_PATH: [
       modulesDir,
       `${APP_RUNTIME_ROOT}/${preferredRuntime}/node_modules`,

--- a/infra/containers/sandbox/app-templates/next/next.config.ts
+++ b/infra/containers/sandbox/app-templates/next/next.config.ts
@@ -1,9 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  // User source is persistent object-store FUSE; generated compiler output belongs
-  // on the sandbox's fast local disk. The managed preview owns this relative path.
-  distDir: process.env["CHEATCODE_NEXT_DIST_DIR"] ?? ".next",
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- keeps Next compiler output in the sandbox-local project mirror, where `.next` remains off Daytona FUSE
- removes the unsupported external `distDir` override that caused Next and the source synchronizer to rewrite `tsconfig.json` repeatedly
- predeclares both Next development and production type paths and corrects the local dependency path

## Architecture
Durable project source remains under `/workspace`. The preview process still runs from `/home/node/.cheatcode/projects/<slug>/source`; its `.next` directory is native-disk-only and is excluded by the one-way synchronizer.

## Decisions Made
| Decision | Choice | Alternative | Reason |
|---|---|---|---|
| compiler output | local mirror `.next` | sibling `../cache/next` | Next.js does not support `distDir` outside the project |
| generated types | declare `.next/types` and `.next/dev/types` | allow Next to mutate config | avoids sync churn between development and build modes |
| dependency paths | point at `source/node_modules` | stale runtime-root path | matches the actual native package runtime layout |

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (only existing configuration hints)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `pnpm db:migrate -- --dry-run`

## Production Acceptance
After merge and sandbox snapshot promotion, run ordinary-user web and mobile app prompts on `trycheatcode.com`, measure preparation/preview timing, exercise the requested interactions, and inspect browser/Workflow state.