### PR TITLE
fix: strengthen model fallback heading

### DIFF
--- a/apps/web/src/components/chat/message-parts.tsx
+++ b/apps/web/src/components/chat/message-parts.tsx
@@ -213,7 +213,7 @@ function ModelFallbackBlock({ data }: { data: ModelFallbackData }) {
   return (
     <MessageStatusShell>
       <div className="text-[11px] text-thread-text-secondary">
-        <div className="mb-1 text-[10px] text-thread-text-muted">model fallback</div>
+        <div className="mb-1 font-medium text-[12px] text-thread-text-muted">Model Fallback</div>
         <div className="text-thread-text-primary">
           Switched from {data.fromModel} to {data.toModel}
         </div>


### PR DESCRIPTION
## Summary
- capitalizes the fallback heading as “Model Fallback”
- increases the heading to 12px with medium weight for clearer hierarchy
- preserves the shared double-shell status surface and all supporting copy sizing

## Architecture
This remains presentation-only inside the existing `ModelFallbackBlock`. No status schema, model routing, or deployment boundary changes.

## Decision
The heading receives the emphasis rather than increasing every line, keeping the operational details compact while making the card purpose immediately scannable.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- `git diff --check`
- production browser QA after merge
