### PR TITLE
chore(sandbox): promote deterministic browser snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-37f59ece8fbb-31586870644",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-c40cc4bf98ad-31591245281",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Summary
- Promote the immutable Daytona snapshot produced from merged browser tooling commit c40cc4bf98ad.
- Route production sandbox reconciliation to the image that passed the build, Trivy scan, runtime smoke test, publication, and active-state verification.

## Architecture
The Worker remains the reviewed source of truth for the snapshot identifier. Existing project sandboxes reconcile through the normal lifecycle path; no provider state is mutated out of band.

## Decisions Made
| Decision | Choice | Alternative | Reasoning |
|---|---|---|---|
| Promotion path | Versioned wrangler configuration | Direct provider mutation | Keeps deployment reproducible and reviewable. |
| Snapshot | cheatcode-sandbox-viewer-bundle-c40cc4bf98ad-31591245281 | Reuse prior image | This exact artifact contains the deterministic browser observe/act implementation. |

## Verification
- [x] Build Sandbox Snapshot workflow 31591245281 passed
- [x] Candidate image scan passed
- [x] Candidate runtime smoke test passed
- [x] Published snapshot verified active with zero provider retries
- [x] `pnpm architecture:check`
- [ ] Deploy Cloudflare Workers after merge
- [ ] Exercise ordinary-user web, mobile, and non-app production flows

## Related
- Browser root fix: #250