### PR TITLE
fix(web): enlarge model fallback heading

### DIFF
--- a/apps/web/src/components/chat/message-parts.tsx
+++ b/apps/web/src/components/chat/message-parts.tsx
@@ -213,7 +213,7 @@ function ModelFallbackBlock({ data }: { data: ModelFallbackData }) {
   return (
     <MessageStatusShell>
       <div className="text-[11px] text-thread-text-secondary">
-        <div className="mb-1 font-medium text-[12px] text-thread-text-muted">Model Fallback</div>
+        <div className="mb-1 font-medium text-[14px] text-thread-text-primary">Model Fallback</div>
         <div className="text-thread-text-primary">
           Switched from {data.fromModel} to {data.toModel}
         </div>


### PR DESCRIPTION
## Why

The fallback label was capitalized correctly but remained 12px in production, so it did not provide the requested heading hierarchy over the fallback details.

## What changed

- renders `Model Fallback` at 14px
- uses the primary thread text token so the heading has clear visual hierarchy
- preserves the unified double-shell status treatment

## Verification

- `pnpm exec biome check apps/web/src/components/chat/message-parts.tsx`
- `pnpm --filter @cheatcode/web typecheck`
- `pnpm --filter @cheatcode/web build`
- production computed-style inspection established the previous heading was 12px
