### PR TITLE
perf: show project progress before sandbox preparation

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -105,6 +105,10 @@ the Daytona adapter normalizes the provider's structured `503` response to an in
 then the lifecycle verifies the active-run lease and canonical volume mount before replacing the
 stopped container on the same isolated workspace-volume subpath. This preserves user files while
 avoiding an indefinite dependency on one unhealthy runner.
+Project materialization publishes its durable project-created event immediately after the database
+commit, before waiting on Daytona workspace preparation. The workspace directory operation is
+itself the sandbox readiness boundary; app-builder preparation does not issue a second synthetic
+code-execution probe after that operation succeeds.
 Provider output-length termination is nonterminal: the Workflow checkpoints the partial model turn,
 adds an internal continuation message, and resumes from that durable state. A tool-free turn completes
 the run only when the model reports an actual stop; content filtering, provider errors, and invalid

--- a/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-app-builder.ts
@@ -29,8 +29,8 @@ import {
   projectLocalSourceDir,
 } from "./project-sandbox-package-runtime";
 
-export type ProjectSandboxStub = CodeRuntimeContext["sandbox"];
-export type AgentRunLogger = ReturnType<typeof createLogger>;
+type ProjectSandboxStub = CodeRuntimeContext["sandbox"];
+type AgentRunLogger = ReturnType<typeof createLogger>;
 
 interface AgentRunAppBuilderEnv extends AnalyticsBindings {
   HYPERDRIVE: Hyperdrive;
@@ -488,21 +488,6 @@ function repoImportError(message: string): APIError {
   return new APIError(502, "repo_import_failed", message, {
     hint: "Check the URL is a public GitHub repo, then retry.",
     retriable: true,
-  });
-}
-
-export async function warmSandbox(
-  sandbox: ProjectSandboxStub,
-  logger: AgentRunLogger,
-): Promise<void> {
-  const result = await sandbox.runCode({
-    code: "print('ready')",
-    language: "python",
-  });
-  const stdout = result.stdout;
-  logger.info("sandbox_warmed", {
-    success: result.success,
-    stdoutBytes: stdout.length,
   });
 }
 

--- a/apps/agent-worker/src/durable-objects/agent-run-path.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-path.ts
@@ -1,7 +1,7 @@
 import type { createLogger } from "@cheatcode/observability";
 import type { CodeRuntimeContext, WorkspaceResolver } from "@cheatcode/sandbox-contracts";
 import type { UIMessageChunk } from "ai";
-import { runAppBuilder, warmSandbox } from "./agent-run-app-builder";
+import { runAppBuilder } from "./agent-run-app-builder";
 import type { AgentRunEnv } from "./agent-run-env";
 import type { StartRunInput } from "./agent-run-schemas";
 
@@ -43,7 +43,6 @@ export async function prepareAppBuilderRun(
   options.input.projectMode = appBuilderMode;
   await options.workspaceResolver();
   const boundOptions = { ...options, input: requireProjectBinding(options.input) };
-  await warmSandbox(boundOptions.sandbox, boundOptions.logger);
   if (boundOptions.isCanceled()) {
     return { options: boundOptions, usesManagedPreview: false, waitsForGeneratedPreview: false };
   }

--- a/apps/agent-worker/src/durable-objects/agent-run-workspace.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-workspace.ts
@@ -56,13 +56,13 @@ async function resolveWorkspace(input: WorkspaceResolverInput): Promise<Workspac
   const project = result.project;
   input.input.projectId = project.id;
   input.input.workspaceSlug = project.workspaceSlug;
-  await ensureWorkspaceDirectory(input, project.workspaceSlug);
   if (result.kind === "created") {
     await input.append({
       data: { projectId: project.id, projectName: project.name, v: 1 },
       type: "data-project-created",
     });
   }
+  await ensureWorkspaceDirectory(input, project.workspaceSlug);
   input.logger.info("agent_workspace_materialized", {
     projectId: project.id,
     workspaceSlug: project.workspaceSlug,


### PR DESCRIPTION
## Summary
- publishes the durable project-created event immediately after the database materialization commits
- removes a redundant Python `print('ready')` call after workspace creation has already started and verified Daytona
- reduces first-run app-builder latency without changing sandbox recovery or readiness guarantees

## Decision
`ensureWorkspaceDirectory` remains the real readiness boundary. It is a sandbox operation backed by `ensureSandbox`, so a second synthetic code execution adds a control-plane and toolbox round trip but proves no additional invariant.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`

A fresh ordinary-user production app-builder run will measure project-visible latency after merge/deploy.
