### PR TITLE
chore: promote verified Daytona snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-eb44a8124bfb-31601276600",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-cc233955706e-31614658830",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Summary
- Promote the immutable Daytona snapshot built from main commit `cc233955706e562dbb2b88e2e6ef8c71f6ae41e5`.
- Move production sandbox creation to `cheatcode-sandbox-viewer-bundle-cc233955706e-31614658830`.

## Provenance
- Source PR: #257
- Snapshot workflow: https://github.com/cheatcode-ai/cheatcode/actions/runs/31614658830
- Source commit: `cc233955706e562dbb2b88e2e6ef8c71f6ae41e5`
- Provider publication retries: 0

## Verification
- Candidate image build passed.
- Trivy configuration and image scan passed.
- Protected runtime smoke passed, including Expo bundle rendering, read-only TypeScript validation, dependency mutation, Metro restart, and post-restart bundle compilation.
- Daytona publication and active-state verification passed.
- Promotion branch: lint, typecheck, forced production build, dead-code analysis, architecture check, skills build, and diff check passed.
