### PR TITLE
fix(sandbox): align Expo snapshot acceptance

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -380,7 +380,7 @@ jobs:
               /home/node/.cheatcode/app-runtimes/expo/node_modules
             expo_bundle="$expo_test_dir/entry.bundle.js"
             fetch_expo_bundle "$expo_bundle"
-            grep --fixed-strings --quiet "Welcome to" "$expo_bundle"
+            grep --fixed-strings --quiet "cheatcode" "$expo_bundle"
             expo_dom="$expo_test_dir/expo-dom.html"
             expo_chrome_log="$expo_test_dir/chromium.log"
             if ! timeout 30 "$CHROME_PATH" \
@@ -394,7 +394,7 @@ jobs:
               sed -n "1,240p" "$expo_chrome_log" >&2
               exit 1
             fi
-            if ! grep --fixed-strings --quiet "Welcome to" "$expo_dom"; then
+            if ! grep --fixed-strings --quiet "cheatcode" "$expo_dom"; then
               sed -n "1,240p" "$expo_log" >&2
               sed -n "1,240p" "$expo_chrome_log" >&2
               sed -n "1,240p" "$expo_dom" >&2
@@ -402,10 +402,10 @@ jobs:
             fi
             expo_watch_source="$(
               grep --recursive --files-with-matches --fixed-strings \
-                "Welcome to" "$expo_source/src/app" | head -n 1
+                "cheatcode" "$expo_source/src/app" | head -n 1
             )"
             test -n "$expo_watch_source"
-            sed -i "s/Welcome to/Metro watcher refreshed/" "$expo_watch_source"
+            sed -i "s/cheatcode/Metro watcher refreshed/" "$expo_watch_source"
             expo_watch_bundle="$expo_test_dir/entry-watch.bundle.js"
             expo_watch_attempt=0
             until fetch_expo_bundle "$expo_watch_bundle" && \

--- a/infra/containers/sandbox/Dockerfile
+++ b/infra/containers/sandbox/Dockerfile
@@ -124,6 +124,10 @@ ENV DISPLAY=:99
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
 ENV CHROME_PATH=/usr/local/bin/cheatcode-chromium
 ENV NODE_PATH=/opt/cheatcode-doc-runtime/node_modules:/opt/cheatcode-skill-runtime/node_modules
+# Sandboxes serve Expo programmatically. Headless mode disables interactive
+# discovery and the background React Native DevTools binary installation.
+ENV EXPO_NO_TELEMETRY=1
+ENV EXPO_UNSTABLE_HEADLESS=1
 COPY browser-driver /opt/cheatcode-browser-driver
 WORKDIR /opt/cheatcode-browser-driver
 RUN npm ci --omit=dev --no-audit --no-fund \

--- a/infra/containers/sandbox/README.md
+++ b/infra/containers/sandbox/README.md
@@ -113,6 +113,9 @@ reviewed Expo template's source aliases while adding only the disposable local a
 dependency locations. Snapshot smoke testing runs that same helper, compiles the
 real Expo Router bundle, and renders the template in headless Chromium; a listening Metro port
 without an executable app is not considered healthy.
+The image also declares Expo's non-interactive headless mode. Sandboxed preview servers do not
+need local-device discovery or a standalone React Native DevTools shell, so those background
+network and binary-install side effects are disabled for every generated mobile project.
 Direct pnpm invocations execute inside one `flock`-guarded transaction; process death
 releases that lock automatically, and successful source changes commit only after a
 three-way conflict check against the durable tree. Long-lived previews invoke the same helper as


### PR DESCRIPTION
## Summary
- Verify the repository-owned Cheatcode wordmark instead of the removed upstream Expo demo copy.
- Keep live Metro refresh coverage by replacing and observing that same source marker.
- Run Expo preview servers in their supported non-interactive headless mode so Daytona does not install or launch a desktop React Native DevTools shell.

## Root cause
The FUSE-safe scaffold rendered correctly, but the protected snapshot smoke still searched for `Welcome to`, a string from Expo's removed demo template. Expo also treated the programmatic server as interactive and attempted a background desktop DevTools installation, producing a non-fatal sandbox warning.

## Decisions made
| Decision | Choice | Reasoning |
|---|---|---|
| Render marker | Visible `cheatcode` wordmark | It is owned by the checked-in scaffold and proves the actual route rendered. |
| Source refresh marker | Replace the same wordmark in the copied source | This continues to verify Metro watches the persistent `/workspace` source. |
| Expo process mode | Image-level `EXPO_UNSTABLE_HEADLESS=1` and telemetry disabled | Every sandbox preview is programmatically managed; local-device discovery and a desktop debugger shell are irrelevant side effects. |

## Verification
- [x] `pnpm lint`
- [x] `pnpm architecture:check`
- [x] `pnpm deadcode`
- [x] `git diff --check`
- [ ] Protected snapshot build, FUSE copy, Expo render, and live-refresh smoke after merge
