### PR TITLE
fix: preserve structured composer intent

### DIFF
--- a/apps/agent-worker/README.md
+++ b/apps/agent-worker/README.md
@@ -73,7 +73,10 @@ the existing account state and R2 lifecycle phases.
 
 Run creation validates the gateway payload with the shared `CreateRunSchema` from
 `packages/types` before selecting the run-scoped `AgentRun` Durable Object. The
-database binds a gateway-hashed idempotency key to the exact body and thread. After the
+validated request keeps the user's exact message separate from explicit non-app run intent,
+selected skill, and selected connected-app metadata. Those selections remain in the
+checkpointed Workflow input and request context; they are never encoded into visible prompt text.
+The database binds a gateway-hashed idempotency key to the exact body and thread. After the
 pending run and thread pointer commit, start delivery is retried and then reconciled through
 an ordered run-key presence probe. A present object reconnects its stream (and finalizes a
 durable Workflow admission first); only an authoritative empty response fails the nonterminal database run

--- a/apps/agent-worker/src/agent-routing.ts
+++ b/apps/agent-worker/src/agent-routing.ts
@@ -190,6 +190,8 @@ export async function startAgentRun(
     model: run.modelId,
     isModelExplicit,
     ...(body.intent ? { runIntent: body.intent } : {}),
+    ...(body.selectedSkill ? { selectedSkill: body.selectedSkill } : {}),
+    ...(body.selectedTool ? { selectedTool: body.selectedTool } : {}),
     ...(run.projectId ? { projectId: run.projectId } : {}),
     ...(run.workspaceSlug ? { workspaceSlug: run.workspaceSlug } : {}),
     ...(run.projectMode ? { projectMode: run.projectMode } : {}),

--- a/apps/agent-worker/src/durable-objects/agent-run-mastra-context.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-mastra-context.ts
@@ -110,6 +110,8 @@ export function createAgentRequestContext(
     openrouterApiKey: credential.transportProvider === "openrouter" ? credential.apiKey : undefined,
     projectMode: input.projectMode,
     runIntent: input.runIntent,
+    selectedSkill: input.selectedSkill,
+    selectedTool: input.selectedTool,
     runId: input.runId,
     taskMessage: input.messageText,
     ...(isSkillCreator ? { userSkillCreator } : {}),

--- a/apps/agent-worker/src/durable-objects/agent-run-schemas.ts
+++ b/apps/agent-worker/src/durable-objects/agent-run-schemas.ts
@@ -1,5 +1,9 @@
-import { CatalogModelIdSchema, LogicalModelIdSchema } from "@cheatcode/types";
-import { ProjectModeSchema, RunIntentSchema } from "@cheatcode/types/api";
+import {
+  CatalogModelIdSchema,
+  IntegrationNameSchema,
+  LogicalModelIdSchema,
+} from "@cheatcode/types";
+import { ProjectModeSchema, RunIntentSchema, SelectedSkillSchema } from "@cheatcode/types/api";
 import { z } from "zod";
 
 export const StartRunInputSchema = z
@@ -16,6 +20,8 @@ export const StartRunInputSchema = z
     // automatic provider fallback so a pinned model is never silently replaced.
     isModelExplicit: z.boolean(),
     runIntent: RunIntentSchema.optional(),
+    selectedSkill: SelectedSkillSchema.optional(),
+    selectedTool: IntegrationNameSchema.optional(),
     projectMode: ProjectModeSchema.default("general"),
     isFirstRun: z.boolean().default(false),
     agentDisplayName: z.string().trim().min(1).max(80).optional(),

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -85,8 +85,10 @@ The composer keeps three independent product concepts separate:
 
 - `ComposerWorkIntentId` describes what the user wants to accomplish. Web app,
   mobile app, slides, research, data, documents, and media are discoverable
-  composer choices. These choices guide prompt context; they are not all project
-  modes. The generic Slides choice activates the general PPTX workflow, never the
+  composer choices. Non-app choices cross the run API as validated intent metadata,
+  so an explicit Documents choice cannot be reclassified as Web merely because the
+  requested document discusses a website. These choices are not all project modes.
+  The generic Slides choice activates the general PPTX workflow, never the
   fundraising-specific pitch-deck skill. Explicit PPTX and pitch-deck skill deep
   links both select the Slides intent while preserving the skill the user chose.
 - `AppBuildTarget` is only the runtime topology for generated applications:
@@ -100,9 +102,12 @@ The composer keeps three independent product concepts separate:
   focus from Files. Explicit browser takeover still selects Browser. The selected tab is not persisted
   across unrelated chats.
 
+Composer selections are request metadata: `@`-selected skills and connected apps are
+validated separately from the exact user-authored text and cross the opaque chat handoff.
+The client never rewrites a visible message with a slash command or internal toolkit preamble.
 Signed-out launch handoff validates and restores `buildTarget`, model, and
-public GitHub repository state before chat creation. The opaque prompt and
-constrained run intent use the same one-shot handoff path. No `surface` query
+public GitHub repository state before chat creation. The opaque prompt,
+constrained run intent, skill, and connected-app selection use the same one-shot handoff path. No `surface` query
 parameter or persisted `app` tab alias is supported.
 
 ## Env

--- a/apps/web/src/components/chat/chat-panel-controller.ts
+++ b/apps/web/src/components/chat/chat-panel-controller.ts
@@ -9,6 +9,7 @@ import type { ChatOnDataCallback, ChatStatus } from "ai";
 import { useRouter } from "next/navigation";
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import type { ChatSubmissionSelection } from "@/components/chat/chat-panel-submission";
 import {
   mergeLoadedMessageHistory,
   type PendingSubmission,
@@ -44,6 +45,8 @@ export interface ChatPanelProps {
   hasOlderMessages: boolean;
   initialMessages?: CheatcodeUIMessage[] | undefined;
   initialRunIntent?: import("@cheatcode/types/api").RunIntent | null | undefined;
+  initialSelectedSkill?: null | string | undefined;
+  initialSelectedTool?: import("@cheatcode/types").IntegrationName | null | undefined;
   isLoadingOlderMessages: boolean;
   latestModelId: null | string;
   onLoadOlderMessages: () => Promise<CheatcodeUIMessage[]>;
@@ -161,7 +164,6 @@ function usePanelSubmission(
       getToken: runtime.getToken,
       hasReceivedStreamDataRef: runtime.hasReceivedStreamDataRef,
       hasSubmittedRef: runtime.hasSubmittedRef,
-      initialRunIntent: input.initialRunIntent ?? null,
       onSubmitDraft: input.onSubmitDraft,
       pendingSubmissionRef: runtime.pendingSubmissionRef,
       project: input.project,
@@ -178,7 +180,6 @@ function usePanelSubmission(
     [
       input.activeRunId,
       input.onSubmitDraft,
-      input.initialRunIntent,
       input.project,
       input.threadId,
       input.threadTitle,
@@ -213,11 +214,19 @@ function useAutoSubmitPrompt(
     if (runtime.store.draft.trim() !== prompt) {
       runtime.store.setDraft(input.threadId, prompt);
     }
-    if (submitText(prompt, input.project)) {
+    const selection: ChatSubmissionSelection = {
+      intent: input.initialRunIntent ?? null,
+      selectedSkill: input.initialSelectedSkill ?? null,
+      selectedTool: input.initialSelectedTool ?? null,
+    };
+    if (submitText(prompt, input.project, selection)) {
       autoSubmittedPromptRef.current = prompt;
     }
   }, [
     input.autoSubmitPrompt,
+    input.initialRunIntent,
+    input.initialSelectedSkill,
+    input.initialSelectedTool,
     input.project,
     input.threadId,
     runtime.store.draft,

--- a/apps/web/src/components/chat/chat-panel-submission.ts
+++ b/apps/web/src/components/chat/chat-panel-submission.ts
@@ -1,5 +1,5 @@
-import type { CheatcodeUIMessage } from "@cheatcode/types";
-import type { ProjectSummary, ThreadMessage } from "@cheatcode/types/api";
+import type { CheatcodeUIMessage, IntegrationName } from "@cheatcode/types";
+import type { ProjectSummary, RunIntent, ThreadMessage } from "@cheatcode/types/api";
 import type { QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { buildExistingProjectParams, launchIntoProject } from "@/lib/api/home-launch";
@@ -11,6 +11,12 @@ import {
   updateThread,
 } from "@/lib/api/project-thread";
 import { sidebarKeys, threadKeys } from "@/lib/api/query-keys";
+
+export interface ChatSubmissionSelection {
+  intent: RunIntent | null;
+  selectedSkill: string | null;
+  selectedTool: IntegrationName | null;
+}
 
 export interface PendingSubmission {
   messageId: string;
@@ -70,6 +76,7 @@ export async function routePromptToProjectTarget(input: {
   queryClient: QueryClient;
   router: PromptRouter;
   selectedModel: null | string;
+  selection: Partial<ChatSubmissionSelection>;
   setDraft: (threadId: string, value: string) => void;
   targetProject: ProjectSummary | null;
   threadId: string;
@@ -144,7 +151,12 @@ function completeProjectTargetNavigation(
   input: Parameters<typeof routePromptToProjectTarget>[0],
   targetThreadId: string,
 ): void {
-  const handoff = buildExistingProjectParams(input.prompt).toString();
+  const handoff = buildExistingProjectParams({
+    prompt: input.prompt,
+    ...(input.selection.intent ? { intent: input.selection.intent } : {}),
+    ...(input.selection.selectedSkill ? { selectedSkill: input.selection.selectedSkill } : {}),
+    ...(input.selection.selectedTool ? { selectedTool: input.selection.selectedTool } : {}),
+  }).toString();
   input.setDraft(input.threadId, "");
   void input.queryClient.invalidateQueries({ queryKey: sidebarKeys.chats });
   void input.queryClient.invalidateQueries({ queryKey: sidebarKeys.projectThreads });

--- a/apps/web/src/components/chat/chat-transport.ts
+++ b/apps/web/src/components/chat/chat-transport.ts
@@ -47,6 +47,8 @@ export function createChatTransport(
           intent: body?.["intent"],
           message: runRequestMessage(latestMessage),
           model: body?.["model"],
+          selectedSkill: body?.["selectedSkill"],
+          selectedTool: body?.["selectedTool"],
         },
         headers: {
           ...headers,

--- a/apps/web/src/components/chat/prompt-composer-controller.ts
+++ b/apps/web/src/components/chat/prompt-composer-controller.ts
@@ -13,7 +13,6 @@ import {
   useState,
 } from "react";
 import type { RunStatus } from "@/components/chat/status-pill";
-import { composePromptWithComposerContext } from "@/components/composer/composer-context-chips";
 import type { ComposerMenuItem } from "@/components/composer/composer-popover";
 import {
   type ComposerMenuController,
@@ -30,7 +29,11 @@ type ComposerControlMenu = "model";
 export interface PromptComposerProps {
   onChange: (value: string) => void;
   onStop: () => void;
-  onSubmit: (value: string, project: ProjectSummary | null) => boolean;
+  onSubmit: (
+    value: string,
+    project: ProjectSummary | null,
+    selection: { selectedSkill: string | null; selectedTool: IntegrationName | null },
+  ) => boolean;
   project: ProjectSummary | null;
   resolvedModelId: null | string;
   status: RunStatus;
@@ -231,14 +234,10 @@ function createComposerSubmission({
   value,
 }: ComposerSubmissionOptions) {
   function submitComposerValue() {
-    const wasAccepted = onSubmit(
-      composePromptWithComposerContext({
-        prompt: value,
-        skill: selection.selectedSkill,
-        tool: selection.selectedTool,
-      }),
-      project,
-    );
+    const wasAccepted = onSubmit(value.trim(), project, {
+      selectedSkill: selection.selectedSkill,
+      selectedTool: selection.selectedTool,
+    });
     if (wasAccepted) {
       selection.setSelectedSkill(null);
       selection.setSelectedTool(null);

--- a/apps/web/src/components/chat/use-chat-submission.ts
+++ b/apps/web/src/components/chat/use-chat-submission.ts
@@ -1,10 +1,11 @@
-import type { CheatcodeUIMessage } from "@cheatcode/types";
+import type { CheatcodeUIMessage, IntegrationName } from "@cheatcode/types";
 import type { ProjectSummary, RunIntent } from "@cheatcode/types/api";
 import type { QueryClient } from "@tanstack/react-query";
 import type { ChatStatus } from "ai";
 import { useCallback } from "react";
 import { toast } from "sonner";
 import {
+  type ChatSubmissionSelection,
   type PendingSubmission,
   type PromptRouter,
   routePromptToProjectTarget,
@@ -23,7 +24,6 @@ interface ChatSubmissionInput {
   getToken: () => Promise<null | string>;
   hasReceivedStreamDataRef: { current: boolean };
   hasSubmittedRef: { current: boolean };
-  initialRunIntent: RunIntent | null;
   onSubmitDraft?: (() => void) | undefined;
   pendingSubmissionRef: { current: PendingSubmission | null };
   project: ProjectSummary | null;
@@ -40,10 +40,18 @@ interface ChatSubmissionInput {
 
 export function useChatSubmission(input: ChatSubmissionInput): {
   continueRun: () => void;
-  submitText: (text: string, targetProject: ProjectSummary | null) => boolean;
+  submitText: (
+    text: string,
+    targetProject: ProjectSummary | null,
+    selection?: Partial<ChatSubmissionSelection>,
+  ) => boolean;
 } {
   const submitText = useCallback(
-    (text: string, targetProject: ProjectSummary | null): boolean => {
+    (
+      text: string,
+      targetProject: ProjectSummary | null,
+      selection: Partial<ChatSubmissionSelection> = {},
+    ): boolean => {
       if (!isValidUserMessage(text)) {
         return false;
       }
@@ -52,10 +60,10 @@ export function useChatSubmission(input: ChatSubmissionInput): {
       }
       input.hasSubmittedRef.current = true;
       if (!isCurrentThreadTarget(input.project, targetProject)) {
-        routeSubmissionToProject(input, text, targetProject);
+        routeSubmissionToProject(input, text, targetProject, selection);
         return true;
       }
-      submitInCurrentThread(input, text);
+      submitInCurrentThread(input, text, selection);
       return true;
     },
     [input],
@@ -73,16 +81,17 @@ export function useChatSubmission(input: ChatSubmissionInput): {
     const pending = pendingSubmission(messageId, text, false);
     input.pendingSubmissionRef.current = pending;
     input.setRunStartedAt(pending.submittedAt);
-    void input.sendMessage(
-      userMessage(messageId, text, null),
-      modelBody(input.selectedModel, null),
-    );
+    void input.sendMessage(userMessage(messageId, text, null), modelBody(input.selectedModel, {}));
   }, [input]);
 
   return { continueRun, submitText };
 }
 
-function submitInCurrentThread(input: ChatSubmissionInput, text: string): void {
+function submitInCurrentThread(
+  input: ChatSubmissionInput,
+  text: string,
+  selection: Partial<ChatSubmissionSelection>,
+): void {
   if (!input.threadTitle?.trim() || input.threadTitle.trim() === "New chat") {
     void titleChatFromFirstPrompt(input.getToken, input.queryClient, input.threadId, text);
   }
@@ -92,8 +101,8 @@ function submitInCurrentThread(input: ChatSubmissionInput, text: string): void {
   input.pendingSubmissionRef.current = pending;
   input.setRunStartedAt(pending.submittedAt);
   void input.sendMessage(
-    userMessage(messageId, text, input.initialRunIntent),
-    modelBody(input.selectedModel, input.initialRunIntent),
+    userMessage(messageId, text, selection.intent ?? null),
+    modelBody(input.selectedModel, selection),
   );
   input.setDraft(input.threadId, "");
   input.onSubmitDraft?.();
@@ -103,6 +112,7 @@ function routeSubmissionToProject(
   input: ChatSubmissionInput,
   prompt: string,
   targetProject: ProjectSummary | null,
+  selection: Partial<ChatSubmissionSelection>,
 ): void {
   void routePromptToProjectTarget({
     getToken: input.getToken,
@@ -110,6 +120,7 @@ function routeSubmissionToProject(
     queryClient: input.queryClient,
     router: input.router,
     selectedModel: input.selectedModel,
+    selection,
     setDraft: input.setDraft,
     targetProject,
     threadId: input.threadId,
@@ -176,12 +187,21 @@ function userMessage(
 
 function modelBody(
   selectedModel: null | string,
-  intent: RunIntent | null,
-): { body: { intent?: RunIntent; model?: string } } {
+  selection: Partial<ChatSubmissionSelection>,
+): {
+  body: {
+    intent?: RunIntent;
+    model?: string;
+    selectedSkill?: string;
+    selectedTool?: IntegrationName;
+  };
+} {
   return {
     body: {
-      ...(intent ? { intent } : {}),
+      ...(selection.intent ? { intent: selection.intent } : {}),
       ...(selectedModel ? { model: selectedModel } : {}),
+      ...(selection.selectedSkill ? { selectedSkill: selection.selectedSkill } : {}),
+      ...(selection.selectedTool ? { selectedTool: selection.selectedTool } : {}),
     },
   };
 }

--- a/apps/web/src/components/composer/composer-context-chips.tsx
+++ b/apps/web/src/components/composer/composer-context-chips.tsx
@@ -25,26 +25,6 @@ function toolLabel(slug: string): string {
   );
 }
 
-export function composePromptWithComposerContext({
-  prompt,
-  skill,
-  tool,
-}: {
-  prompt: string;
-  skill: string | null;
-  tool: IntegrationName | null;
-}): string {
-  const trimmed = prompt.trim();
-  let nextPrompt = skill && !trimmed.startsWith("/") ? `/${skill} ${trimmed}` : trimmed;
-  if (tool) {
-    nextPrompt = [
-      `Selected tool: ${toolLabel(tool)} (${tool}). Use the Composio integration for this request when an external app action is needed.`,
-      nextPrompt,
-    ].join("\n\n");
-  }
-  return nextPrompt.trim();
-}
-
 export function ComposerContextChips({
   className,
   onClearSkill,

--- a/apps/web/src/components/home/home-composer-controller.ts
+++ b/apps/web/src/components/home/home-composer-controller.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { IntegrationName } from "@cheatcode/types";
+import type { RunIntent } from "@cheatcode/types/api";
 import { useAuth } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import {
@@ -29,6 +30,7 @@ export interface HomeComposerProps {
   initialModel?: AgentModelId | undefined;
   initialPromptKey?: string | undefined;
   initialRepoUrl?: string | undefined;
+  initialRunIntent?: RunIntent | undefined;
   initialSkill?: string | undefined;
   initialTool?: IntegrationName | undefined;
   quickActionsSlot?: HTMLElement | null | undefined;
@@ -93,6 +95,7 @@ function useInitialHomeSelection(input: HomeComposerProps, focusTextarea: () => 
       appBuildTarget: input.initialAppBuildTarget ?? null,
       initialSkill,
       initialTool: input.initialTool ?? null,
+      runIntent: input.initialRunIntent ?? null,
       repoUrl: input.initialRepoUrl ?? null,
       skillCreator: input.skillCreator ?? false,
     },

--- a/apps/web/src/components/home/home-composer-from-search-params.tsx
+++ b/apps/web/src/components/home/home-composer-from-search-params.tsx
@@ -2,7 +2,7 @@
 
 import { SKILL_MANIFEST } from "@cheatcode/skills/manifest";
 import { type IntegrationName, IntegrationNameSchema } from "@cheatcode/types";
-import { GitHubRepoUrlSchema } from "@cheatcode/types/api";
+import { GitHubRepoUrlSchema, type RunIntent, RunIntentSchema } from "@cheatcode/types/api";
 import { useEffect, useState } from "react";
 import { type AgentModelId, isAgentModelId } from "@/lib/agent-models";
 import { type AppBuildTarget, isAppBuildTarget } from "@/lib/app-build-target";
@@ -14,6 +14,7 @@ type InitialComposerParams = {
   model?: AgentModelId | undefined;
   promptKey?: string | undefined;
   repoUrl?: string | undefined;
+  runIntent?: RunIntent | undefined;
   skill?: string | undefined;
   skillCreator?: boolean | undefined;
   tool?: IntegrationName | undefined;
@@ -34,6 +35,7 @@ export function HomeComposerFromSearchParams({
       model: validInitialModel(searchParams.get("model")),
       promptKey: validInitialPromptKey(searchParams.get("promptKey")),
       repoUrl: validInitialRepoUrl(searchParams.get("repo")),
+      runIntent: validRunIntent(searchParams.get("intent")),
       skill: validInitialSkill(searchParams.get("skill")),
       skillCreator: searchParams.get("intent") === "skill-creator",
       tool: validInitialTool(searchParams.get("tool")),
@@ -50,6 +52,7 @@ export function HomeComposerFromSearchParams({
       initialModel={params.model}
       initialPromptKey={params.promptKey}
       initialRepoUrl={params.repoUrl}
+      initialRunIntent={params.runIntent}
       initialSkill={params.skill}
       initialTool={params.tool}
       key={`${resetToken}:${params.promptKey ?? ""}:${params.skill ?? ""}:${params.tool ?? ""}:${params.appBuildTarget ?? ""}:${params.model ?? ""}:${params.repoUrl ?? ""}:${params.skillCreator ? "sc" : ""}`}
@@ -81,6 +84,11 @@ function validInitialSkill(value: string | null): string | undefined {
 
 function validInitialTool(value: string | null): IntegrationName | undefined {
   const result = IntegrationNameSchema.safeParse(value);
+  return result.success ? result.data : undefined;
+}
+
+function validRunIntent(value: string | null): RunIntent | undefined {
+  const result = RunIntentSchema.safeParse(value);
   return result.success ? result.data : undefined;
 }
 

--- a/apps/web/src/components/home/home-composer-intents.ts
+++ b/apps/web/src/components/home/home-composer-intents.ts
@@ -1,3 +1,4 @@
+import type { RunIntent } from "@cheatcode/types/api";
 import type { ComponentType } from "react";
 import type { ComposerWorkIntentId } from "@/components/home/home-composer.types";
 import { skillAppBuildTarget } from "@/components/home/use-initial-skill";
@@ -10,6 +11,7 @@ export type ComposerWorkIntent = {
   id: ComposerWorkIntentId;
   label: string;
   placeholder: string;
+  runIntent: RunIntent | null;
   skill: null | string;
   appBuildTarget: AppBuildTarget | null;
 };
@@ -21,6 +23,7 @@ export const COMPOSER_WORK_INTENTS: readonly ComposerWorkIntent[] = [
     id: "mobile-app",
     label: "Mobile app",
     placeholder: "Describe the app - I'll build it with a live phone preview",
+    runIntent: null,
     skill: null,
   },
   {
@@ -29,6 +32,7 @@ export const COMPOSER_WORK_INTENTS: readonly ComposerWorkIntent[] = [
     id: "web-app",
     label: "Web app",
     placeholder: "Describe the site or web app - I'll build and preview it",
+    runIntent: null,
     skill: null,
   },
   {
@@ -37,6 +41,7 @@ export const COMPOSER_WORK_INTENTS: readonly ComposerWorkIntent[] = [
     id: "slides",
     label: "Slides",
     placeholder: "What's the deck about? Audience and key points help",
+    runIntent: "slides",
     skill: "pptx",
   },
   {
@@ -45,6 +50,7 @@ export const COMPOSER_WORK_INTENTS: readonly ComposerWorkIntent[] = [
     id: "research",
     label: "Research",
     placeholder: "What should I research? I'll fan out agents and cite sources",
+    runIntent: "research",
     skill: "deep-research",
   },
   {
@@ -53,6 +59,7 @@ export const COMPOSER_WORK_INTENTS: readonly ComposerWorkIntent[] = [
     id: "data",
     label: "Data",
     placeholder: "Attach or describe the data - I'll profile and chart it",
+    runIntent: "data",
     skill: "csv-analyst",
   },
   {
@@ -61,6 +68,7 @@ export const COMPOSER_WORK_INTENTS: readonly ComposerWorkIntent[] = [
     id: "documents",
     label: "Documents",
     placeholder: "Describe the report, memo, PDF, or document you need",
+    runIntent: "documents",
     skill: null,
   },
   {
@@ -69,6 +77,7 @@ export const COMPOSER_WORK_INTENTS: readonly ComposerWorkIntent[] = [
     id: "media",
     label: "Media",
     placeholder: "Describe the image or video you want to create or edit",
+    runIntent: "media",
     skill: "generate-media",
   },
 ] as const;

--- a/apps/web/src/components/home/home-composer-prompt-state.ts
+++ b/apps/web/src/components/home/home-composer-prompt-state.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import type { IntegrationName } from "@cheatcode/types";
 import type { RunIntent } from "@cheatcode/types/api";
 import type { AppBuildTarget } from "@/lib/app-build-target";
 import { createPromptHandoff } from "@/lib/input/prompt-handoff";
@@ -10,6 +11,8 @@ export function buildLaunchParams(input: {
   model: null | string;
   prompt: string;
   repo: null | string;
+  selectedSkill: null | string;
+  selectedTool: IntegrationName | null;
 }): URLSearchParams {
   const params = new URLSearchParams();
   if (input.intent) {
@@ -26,6 +29,12 @@ export function buildLaunchParams(input: {
   }
   if (input.repo) {
     params.set("repo", input.repo);
+  }
+  if (input.selectedSkill) {
+    params.set("skill", input.selectedSkill);
+  }
+  if (input.selectedTool) {
+    params.set("tool", input.selectedTool);
   }
   return params;
 }

--- a/apps/web/src/components/home/use-home-composer-selection.ts
+++ b/apps/web/src/components/home/use-home-composer-selection.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import type { IntegrationName } from "@cheatcode/types";
-import type { ProjectSummary } from "@cheatcode/types/api";
+import type { ProjectSummary, RunIntent } from "@cheatcode/types/api";
 import { useCallback, useState } from "react";
 import type { ComposerWorkIntentId } from "@/components/home/home-composer.types";
 import { COMPOSER_WORK_INTENTS } from "@/components/home/home-composer-intents";
@@ -13,6 +13,7 @@ interface InitialSelection {
   initialSkill: ReturnType<typeof resolveInitialSkill>;
   initialTool: IntegrationName | null;
   repoUrl: string | null;
+  runIntent: RunIntent | null;
   skillCreator: boolean;
 }
 
@@ -36,7 +37,9 @@ export function useHomeComposerSelection(initial: InitialSelection, focusTextare
 
 function useHomeSelectionState(initial: InitialSelection) {
   const [intentId, setIntentId] = useState<ComposerWorkIntentId | null>(
-    initial.initialSkill.intent ?? appBuildTargetIntent(initial.appBuildTarget),
+    initial.initialSkill.intent ??
+      appBuildTargetIntent(initial.appBuildTarget) ??
+      runIntentWorkIntent(initial.runIntent),
   );
   const [skillChip, setSkillChip] = useState<string | null>(initial.initialSkill.chip);
   const [toolChip, setToolChip] = useState<IntegrationName | null>(initial.initialTool);
@@ -100,6 +103,15 @@ function useIntentSelectionActions(
 function appBuildTargetIntent(target: AppBuildTarget | null): ComposerWorkIntentId | null {
   if (target === "mobile") return "mobile-app";
   return target === "web" ? "web-app" : null;
+}
+
+function runIntentWorkIntent(intent: RunIntent | null): ComposerWorkIntentId | null {
+  if (intent === "data") return "data";
+  if (intent === "documents") return "documents";
+  if (intent === "media") return "media";
+  if (intent === "research") return "research";
+  if (intent === "slides") return "slides";
+  return null;
 }
 
 function useResourceSelectionActions(state: ReturnType<typeof useHomeSelectionState>) {

--- a/apps/web/src/components/home/use-home-composer-submission.ts
+++ b/apps/web/src/components/home/use-home-composer-submission.ts
@@ -4,7 +4,6 @@ import type { IntegrationName } from "@cheatcode/types";
 import type { ProjectSummary, RunIntent } from "@cheatcode/types/api";
 import { useCallback, useRef, useState } from "react";
 import { toast } from "sonner";
-import { composePromptWithComposerContext } from "@/components/composer/composer-context-chips";
 import type { ComposerWorkIntentId } from "@/components/home/home-composer.types";
 import type { ComposerWorkIntent } from "@/components/home/home-composer-intents";
 import {
@@ -37,6 +36,8 @@ interface HomeSubmissionSnapshot {
   project: ProjectSummary | null;
   prompt: string;
   repoUrl: string | null;
+  selectedSkill: string | null;
+  selectedTool: IntegrationName | null;
 }
 
 interface SubmissionRuntime {
@@ -83,12 +84,7 @@ export function useHomeComposerSubmission(input: {
 }
 
 function buildSubmissionSnapshot(state: HomeSubmissionState): HomeSubmissionSnapshot | null {
-  const skill = resolveSubmitSkill(state.repoUrl, state.intent, state.skillChip);
-  const prompt = composePromptWithComposerContext({
-    prompt: state.value.trim(),
-    skill,
-    tool: state.toolChip,
-  });
+  const prompt = state.value.trim();
   try {
     assertUserMessageWithinLimit(prompt);
   } catch (error) {
@@ -102,11 +98,13 @@ function buildSubmissionSnapshot(state: HomeSubmissionState): HomeSubmissionSnap
       state.intent,
       state.skillChip,
     ),
-    intent: state.skillCreatorMode ? "skill-creator" : null,
+    intent: state.skillCreatorMode ? "skill-creator" : (state.intent?.runIntent ?? null),
     model: agentModelRequestValue(state.agentModelId) ?? null,
     project: state.selectedProject,
     prompt,
     repoUrl: state.repoUrl,
+    selectedSkill: resolveSubmitSkill(state.repoUrl, state.intent, state.skillChip),
+    selectedTool: state.repoUrl ? null : state.toolChip,
   };
 }
 
@@ -135,7 +133,7 @@ async function launchExistingProject(
       runtime.endSubmitting();
       return;
     }
-    navigateToChat(runtime, result.threadId, snapshot.prompt, snapshot.intent);
+    navigateToChat(runtime, result.threadId, snapshot);
   } catch (error) {
     toast.error(error instanceof Error ? error.message : "Could not open that project.");
     runtime.endSubmitting();
@@ -159,7 +157,7 @@ async function startNewChat(
       ...(snapshot.repoUrl ? { importRepoUrl: snapshot.repoUrl } : {}),
       ...(snapshot.model ? { defaultModel: snapshot.model } : {}),
     });
-    navigateToChat(runtime, thread.id, snapshot.prompt, snapshot.intent);
+    navigateToChat(runtime, thread.id, snapshot);
   } catch (error) {
     toast.error(error instanceof Error ? error.message : "Could not start that chat.");
     runtime.endSubmitting();
@@ -176,6 +174,8 @@ function preservePromptForSignIn(
       model: snapshot.model,
       prompt: snapshot.prompt,
       repo: snapshot.repoUrl,
+      selectedSkill: snapshot.selectedSkill,
+      selectedTool: snapshot.selectedTool,
       appBuildTarget: snapshot.appBuildTarget,
     });
     runtime.setAuthRedirectTo(`/?${params.toString()}`);
@@ -188,10 +188,14 @@ function preservePromptForSignIn(
 function navigateToChat(
   runtime: SubmissionRuntime,
   threadId: string,
-  prompt: string,
-  intent: RunIntent | null,
+  snapshot: HomeSubmissionSnapshot,
 ): void {
-  const handoff = buildExistingProjectParams(prompt, intent).toString();
+  const handoff = buildExistingProjectParams({
+    intent: snapshot.intent,
+    prompt: snapshot.prompt,
+    selectedSkill: snapshot.selectedSkill,
+    selectedTool: snapshot.selectedTool,
+  }).toString();
   // A soft navigation may preserve this page in the Next.js route cache. Release
   // the submission lock before leaving so restoring the page can never revive a
   // permanently disabled composer.

--- a/apps/web/src/components/projects/projects-shell.tsx
+++ b/apps/web/src/components/projects/projects-shell.tsx
@@ -4,8 +4,15 @@ import {
   type CheatcodeUIMessage,
   coalesceTranscriptUIMessages,
   hasIncompleteTranscriptUIMessages,
+  IntegrationNameSchema,
 } from "@cheatcode/types";
-import type { ProjectSummary, RunIntent, Thread } from "@cheatcode/types/api";
+import {
+  type ProjectSummary,
+  type RunIntent,
+  RunIntentSchema,
+  SelectedSkillSchema,
+  type Thread,
+} from "@cheatcode/types/api";
 import { useAuth } from "@clerk/nextjs";
 import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
 import { parseAsString, useQueryStates } from "nuqs";
@@ -30,6 +37,8 @@ import { useAppStore } from "@/lib/store/app-store";
 const PROMPT_URL_STATE = {
   intent: parseAsString,
   promptKey: parseAsString,
+  skill: parseAsString,
+  tool: parseAsString,
 } as const;
 
 export function ProjectsShell({ threadId: threadIdProp }: { threadId?: string }) {
@@ -60,14 +69,13 @@ function useProjectsShell(threadIdProp: string | undefined) {
     () => chronologicalMessages(initialMessagesQuery.data?.pages ?? []),
     [initialMessagesQuery.data?.pages],
   );
-  const { clearPromptParams, prompt, runIntent } = useInitialChatPrompt(
-    threadQuery.data ?? null,
-    initialMessagesQuery.isPending ? null : initialMessages,
-  );
-  const hasProject = projectId !== null;
+  const { clearPromptParams, prompt, runIntent, selectedSkill, selectedTool } =
+    useInitialChatPrompt(
+      threadQuery.data ?? null,
+      initialMessagesQuery.isPending ? null : initialMessages,
+    );
   const previewPanelOpen = useAppStore((state) => state.previewPanelOpen);
   const sandboxStatus = useAppStore((state) => state.sandboxStatus);
-  const hasComputer = hasProject || sandboxStatus !== "cold";
   const deliverableCount = countDeliverables(initialMessages);
   const loadOlderMessages = useOlderThreadMessagesLoader(initialMessagesQuery);
 
@@ -86,7 +94,7 @@ function useProjectsShell(threadIdProp: string | undefined) {
       initialMessagesQuery.hasTranscriptIntegrityError ||
       projectQuery.isError ||
       threadQuery.isError,
-    hasComputer,
+    hasComputer: projectId !== null || sandboxStatus !== "cold",
     initialMessages,
     initialMessagesQuery,
     isRetrying: retry.isRetrying,
@@ -95,6 +103,8 @@ function useProjectsShell(threadIdProp: string | undefined) {
     projectQuery,
     prompt,
     runIntent,
+    selectedSkill,
+    selectedTool,
     retry: retry.run,
     threadId,
     threadQuery,
@@ -168,6 +178,8 @@ function ProjectsWorkspace({
           initialMessages={shell.initialMessages}
           isLoadingOlderMessages={shell.initialMessagesQuery.isFetchingNextPage}
           initialRunIntent={shell.runIntent}
+          initialSelectedSkill={shell.selectedSkill}
+          initialSelectedTool={shell.selectedTool}
           key={threadId}
           latestModelId={shell.threadQuery.data?.latestModelId ?? null}
           onLoadOlderMessages={shell.loadOlderMessages}
@@ -197,7 +209,13 @@ function countDeliverables(messages: readonly CheatcodeUIMessage[]): number {
 function useInitialChatPrompt(
   thread: Thread | null,
   initialMessages: CheatcodeUIMessage[] | null,
-): { clearPromptParams: () => void; prompt: null | string; runIntent: RunIntent | null } {
+): {
+  clearPromptParams: () => void;
+  prompt: null | string;
+  runIntent: RunIntent | null;
+  selectedSkill: string | null;
+  selectedTool: import("@cheatcode/types").IntegrationName | null;
+} {
   const [urlState, setUrlState] = useQueryStates(PROMPT_URL_STATE, {
     history: "replace",
     shallow: true,
@@ -211,7 +229,12 @@ function useInitialChatPrompt(
     initialMessages,
     thread,
   });
-  const runIntent = urlState.intent === "skill-creator" ? urlState.intent : null;
+  const parsedRunIntent = RunIntentSchema.safeParse(urlState.intent);
+  const runIntent = parsedRunIntent.success ? parsedRunIntent.data : null;
+  const parsedSkill = SelectedSkillSchema.safeParse(urlState.skill);
+  const selectedSkill = parsedSkill.success ? parsedSkill.data : null;
+  const parsedTool = IntegrationNameSchema.safeParse(urlState.tool);
+  const selectedTool = parsedTool.success ? parsedTool.data : null;
   const clearPromptParams = useCallback(() => {
     if (!hasPromptUrlState(urlState)) {
       return;
@@ -219,9 +242,11 @@ function useInitialChatPrompt(
     void setUrlState({
       intent: null,
       promptKey: null,
+      skill: null,
+      tool: null,
     });
   }, [setUrlState, urlState]);
-  return { clearPromptParams, prompt, runIntent };
+  return { clearPromptParams, prompt, runIntent, selectedSkill, selectedTool };
 }
 
 function useRefreshThreadProjectOnSandboxChange(input: {
@@ -245,7 +270,7 @@ function useRefreshThreadProjectOnSandboxChange(input: {
 function hasPromptUrlState(
   urlState: Record<keyof typeof PROMPT_URL_STATE, null | string>,
 ): boolean {
-  return Boolean(urlState.intent ?? urlState.promptKey);
+  return Boolean(urlState.intent ?? urlState.promptKey ?? urlState.skill ?? urlState.tool);
 }
 
 function useThreadQuery(getToken: () => Promise<null | string>, threadId: null | string) {

--- a/apps/web/src/lib/api/home-launch.ts
+++ b/apps/web/src/lib/api/home-launch.ts
@@ -1,3 +1,4 @@
+import type { IntegrationName } from "@cheatcode/types";
 import type { RunIntent } from "@cheatcode/types/api";
 import { createChat, listProjectThreadsPage, threadTitle } from "@/lib/api/project-thread";
 import { createPromptHandoff } from "@/lib/input/prompt-handoff";
@@ -36,14 +37,22 @@ export async function launchIntoProject(
  * are already persisted on the newly created chat; this handoff carries only the
  * prompt and constrained run intent consumed by the chat workspace.
  */
-export function buildExistingProjectParams(
-  prompt: string,
-  intent: RunIntent | null = null,
-): URLSearchParams {
+export function buildExistingProjectParams(input: {
+  intent?: RunIntent | null;
+  prompt: string;
+  selectedSkill?: string | null;
+  selectedTool?: IntegrationName | null;
+}): URLSearchParams {
   const params = new URLSearchParams();
-  params.set("promptKey", createPromptHandoff(prompt).promptKey);
-  if (intent) {
-    params.set("intent", intent);
+  params.set("promptKey", createPromptHandoff(input.prompt).promptKey);
+  if (input.intent) {
+    params.set("intent", input.intent);
+  }
+  if (input.selectedSkill) {
+    params.set("skill", input.selectedSkill);
+  }
+  if (input.selectedTool) {
+    params.set("tool", input.selectedTool);
   }
   return params;
 }

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -43,7 +43,11 @@ Tools execute autonomously inside the active request context. Sandbox operations
 remain project-root confined, browser actions remain origin-bound, connected-app
 actions remain scoped to the user's active account, and secret-bearing input is
 validated before execution. Deterministic prepare/execute boundaries keep dynamic
-ports and Git destinations stable between resolution and execution. The managed browser follows
+ports and Git destinations stable between resolution and execution.
+Explicit composer intent is authoritative before message keyword classification on general-project
+runs. A selected skill or connected app arrives as validated request context, prompts the agent to
+load or use that exact capability, and never mutates the user's message into internal command syntax.
+The managed browser follows
 the same boundary: observation reads Stagehand's native accessibility snapshot without model
 inference and returns page-bound element refs. Execution accepts only a single-use ref from the
 latest state tree plus a bounded method/value, resolves its server-held XPath, and atomically binds

--- a/packages/agent-core/src/mastra/context.ts
+++ b/packages/agent-core/src/mastra/context.ts
@@ -25,6 +25,8 @@ export const CONTEXT = {
   researchWorkflowAttempted: "researchWorkflowAttempted",
   researchWorkflowActive: "researchWorkflowActive",
   runIntent: "runIntent",
+  selectedSkill: "selectedSkill",
+  selectedTool: "selectedTool",
   userSkillCreator: "userSkillCreator",
   userSkillLoader: "userSkillLoader",
   userSkills: "userSkills",

--- a/packages/agent-core/src/mastra/system-prompt.ts
+++ b/packages/agent-core/src/mastra/system-prompt.ts
@@ -1,5 +1,11 @@
 import { buildSystemPromptSection, getSkillByName, SKILLS } from "@cheatcode/skills";
-import { MAX_USER_SKILLS, type RunIntent } from "@cheatcode/types/api";
+import {
+  MAX_USER_SKILLS,
+  type RunIntent,
+  RunIntentSchema,
+  SelectedSkillSchema,
+} from "@cheatcode/types/api";
+import { type IntegrationName, IntegrationNameSchema } from "@cheatcode/types/integrations";
 import { CONTEXT } from "./context";
 import type { UserSkillRuntime } from "./user-skill-runtime";
 
@@ -14,6 +20,8 @@ export interface PromptRuntimeContext {
   /** app-builder / app-builder-mobile / general — selects the domain module. */
   projectMode?: string;
   runIntent?: RunIntent;
+  selectedSkill?: string;
+  selectedTool?: IntegrationName;
   /** The user's request text, classified to select domain modules on the general path. */
   taskMessage?: string;
   /** The run's project folder in the sandbox (/workspace/<slug>) — the agent's working directory. */
@@ -67,9 +75,23 @@ export function promptRuntimeContextFromRequestContext(
   if (projectMode) {
     context.projectMode = projectMode;
   }
-  const runIntent = trimmedContextValue(requestContext, CONTEXT.runIntent);
-  if (runIntent === "skill-creator") {
-    context.runIntent = runIntent;
+  const runIntent = RunIntentSchema.safeParse(
+    trimmedContextValue(requestContext, CONTEXT.runIntent),
+  );
+  if (runIntent.success) {
+    context.runIntent = runIntent.data;
+  }
+  const selectedSkill = SelectedSkillSchema.safeParse(
+    trimmedContextValue(requestContext, CONTEXT.selectedSkill),
+  );
+  if (selectedSkill.success) {
+    context.selectedSkill = selectedSkill.data;
+  }
+  const selectedTool = IntegrationNameSchema.safeParse(
+    trimmedContextValue(requestContext, CONTEXT.selectedTool),
+  );
+  if (selectedTool.success) {
+    context.selectedTool = selectedTool.data;
   }
   const taskMessage = trimmedContextValue(requestContext, CONTEXT.promptTaskMessage);
   if (taskMessage) {
@@ -111,7 +133,13 @@ export function buildSystemPrompt(runtimeContext: PromptRuntimeContext = {}): st
     runtimeContext.workspaceDir
       ? `Your project workspace is \`${runtimeContext.workspaceDir}\`. Create, edit, and run everything there (it's your project's folder in the shared computer). Use it as the working directory for shell commands and the dev server.`
       : "",
-    ...selectDomainModules(runtimeContext.projectMode, runtimeContext.taskMessage),
+    ...selectDomainModules(
+      runtimeContext.projectMode,
+      runtimeContext.taskMessage,
+      runtimeContext.runIntent,
+    ),
+    buildSelectedSkillDirective(runtimeContext.selectedSkill),
+    buildSelectedToolDirective(runtimeContext.selectedTool),
     FINISHING,
     runtimeContext.globalMemory ? `## User Memory\n${runtimeContext.globalMemory}` : "",
     buildSystemPromptSection(GENERAL_SKILLS),
@@ -150,6 +178,26 @@ function requiredBundledSkillInstructions(name: string): string {
     throw new Error(`Required bundled skill is unavailable: ${name}`);
   }
   return skill.body;
+}
+
+function buildSelectedSkillDirective(selectedSkill: string | undefined): string {
+  if (!selectedSkill) {
+    return "";
+  }
+  return [
+    "## User-selected skill",
+    `The user selected the ${JSON.stringify(selectedSkill)} skill in the composer. Before doing the work, call \`skill_invoke\` with exactly that skill name and follow the returned instructions. The user's visible message is their complete request; do not mention this internal selection or rewrite their request as a slash command.`,
+  ].join("\n");
+}
+
+function buildSelectedToolDirective(selectedTool: IntegrationName | undefined): string {
+  if (!selectedTool) {
+    return "";
+  }
+  return [
+    "## User-selected connected app",
+    `The user selected the connected ${JSON.stringify(selectedTool)} app in the composer. Use that integration for any external-app action required by the request. Discover the narrow action first, then execute it. Do not mention the internal toolkit slug unless the user asks.`,
+  ].join("\n");
 }
 
 const CORE_IDENTITY = [
@@ -272,15 +320,31 @@ const DOMAIN_MODULES: Record<DomainKey, string> = {
  * path classifies the message and falls back to the compact all-domains pointer when the
  * intent is ambiguous (so the model is never blind — the classifier favours precision).
  */
-function selectDomainModules(projectMode?: string, taskMessage?: string): string[] {
+function selectDomainModules(
+  projectMode?: string,
+  taskMessage?: string,
+  runIntent?: RunIntent,
+): string[] {
   if (projectMode === "app-builder") {
     return [WEB_MODULE, APP_BUILDER_PREVIEW_NOTE];
   }
   if (projectMode === "app-builder-mobile") {
     return [MOBILE_MODULE, APP_BUILDER_PREVIEW_NOTE];
   }
+  const intentDomain = domainForRunIntent(runIntent);
+  if (intentDomain) {
+    return [DOMAIN_MODULES[intentDomain]];
+  }
   const domains = classifyDomains(taskMessage ?? "");
   return domains.length > 0 ? domains.map((domain) => DOMAIN_MODULES[domain]) : [GENERALIST_MODULE];
+}
+
+function domainForRunIntent(runIntent: RunIntent | undefined): DomainKey | null {
+  if (runIntent === "data") return "data";
+  if (runIntent === "documents" || runIntent === "slides") return "docs";
+  if (runIntent === "media") return "media";
+  if (runIntent === "research") return "research";
+  return null;
 }
 
 const DOMAIN_PATTERNS: ReadonlyArray<readonly [DomainKey, RegExp]> = [

--- a/packages/agent-core/src/mastra/tool-defs/request-context.ts
+++ b/packages/agent-core/src/mastra/tool-defs/request-context.ts
@@ -1,6 +1,7 @@
 import type { MorphApplyRuntime } from "@cheatcode/morph";
 import type { CodeRuntimeContext } from "@cheatcode/sandbox-contracts";
 import type { RunIntent } from "@cheatcode/types/api";
+import type { IntegrationName } from "@cheatcode/types/integrations";
 import { RequestContext } from "@mastra/core/request-context";
 import type { ComposioConnectedAccounts, ComposioQuotaMeter } from "../composio-context";
 import { CONTEXT, type ContextKey } from "../context";
@@ -30,6 +31,8 @@ interface CodeRequestContextOptions {
   openrouterApiKey?: string | undefined;
   projectMode?: string | undefined;
   runIntent?: RunIntent | undefined;
+  selectedSkill?: string | undefined;
+  selectedTool?: IntegrationName | undefined;
   runId?: string | undefined;
   taskMessage?: string | undefined;
   userSkills?: UserSkillRuntime[] | undefined;
@@ -61,6 +64,8 @@ function contextEntries(
     [CONTEXT.globalMemory, options.globalMemory],
     [CONTEXT.promptProjectMode, options.projectMode],
     [CONTEXT.runIntent, options.runIntent],
+    [CONTEXT.selectedSkill, options.selectedSkill],
+    [CONTEXT.selectedTool, options.selectedTool],
     [CONTEXT.promptTaskMessage, options.taskMessage],
     [CONTEXT.anthropicApiKey, options.anthropicApiKey],
     [CONTEXT.composioApiKey, options.composioApiKey],

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -32,7 +32,8 @@ capability discovery contracts, error codes, and UI message types.
 The `./api` subpath also exports the canonical user-message character budget, project-file
 upload/batch/namespace limits and schemas, the discriminated upload/generated-Deliverable project
 file catalog plus deterministic Deliverable path builder, and finalized project-archive byte
-limit so browser and Worker boundaries cannot drift.
+limit so browser and Worker boundaries cannot drift. `CreateRunSchema` keeps the exact user message
+separate from validated non-app run intent, selected-skill, and connected-app metadata.
 
 ## Code Checks
 

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -34,9 +34,12 @@ export const GitHubRepoUrlSchema = z
 const PROJECT_MODES = ["app-builder", "app-builder-mobile", "general"] as const;
 export const ProjectModeSchema = z.enum(PROJECT_MODES);
 
-/** Product modes selected by UI intent or a high-confidence projectless build imperative. */
-const RUN_INTENTS = ["skill-creator"] as const;
+/** Explicit non-app work paths selected by the composer; app topology remains a project mode. */
+const RUN_INTENTS = ["data", "documents", "media", "research", "skill-creator", "slides"] as const;
 export const RunIntentSchema = z.enum(RUN_INTENTS);
+
+/** Skill selected through the `@` picker or a curated work-intent shortcut. */
+export const SelectedSkillSchema = z.string().trim().min(1).max(80);
 
 export const CreateProjectSchema = z.strictObject({
   defaultModel: LogicalModelIdSchema.optional(),
@@ -215,6 +218,8 @@ export const CreateRunSchema = z.strictObject({
     parts: z.array(UserTextPartSchema).length(1),
   }),
   model: LogicalModelIdSchema.optional(),
+  selectedSkill: SelectedSkillSchema.optional(),
+  selectedTool: IntegrationNameSchema.optional(),
 });
 
 export const ProviderSchema = z.enum([


### PR DESCRIPTION
## Summary
- preserve the user's exact authored message instead of encoding selected skills or connected apps into visible prompt text
- carry non-app work intent, selected skill, and selected connected app through the validated run contract and durable Workflow input
- make explicit Documents, Slides, Research, Data, and Media choices authoritative before keyword-based domain classification

## Architecture
The browser sends an exact text message plus a small validated metadata envelope. The gateway includes that envelope in its idempotency body, the agent Worker checkpoints it in Workflow input, and agent-core converts it into request-scoped domain and capability guidance. App topology remains project mode; non-app work remains a general project.

## Decisions Made
| Decision | Choice | Alternatives considered | Reasoning |
|---|---|---|---|
| Preserve message identity | Keep user text byte-for-byte and send selections separately | Strip hidden prefixes at render time | Rendering would hide persisted corruption and leave routing ambiguous |
| Route non-app surfaces | Validated run intent | More project modes or keyword-only classification | Intent is per run; project storage topology is unchanged |
| Selected capabilities | Separate skill and connected-app fields | Internal prose or slash prefixes | Typed metadata survives retries without polluting transcript or model task text |
| Classification precedence | App project mode, then explicit run intent, then keywords | Keywords first | Explicit user choices must win over incidental words such as “website” in a memo |

## Edge Cases Handled
- signed-out and existing-project prompt handoffs retain intent and capability selections
- custom user skills use the same bounded selected-skill contract as bundled skills
- follow-up messages do not accidentally inherit first-run selection metadata
- selected project or repository import keeps its existing app/general topology contract
- invalid URL metadata is discarded before request submission and revalidated at the API boundary

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`

## Production QA after merge
- submit an ordinary Documents request that mentions a website and confirm a document deliverable, exact visible prompt, and Files surface
- submit ordinary Data and Research requests and confirm no internal skill prefix appears
- submit a Slides request and confirm the deck skill is loaded from metadata
- inspect browser console and production deployment health
