### PR TITLE
chore(sandbox): promote FUSE-safe mobile snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-2b8400f38fd3-31594414380",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-eb44a8124bfb-31601276600",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

Production mobile projects were still created from the older sandbox snapshot, so the merged FUSE-safe Expo bootstrap was not yet active for users.

## What changed

- Promotes the immutable Daytona snapshot `cheatcode-sandbox-viewer-bundle-eb44a8124bfb-31601276600`.
- Changes only the agent worker snapshot binding.
- Keeps publication and promotion separate: the candidate was built and tested before this reviewable configuration change.

## Provenance

- Source commit: `eb44a8124bfb677c8bb4e3ab4fac9446f8c19b80`
- Protected snapshot build: https://github.com/cheatcode-ai/cheatcode/actions/runs/31601276600
- Snapshot publication retries: 0

The protected smoke copied the exact minimal Expo template through the durable `/workspace` mount, resolved the prebuilt runtime, verified the initial bundle and rendered DOM, observed a Metro live refresh, and confirmed source synchronization.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `git diff --check`

## Deployment impact

No schema or secret changes. Merging deploys the agent worker with the new immutable snapshot name. A fresh production mobile-project flow will be exercised after deployment.