### PR TITLE
fix: restart previews after dependency changes

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -321,6 +321,11 @@ jobs:
             test ! -e /home/node/cheatcode-expo-template/assets
             test -x /home/node/.cheatcode/app-runtimes/next/node_modules/.bin/next
             test -x /home/node/.cheatcode/app-runtimes/expo/node_modules/.bin/expo
+            test ! -w /home/node/.cheatcode/app-runtimes/next/package.json
+            test ! -w /home/node/.cheatcode/app-runtimes/expo/package.json
+            test ! -w /home/node/.cheatcode/app-runtimes/next/node_modules
+            test ! -w /home/node/.cheatcode/app-runtimes/expo/node_modules
+            test -z "$(find /home/node/.cheatcode/app-runtimes -not -type l -perm /022 -print -quit)"
             NODE_PATH=/home/node/.cheatcode/app-runtimes/next/node_modules node -e "require.resolve(\"next\");require.resolve(\"react\");require.resolve(\"react-dom\")"
             NODE_PATH=/home/node/.cheatcode/app-runtimes/expo/node_modules node -e "require.resolve(\"expo\");require.resolve(\"react-native-web\");require.resolve(\"@expo/metro-runtime\")"
 
@@ -343,7 +348,6 @@ jobs:
             (
               cd "$expo_source"
               /opt/cheatcode/configure-expo-runtime.mjs \
-                "$expo_mirror/node_modules" \
                 /home/node/.cheatcode/app-runtimes/expo/node_modules
             )
             fetch_expo_bundle() {
@@ -381,6 +385,50 @@ jobs:
             expo_bundle="$expo_test_dir/entry.bundle.js"
             fetch_expo_bundle "$expo_bundle"
             grep --fixed-strings --quiet "cheatcode" "$expo_bundle"
+            expo_sync_pid="$(pgrep -P "$expo_pid" -f "project-source-sync.py preview-loop" | head -n 1)"
+            expo_app_pid="$(pgrep -P "$expo_pid" | grep -v "$expo_sync_pid" | head -n 1)"
+            test -n "$expo_sync_pid"
+            test -n "$expo_app_pid"
+            generation_before="$(cat "$expo_test_dir/dependency-generation" 2>/dev/null || true)"
+            /opt/cheatcode/project-source-sync.py package-run \
+              "$expo_source" "$expo_mirror" "$expo_lock" "$expo_mirror" -- \
+              pnpm exec tsc --noEmit
+            test -L "$expo_mirror/node_modules"
+            test "$(readlink -f "$expo_mirror/node_modules")" = \
+              /home/node/.cheatcode/app-runtimes/expo/node_modules
+            test "$(cat "$expo_test_dir/dependency-generation" 2>/dev/null || true)" = \
+              "$generation_before"
+            test "$(pgrep -P "$expo_pid" | grep -v "$expo_sync_pid" | head -n 1)" = \
+              "$expo_app_pid"
+            fetch_expo_bundle "$expo_bundle"
+            grep --fixed-strings --quiet "cheatcode" "$expo_bundle"
+
+            /opt/cheatcode/project-source-sync.py package-run \
+              "$expo_source" "$expo_mirror" "$expo_lock" "$expo_mirror" -- \
+              pnpm install --frozen-lockfile --offline
+            test ! -L "$expo_mirror/node_modules"
+            test -f "$expo_mirror/node_modules/.cheatcode-dependency-state"
+            test -n "$(cat "$expo_test_dir/dependency-generation")"
+            expo_restart_attempt=0
+            while [ "$(pgrep -P "$expo_pid" | grep -v "$expo_sync_pid" | head -n 1)" = \
+              "$expo_app_pid" ]; do
+              if ! kill -0 "$expo_pid" 2>/dev/null || [ "$expo_restart_attempt" -ge 30 ]; then
+                sed -n "1,240p" "$expo_log" >&2
+                exit 1
+              fi
+              sleep 1
+              expo_restart_attempt=$((expo_restart_attempt + 1))
+            done
+            expo_restart_attempt=0
+            until fetch_expo_bundle "$expo_bundle" && \
+              grep --fixed-strings --quiet "cheatcode" "$expo_bundle"; do
+              if ! kill -0 "$expo_pid" 2>/dev/null || [ "$expo_restart_attempt" -ge 30 ]; then
+                sed -n "1,240p" "$expo_log" >&2
+                exit 1
+              fi
+              sleep 1
+              expo_restart_attempt=$((expo_restart_attempt + 1))
+            done
             expo_dom="$expo_test_dir/expo-dom.html"
             expo_chrome_log="$expo_test_dir/chromium.log"
             if ! timeout 30 "$CHROME_PATH" \

--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -192,7 +192,13 @@ dependency tree, and build cache are disposable;
 wake and restart reconstruct them from the durable project without changing the Files surface.
 Persisted pnpm-backed preview commands restore a missing sandbox-local dependency tree before the
 server starts. Exact scaffold manifests link the disposable mirror to the matching immutable runtime
-dependency tree; the package boundary detaches that link before any dependency mutation. A
+dependency tree. That shared runtime is image-owned and read-only. Read-only pnpm validation and
+script commands disable pnpm's pre-run dependency verification and keep the link intact, while the
+package boundary detaches it before a dependency mutation. Dependency mutations advance a
+generation under the same package lock; the native preview supervisor observes that generation and
+restarts only the app child after the transaction releases the lock, preserving its process session,
+source synchronizer, and signed launch environment. Metro and other long-lived resolvers therefore
+never retain a module graph from before an install. A
 package/lock/config digest skips the install entirely when a project-local dependency tree is current;
 automatic preview restoration does not create a durable lockfile.
 The app-builder harness launches its already-resolved native-mirror command directly through the
@@ -204,8 +210,8 @@ and making the snapshot the source of truth for executable sandbox runtime code.
 Direct pnpm commands use that same native-disk source as one OS-locked transaction: the runtime
 snapshots the durable source, executes pnpm locally without a shell, and copies only command-produced
 source changes back after verifying that the corresponding durable paths did not change concurrently.
-The kernel releases the lock if the request or package process dies, so preview synchronization cannot
-be stranded behind a stale marker. Long-running pnpm
+The kernel releases the lock if the request or package process dies, so preview synchronization and
+dependency-generation restarts cannot be stranded behind a stale marker. Long-running pnpm
 processes keep the durable-to-local mirror alive for hot reload. Shell-wrapped package managers are
 rejected because they cannot participate in this synchronization boundary; npm, Yarn, and Bun stay
 disabled for project workspaces.

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder-scaffold.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder-scaffold.ts
@@ -19,7 +19,6 @@ import {
   EXPO_TEMPLATE_DIR,
   NEXT_RUNTIME_BIN,
   NEXT_TEMPLATE_DIR,
-  projectLocalModulesDir,
 } from "./project-sandbox-package-runtime";
 
 type ProjectSandboxStub = CodeRuntimeContext["sandbox"];
@@ -164,7 +163,6 @@ export async function ensureAppBuilderRuntime(
 export async function ensureExpoWebSupport(
   sandbox: ProjectSandboxStub,
   dir: string,
-  workspaceSlug: string,
 ): Promise<void> {
   try {
     await executeShellExec(
@@ -185,11 +183,7 @@ export async function ensureExpoWebSupport(
   }
   await executeShellExec(
     {
-      command: [
-        EXPO_RUNTIME_CONFIG_BIN,
-        projectLocalModulesDir(workspaceSlug),
-        `${EXPO_RUNTIME_DIR}/node_modules`,
-      ],
+      command: [EXPO_RUNTIME_CONFIG_BIN, `${EXPO_RUNTIME_DIR}/node_modules`],
       cwd: dir,
       timeoutMs: 15_000,
     },

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -226,7 +226,7 @@ async function prepareTemplateWorkspace(
       await installAppBuilderDependencies(sandbox, logger, workspace.dir, mobile);
     }
     if (mobile) {
-      await ensureExpoWebSupport(sandbox, workspace.dir, workspace.slug);
+      await ensureExpoWebSupport(sandbox, workspace.dir);
     }
     return;
   }
@@ -239,7 +239,7 @@ async function prepareTemplateWorkspace(
   }
   throwIfRunCanceled(options.abortSignal);
   if (mobile) {
-    await ensureExpoWebSupport(sandbox, workspace.dir, workspace.slug);
+    await ensureExpoWebSupport(sandbox, workspace.dir);
   } else {
     await setRunStage("Seeding the starter files.");
     await writeAppBuilderFiles(input, sandbox, workspace.dir);

--- a/infra/containers/sandbox/Dockerfile
+++ b/infra/containers/sandbox/Dockerfile
@@ -275,6 +275,7 @@ COPY scripts/ /opt/cheatcode/
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod -R a+rx /opt/cheatcode \
   && chmod a+rx /entrypoint.sh \
+  && chown -R root:root /home/node/.cheatcode/app-runtimes \
   && useradd --create-home --home-dir /home/cheatcode-browser \
     --shell /usr/sbin/nologin cheatcode-browser \
   && chmod 0700 /home/cheatcode-browser \

--- a/infra/containers/sandbox/README.md
+++ b/infra/containers/sandbox/README.md
@@ -92,8 +92,10 @@ sandbox-local runtimes in the image. Project creation copies only source and con
 the persistent Daytona volume; dependency trees and generated compiler caches stay on
 the sandbox's local filesystem, avoiding slow, partial writes to object-store FUSE.
 Exact scaffold projects link their disposable native-disk mirror to the matching immutable
-runtime dependency tree, avoiding both package copies and installs during startup. The helper
-detaches that link before a package mutation or non-template restore; additional dependencies then
+runtime dependency tree, avoiding both package copies and installs during startup. That tree is
+root-owned and read-only. Read-only validation and project-script commands keep its link intact and
+disable pnpm's pre-run auto-install, while the helper detaches the link before a package mutation or
+non-template restore; additional dependencies then
 use a project-scoped local modules directory and can be restored from the reviewed package store
 after a sandbox replacement. The minimal Expo scaffold intentionally contains no
 generated images: only manifests and the starter route cross the persistent object-store
@@ -109,8 +111,8 @@ It uses content hashes and atomic replacement on native disk. Writes back to Day
 object-store FUSE use direct overwrite plus checksum verification because that mount does
 not implement replacement renames or portable chmod semantics.
 The adjacent root-owned `/opt/cheatcode/configure-expo-runtime.mjs` helper preserves the
-reviewed Expo template's source aliases while adding only the disposable local and immutable
-dependency locations. Snapshot smoke testing runs that same helper, compiles the
+reviewed Expo template's source aliases while pinning its TypeScript base configuration to the
+immutable runtime. Snapshot smoke testing runs that same helper, compiles the
 real Expo Router bundle, and renders the template in headless Chromium; a listening Metro port
 without an executable app is not considered healthy.
 The image also declares Expo's non-interactive headless mode. Sandboxed preview servers do not
@@ -135,6 +137,14 @@ preview disables pnpm's redundant pre-script auto-install because the helper has
 and digested that exact dependency state under the project lock. The Worker therefore does
 not transport an executable shell wrapper or make trusted bootstrap commands indistinguishable from
 model-supplied shell input.
+
+A dependency mutation advances a generation while holding the package lock. The long-lived preview
+supervisor waits for that transaction to release the lock, then replaces only its app child while
+retaining the source synchronizer and original signed environment. Metro and other module resolvers
+therefore cannot keep serving the dependency graph they cached before an install. The protected
+snapshot smoke exercises both contracts: `pnpm exec tsc` must preserve the immutable runtime and
+running Metro process, while an offline install must create a project-local dependency tree, restart
+Metro, and compile the application bundle again.
 
 Open VSX currently publishes Parquet Viewer 3.1.0 with vulnerable Thrift and WebSocket
 runtimes. The image keeps the extension feature but replaces those two runtime packages

--- a/infra/containers/sandbox/scripts/configure-expo-runtime.mjs
+++ b/infra/containers/sandbox/scripts/configure-expo-runtime.mjs
@@ -3,9 +3,9 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { isAbsolute, join } from "node:path";
 
-const [localModules, runtimeModules] = process.argv.slice(2);
-if (!localModules || !runtimeModules || !isAbsolute(localModules) || !isAbsolute(runtimeModules)) {
-  throw new TypeError("Expo runtime configuration requires absolute local and immutable module paths");
+const [runtimeModules] = process.argv.slice(2);
+if (!runtimeModules || !isAbsolute(runtimeModules)) {
+  throw new TypeError("Expo runtime configuration requires an absolute immutable module path");
 }
 
 const configPath = join(process.cwd(), "tsconfig.json");
@@ -14,19 +14,9 @@ if (!isRecord(config)) {
   throw new TypeError("Expo tsconfig.json must contain a JSON object");
 }
 
-const compilerOptions = isRecord(config.compilerOptions) ? config.compilerOptions : {};
-const paths = isRecord(compilerOptions.paths) ? compilerOptions.paths : {};
-
-// The checksum-pinned Expo template owns its source aliases. Runtime configuration only adds the
-// disposable dependency locations; replacing the alias map would silently break template imports.
+// The checksum-pinned Expo template owns its source aliases. Node's normal module resolution follows
+// the project node_modules link, so TypeScript needs only the immutable Expo base configuration.
 config.extends = join(runtimeModules, "expo/tsconfig.base");
-config.compilerOptions = {
-  ...compilerOptions,
-  paths: {
-    ...paths,
-    "*": [`${localModules}/*`, `${runtimeModules}/*`],
-  },
-};
 
 await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`);
 

--- a/infra/containers/sandbox/scripts/project-source-sync.py
+++ b/infra/containers/sandbox/scripts/project-source-sync.py
@@ -4,6 +4,7 @@
 import errno
 import fcntl
 import hashlib
+import json
 import os
 import shutil
 import signal
@@ -19,7 +20,20 @@ LOCAL_ONLY_NAMES = IGNORED_DIRS | {"next-env.d.ts"}
 PACKAGE_CONFLICT_EXIT = 74
 PREVIEW_SYNC_FAILURE_EXIT = 75
 DEPENDENCY_STATE_FILENAME = ".cheatcode-dependency-state"
+DEPENDENCY_GENERATION_FILENAME = "dependency-generation"
 PNPM_BUILD_POLICY_BINARY = "/opt/cheatcode/pnpm-build-policy.mjs"
+READ_ONLY_PNPM_COMMANDS = {
+    "exec",
+    "list",
+    "ls",
+    "outdated",
+    "root",
+    "run",
+    "run-script",
+    "start",
+    "test",
+    "why",
+}
 PREVIEW_SYNC_INTERVAL_SECONDS = 0.25
 SOURCE_FAILURE_GRACE_SECONDS = 10
 SOURCE_READ_RETRY_DELAYS_SECONDS = (0.05, 0.1, 0.2)
@@ -279,8 +293,22 @@ def package_run(source, target, lock_path, local_cwd, command):
         fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
         sync_directory(source, target)
         baseline = tree_state(target)
-        detach_runtime_dependencies(local_cwd)
-        completed = subprocess.run(command, cwd=local_cwd, check=False)
+        preserve_dependencies = pnpm_command_is_read_only(local_cwd, command)
+        dependencies_before = dependency_runtime_state(local_cwd, target)
+        if not preserve_dependencies:
+            publish_dependency_generation(lock_path)
+            detach_runtime_dependencies(local_cwd)
+        command_environment = os.environ.copy()
+        if preserve_dependencies:
+            command_environment["pnpm_config_verify_deps_before_run"] = "false"
+        completed = subprocess.run(
+            command,
+            cwd=local_cwd,
+            env=command_environment,
+            check=False,
+        )
+        if preserve_dependencies and dependency_runtime_state(local_cwd, target) != dependencies_before:
+            publish_dependency_generation(lock_path)
         if completed.returncode != 0:
             return completed.returncode
         record_dependency_state(local_cwd, target)
@@ -329,6 +357,80 @@ def dependency_state_path(local_cwd):
     return os.path.join(local_cwd, "node_modules", DEPENDENCY_STATE_FILENAME)
 
 
+def dependency_generation_path(lock_path):
+    return os.path.join(os.path.dirname(lock_path), DEPENDENCY_GENERATION_FILENAME)
+
+
+def read_dependency_generation(lock_path):
+    try:
+        with open(dependency_generation_path(lock_path), "r", encoding="ascii") as source:
+            return source.read().strip()
+    except (FileNotFoundError, OSError, UnicodeError):
+        return ""
+
+
+def publish_dependency_generation(lock_path):
+    target = dependency_generation_path(lock_path)
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=".cheatcode-dependency-generation-",
+        dir=os.path.dirname(target),
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="ascii") as output:
+            output.write(f"{time.time_ns()}-{os.getpid()}\n")
+        os.replace(temporary, target)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+
+
+def pnpm_command_is_read_only(local_cwd, command):
+    if not command:
+        return False
+    executable = os.path.basename(command[0])
+    if executable == "pnpx":
+        return True
+    subcommand = next(
+        (argument for argument in command[1:] if argument != "--" and not argument.startswith("-")),
+        "",
+    )
+    if subcommand in READ_ONLY_PNPM_COMMANDS:
+        return True
+    try:
+        with open(os.path.join(local_cwd, "package.json"), "r", encoding="utf-8") as source:
+            manifest = json.load(source)
+    except (FileNotFoundError, OSError, UnicodeError, json.JSONDecodeError):
+        return False
+    if not isinstance(manifest, dict):
+        return False
+    scripts = manifest.get("scripts", {})
+    return isinstance(scripts, dict) and subcommand in scripts
+
+
+def dependency_runtime_state(local_cwd, local_root):
+    modules = os.path.join(local_cwd, "node_modules")
+    if os.path.islink(modules):
+        modules_state = ("link", os.path.realpath(modules))
+    elif not os.path.isdir(modules):
+        modules_state = ("missing",)
+    else:
+        entries = []
+        for entry in sorted(os.scandir(modules), key=lambda value: value.name):
+            if entry.is_symlink():
+                entries.append((entry.name, "link", os.readlink(entry.path)))
+            elif entry.name in {".modules.yaml", DEPENDENCY_STATE_FILENAME} and entry.is_file(
+                follow_symlinks=False
+            ):
+                entries.append((entry.name, "file", file_digest(entry.path)))
+            else:
+                entries.append((entry.name, "entry"))
+        modules_state = ("directory", tuple(entries))
+    return (dependency_state(local_cwd, local_root), modules_state)
+
+
 def dependencies_are_current(local_cwd, local_root):
     modules = os.path.join(local_cwd, "node_modules")
     if os.path.islink(modules):
@@ -343,7 +445,7 @@ def dependencies_are_current(local_cwd, local_root):
 
 def record_dependency_state(local_cwd, local_root):
     modules = os.path.join(local_cwd, "node_modules")
-    if not os.path.isdir(modules):
+    if os.path.islink(modules) or not os.path.isdir(modules):
         return
     descriptor, temporary = tempfile.mkstemp(prefix=".cheatcode-dependency-", dir=modules)
     try:
@@ -512,6 +614,7 @@ def preview_run(source, target, lock_path, local_cwd, dependency_runtime, comman
         dependency_status = restore_pnpm_dependencies(local_cwd, target, dependency_runtime)
         if dependency_status != 0:
             return dependency_status
+        observed_dependency_generation = read_dependency_generation(lock_path)
 
     sync_process = subprocess.Popen(
         [sys.executable, os.path.realpath(__file__), "preview-loop", source, target, lock_path],
@@ -529,13 +632,18 @@ def preview_run(source, target, lock_path, local_cwd, dependency_runtime, comman
             previous_handlers[signal_number] = signal.signal(signal_number, terminate_children)
         app_environment = os.environ.copy()
         app_environment["pnpm_config_verify_deps_before_run"] = "false"
-        app_process = subprocess.Popen(
-            command,
-            cwd=local_cwd,
-            env=app_environment,
-            start_new_session=True,
-        )
+        app_process = start_preview_app(command, local_cwd, app_environment)
         while True:
+            dependency_generation = read_dependency_generation(lock_path)
+            if dependency_generation != observed_dependency_generation:
+                with open_lock(lock_path) as lock:
+                    fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+                    dependency_generation = read_dependency_generation(lock_path)
+                    if dependency_generation != observed_dependency_generation:
+                        stop_process(app_process)
+                        reap_process(app_process)
+                        app_process = start_preview_app(command, local_cwd, app_environment)
+                        observed_dependency_generation = dependency_generation
             app_status = app_process.poll()
             if app_status is not None:
                 return app_status
@@ -556,6 +664,15 @@ def preview_run(source, target, lock_path, local_cwd, dependency_runtime, comman
         reap_process(sync_process)
         for signal_number, handler in previous_handlers.items():
             signal.signal(signal_number, handler)
+
+
+def start_preview_app(command, local_cwd, environment):
+    return subprocess.Popen(
+        command,
+        cwd=local_cwd,
+        env=environment,
+        start_new_session=True,
+    )
 
 
 def main():


### PR DESCRIPTION
## Summary\n- Keep snapshot dependency runtimes image-owned and read-only.\n- Preserve the shared runtime for read-only pnpm validation and project scripts.\n- Restart only the preview app after a locked dependency mutation so Metro cannot retain a stale module graph.\n- Extend protected snapshot smoke coverage through both dependency paths.\n\n## Architecture\nThe package transaction publishes a dependency generation under the existing project package lock. The native preview supervisor observes that generation, waits for the transaction, and replaces only its app child while retaining source synchronization and the signed launch environment.\n\n## Decisions Made\n| Decision | Choice | Reasoning |\n|---|---|---|\n| Shared dependencies | Root-owned immutable runtime | Prevent project commands from mutating snapshot state |\n| Read-only commands | Disable pnpm pre-run dependency verification | Avoid an implicit install replacing the runtime link |\n| Dependency changes | Generation event under package lock | Make mutation and restart one coordinated lifecycle |\n| Preview recovery | Supervisor-owned app-child restart | Preserve the durable process session and signed environment |\n\n## Edge Cases\n- A read-only command that unexpectedly changes dependency topology still advances the generation.\n- A failed dependency mutation still invalidates the old resolver before it can continue serving stale state.\n- Process death releases the kernel lock, so preview recovery cannot be stranded.\n\n## Verification\n- pnpm lint\n- pnpm typecheck\n- pnpm turbo build --force\n- pnpm deadcode\n- pnpm architecture:check\n- pnpm turbo skills:build\n- git diff --check\n- Built the final AMD64 sandbox image locally.\n- Verified read-only tsc preserves the runtime symlink and Metro PID.\n- Verified offline pnpm install creates a local tree, advances the generation, restarts Metro, and recompiles the Expo bundle.\n- Verified all non-symlink runtime files are non-writable to the sandbox user.