### PR TITLE
chore: promote verified app-builder sandbox snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-cc233955706e-31614658830",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-f03165e3611a-31633499092",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Summary
- promote the immutable Daytona snapshot built from main commit `f03165e3611a`
- activate the complete Next scaffold, production-build contract, and existing Expo runtime smokes for newly provisioned user sandboxes

## Candidate evidence
- Snapshot: `cheatcode-sandbox-viewer-bundle-f03165e3611a-31633499092`
- Build workflow: https://github.com/cheatcode-ai/cheatcode/actions/runs/31633499092
- Image build: passed
- Trivy configuration, vulnerability, and secret scans: passed
- Next native-mirror production build: passed
- Expo/Metro preview and hot-reload smoke: passed
- Daytona publication and active-state verification: passed

## Verification
- [x] `pnpm lint`
- [x] `pnpm --filter @cheatcode/agent-worker typecheck`
- [x] `pnpm --filter @cheatcode/agent-worker build`
- [x] immutable candidate workflow
