### PR TITLE
fix(web): unify deliverables double shell

### DIFF
--- a/apps/web/src/components/chat/message-deliverables.tsx
+++ b/apps/web/src/components/chat/message-deliverables.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { useEffect, useId, useState } from "react";
 import { toast } from "sonner";
 import { formatBytes } from "@/components/chat/message-deliverable-model";
+import { MessageDoubleShell } from "@/components/chat/message-part-blocks";
 import type { ArtifactData } from "@/components/chat/message-parts.types";
 import {
   type OutputImagePreviewState,
@@ -36,18 +37,17 @@ interface DeliverablesBlockProps {
 export function DeliverablesBlock({ items, threadId }: DeliverablesBlockProps) {
   useAutoOpenLatestImage(items, threadId);
   return (
-    <div
-      className="cc-fade-in rounded-[14px] border border-thread-border bg-[var(--thread-code-bg)] p-3"
-      data-chat-deliverables="true"
-    >
-      <div className="mb-2 text-[10px] text-thread-text-muted uppercase tracking-[0.18em]">
-        Deliverables
-      </div>
-      <div className="space-y-2">
-        {items.map((item) => (
-          <DeliverableCard data={item} key={item.outputId} threadId={threadId} />
-        ))}
-      </div>
+    <div data-chat-deliverables="true">
+      <MessageDoubleShell innerClassName="p-3">
+        <div className="mb-2 text-[10px] text-thread-text-muted uppercase tracking-[0.18em]">
+          Deliverables
+        </div>
+        <div className="space-y-2">
+          {items.map((item) => (
+            <DeliverableCard data={item} key={item.outputId} threadId={threadId} />
+          ))}
+        </div>
+      </MessageDoubleShell>
     </div>
   );
 }

--- a/apps/web/src/components/chat/message-part-blocks.tsx
+++ b/apps/web/src/components/chat/message-part-blocks.tsx
@@ -10,11 +10,28 @@ export function MessageStatusShell({
   tone?: "danger" | "neutral";
 }) {
   return (
+    <MessageDoubleShell innerClassName="px-4 py-3.5" tone={tone}>
+      {children}
+    </MessageDoubleShell>
+  );
+}
+
+export function MessageDoubleShell({
+  children,
+  innerClassName,
+  tone = "neutral",
+}: {
+  children: ReactNode;
+  innerClassName?: string;
+  tone?: "danger" | "neutral";
+}) {
+  return (
     <div className="cc-fade-in overflow-hidden rounded-[20px] border-2 border-border bg-background p-0.5">
       <div
         className={cn(
-          "rounded-[16px] bg-gradient-to-b to-background px-4 py-3.5",
+          "rounded-[16px] bg-gradient-to-b to-background",
           tone === "danger" ? "from-danger-bg" : "from-bg-secondary",
+          innerClassName,
         )}
       >
         {children}


### PR DESCRIPTION
## Summary

- give every Deliverables block the same two-layer shell used by message status surfaces
- extract the shell framing into a shared primitive instead of duplicating visual classes
- preserve existing artifact metadata, image preview, Files, and download behavior

## Architecture

`MessageDoubleShell` owns the outer 2px frame, inset surface, radius relationship, background gradient, and entrance animation. `MessageStatusShell` supplies status-specific padding and tone; `DeliverablesBlock` supplies artifact-specific spacing.

## Decisions Made

| Decision | Choice | Alternative | Reason |
|---|---|---|---|
| Shared styling boundary | Reusable message-shell primitive | Copy status classes into Deliverables | Prevents the two surfaces drifting again |
| Artifact internals | Leave cards and actions unchanged | Restyle each artifact row | The defect is the containing shell, not its interaction model |

No schema, migration, environment, Worker, or deployment-topology changes.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (passes with the existing Knip configuration hint)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- production browser QA will verify the released shell at desktop and narrow chat widths
- production paid video QA will exercise generation, preview, Files, download, activity trace, timing, and console