### PR TITLE
chore(agent): promote atomic browser snapshot

### DIFF
--- a/apps/agent-worker/wrangler.jsonc
+++ b/apps/agent-worker/wrangler.jsonc
@@ -19,7 +19,7 @@
     "CHEATCODE_ENVIRONMENT": "production",
     "DAYTONA_API_URL": "https://app.daytona.io/api",
     "DAYTONA_ORG_ID": "300a0c8b-dc3b-4c5f-b31c-0f9e0344d00d",
-    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-f03165e3611a-31633499092",
+    "DAYTONA_SANDBOX_SNAPSHOT": "cheatcode-sandbox-viewer-bundle-7d0bc46cdd0d-31644250058",
     "DAYTONA_WORKSPACE_VOLUME": "cheatcode-workspaces-production"
   },
   "secrets_store_secrets": [


### PR DESCRIPTION
## Why

The atomic browser-action contract is implemented in both the agent Worker and the sandbox driver. Production must promote the verified immutable sandbox artifact before deploying the compatible Worker, so no mixed-version window is possible.

## What changed

- points the production agent Worker at `cheatcode-sandbox-viewer-bundle-7d0bc46cdd0d-31644250058`
- promotes the artifact published by snapshot workflow run `31644250058`
- the candidate passed image construction, Trivy scanning, runtime smoke testing, publication, and post-publication verification

## Verification

- `git diff --check`
- `pnpm architecture:check`
- snapshot workflow `31644250058` completed successfully
- verified the promoted Daytona snapshot is active
