### PR TITLE
chore(sandbox): promote next preview snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-524842b2b711-31581198909",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-37f59ece8fbb-31586870644",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Promote the immutable Daytona sandbox candidate that contains the native Next.js cache/source-layout fix from #248. This makes new and automatically replaced production runtimes use the verified image.

## Change

- Point `DAYTONA_SANDBOX_SNAPSHOT` at `cheatcode-sandbox-viewer-bundle-37f59ece8fbb-31586870644`.
- Candidate source commit: `37f59ece8fbbffdd6904ecb99df5cddd62817cf1`.
- Snapshot build/scan/smoke/publication: https://github.com/cheatcode-ai/cheatcode/actions/runs/31586870644

No database, secret, API, or user-file boundary changes. Existing workspace data remains on the durable Daytona volume; runtime identity checks replace stale containers safely.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (only existing configuration hints)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `pnpm db:migrate -- --dry-run`
- Candidate verified active through the Daytona CLI with no error reason.

Production browser acceptance will run after the reviewed promotion is merged and the exact main revision is deployed.