### PR TITLE
chore(sandbox): promote browser state snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-c40cc4bf98ad-31591245281",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-2b8400f38fd3-31594414380",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Production must reference the immutable Daytona snapshot that contains the browser post-action state fix from #252. The candidate was built from the exact merged commit and passed the protected snapshot workflow before this configuration change.

## What changed

- Promote `DAYTONA_SANDBOX_SNAPSHOT` to `cheatcode-sandbox-viewer-bundle-2b8400f38fd3-31594414380`.
- No runtime code, schema, environment contract, or migration changes.

## Verification

- `pnpm architecture:check`
- `git diff --check`
- Immutable snapshot workflow [31594414380](https://github.com/cheatcode-ai/cheatcode/actions/runs/31594414380): build, Trivy scan, runtime smoke test, publication, and activation all passed; zero transient provider retries.

## Production follow-up

After merge, deploy Cloudflare and run natural-language web, mobile, and non-app acceptance flows against the promoted snapshot.