### PR TITLE
fix(agent): keep browser tool schema object-based

### DIFF
--- a/packages/agent-core/src/tools/browser/browser-action-contract-support.ts
+++ b/packages/agent-core/src/tools/browser/browser-action-contract-support.ts
@@ -61,11 +61,27 @@ export const BrowserBoundActionSchema = z.union([
   }),
 ]);
 
-// Provider and driver share one method-specific contract. Placeholder nulls add no runtime safety
-// and are emitted inconsistently across otherwise compatible model transports.
-export const BrowserActInputSchema = BrowserBoundActionSchema.describe(
-  "One method-specific action using an exact ref from the latest browser tree.",
-);
+// Tool providers require a top-level object schema. Keep the provider-facing shape object-based,
+// then narrow it to the driver's method-specific union before crossing the sandbox boundary.
+export const BrowserActInputSchema = z
+  .strictObject({
+    method: BrowserActionMethodSchema.describe("Deterministic action to perform on the ref."),
+    ref: BrowserElementRefSchema,
+    targetRef: BrowserElementRefSchema.optional().describe(
+      "Destination ref. Required only for dragAndDrop; omit for every other method.",
+    ),
+    value: z
+      .string()
+      .max(2_000)
+      .optional()
+      .describe(
+        "Text, key, option, or percentage. Required for fill, press, scrollTo, selectOptionFromDropdown, and type; omit otherwise.",
+      ),
+  })
+  .refine((input) => BrowserBoundActionSchema.safeParse(input).success, {
+    message: "The selected browser method requires its exact method-specific fields.",
+  })
+  .describe("One method-specific action using an exact ref from the latest browser tree.");
 
 export function browserBoundActionFromInput(
   input: z.infer<typeof BrowserActInputSchema>,


### PR DESCRIPTION
## Why

Anthropic rejects top-level union tool schemas before inference. The browser action contract became a Zod union, which serialized without a top-level JSON Schema object and caused every app-builder run to retry the same deterministic provider error for roughly 42 seconds before failing.

## What changed

- expose one strict top-level object schema to model providers
- retain method-specific validation against the canonical browser driver union
- omit placeholder null fields while preserving exact action requirements

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- converted the tool schema with Zod and verified `type: object`
- verified click/fill inputs pass and incomplete/unknown-field inputs fail

Production browser acceptance will run after merge and deployment.