### PR TITLE
fix(media): align Veo generation contract

### DIFF
--- a/apps/web/src/components/chat/message-deliverables.tsx
+++ b/apps/web/src/components/chat/message-deliverables.tsx
@@ -11,6 +11,8 @@ import {
   type OutputImagePreviewState,
   useLazyOutputImagePreview,
 } from "@/components/chat/output-image-preview";
+import type { OutputPreviewState } from "@/components/chat/output-preview-support";
+import { useLazyOutputVideoPreview } from "@/components/chat/output-video-preview";
 import {
   Code,
   Download,
@@ -35,7 +37,7 @@ interface DeliverablesBlockProps {
 }
 
 export function DeliverablesBlock({ items, threadId }: DeliverablesBlockProps) {
-  useAutoOpenLatestImage(items, threadId);
+  useAutoOpenLatestMedia(items, threadId);
   return (
     <div data-chat-deliverables="true">
       <MessageDoubleShell innerClassName="p-3">
@@ -65,7 +67,97 @@ function DeliverableCard({ data, threadId }: { data: ArtifactData; threadId: str
       />
     );
   }
+  if (isVideoArtifact(data)) {
+    return (
+      <VideoDeliverableCard
+        data={data}
+        download={download}
+        getToken={getToken}
+        threadId={threadId}
+      />
+    );
+  }
   return <FileDeliverableCard data={data} download={download} />;
+}
+
+function VideoDeliverableCard({
+  data,
+  download,
+  getToken,
+  threadId,
+}: {
+  data: ArtifactData;
+  download: DeliverableDownload;
+  getToken: () => Promise<null | string>;
+  threadId: string;
+}) {
+  const preview = useLazyOutputVideoPreview(data, getToken);
+  const openInFiles = useOpenMediaInFiles(data, threadId, "video");
+  return (
+    <div className="overflow-hidden rounded-[12px] border border-border bg-background">
+      <VideoPreview data={data} preview={preview} />
+      <div className="flex flex-wrap items-center gap-2 px-2.5 py-2.5">
+        <Video aria-hidden="true" className="h-4 w-4 shrink-0 text-fg-secondary" />
+        <DeliverableMetadata data={data} />
+        <button
+          className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full px-2 text-[12px] text-fg-secondary transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={openInFiles}
+          type="button"
+        >
+          <FolderOpen aria-hidden="true" className="h-3.5 w-3.5" />
+          Open in Files
+        </button>
+        <DownloadButton download={download} filename={data.filename} />
+      </div>
+    </div>
+  );
+}
+
+function VideoPreview({ data, preview }: { data: ArtifactData; preview: OutputPreviewState }) {
+  return (
+    <div
+      className="relative aspect-video w-full overflow-hidden bg-secondary"
+      ref={preview.hostRef}
+    >
+      {preview.url ? (
+        // Generated assets do not include a timed-text sidecar to attach here.
+        // biome-ignore lint/a11y/useMediaCaption: No caption track exists for arbitrary provider output.
+        <video
+          aria-label={`Generated video: ${readableFilename(data.filename)}`}
+          className="h-full w-full bg-black object-contain"
+          controls
+          playsInline
+          preload="metadata"
+          src={preview.url}
+        />
+      ) : (
+        <VideoPreviewPlaceholder message={preview.message} status={preview.status} />
+      )}
+    </div>
+  );
+}
+
+function VideoPreviewPlaceholder({
+  message,
+  status,
+}: Pick<OutputPreviewState, "message" | "status">) {
+  const isLoading = status === "idle" || status === "loading";
+  return (
+    <div
+      aria-live="polite"
+      className={cn(
+        "flex h-full w-full flex-col items-center justify-center gap-2 p-5 text-center text-[12px] text-fg-secondary",
+        isLoading && "motion-safe:animate-pulse",
+      )}
+    >
+      {isLoading ? (
+        <Loader2 aria-hidden="true" className="h-5 w-5 animate-spin motion-reduce:animate-none" />
+      ) : (
+        <Video aria-hidden="true" className="h-5 w-5" />
+      )}
+      <span>{isLoading ? "Preparing video…" : (message ?? "Video preview unavailable")}</span>
+    </div>
+  );
 }
 
 function FileDeliverableCard({
@@ -98,7 +190,7 @@ function ImageDeliverableCard({
 }) {
   const [isViewerOpen, setViewerOpen] = useState(false);
   const preview = useLazyOutputImagePreview(data, getToken);
-  const openInFiles = useOpenImageInFiles(data, threadId, () => setViewerOpen(false));
+  const openInFiles = useOpenMediaInFiles(data, threadId, "image", () => setViewerOpen(false));
   return (
     <div className="overflow-hidden rounded-[12px] border border-border bg-background">
       <ImageThumbnail data={data} onOpen={() => setViewerOpen(true)} preview={preview} />
@@ -349,14 +441,19 @@ function useDeliverableDownload(
   return { isPreparing, start };
 }
 
-function useOpenImageInFiles(data: ArtifactData, threadId: string, afterOpen: () => void) {
+function useOpenMediaInFiles(
+  data: ArtifactData,
+  threadId: string,
+  type: "image" | "video",
+  afterOpen: () => void = () => undefined,
+) {
   const requestFileOpen = useAppStore((state) => state.requestFileOpen);
   const setActiveComputerTab = useAppStore((state) => state.setActiveComputerTab);
   const setPreviewPanelOpen = useAppStore((state) => state.setPreviewPanelOpen);
   return () => {
-    const path = imageWorkspacePath(data);
+    const path = mediaWorkspacePath(data, type);
     if (!path) {
-      toast.error("This image does not have a safe workspace path.");
+      toast.error(`This ${type} does not have a safe workspace path.`);
       return;
     }
     requestFileOpen(threadId, path);
@@ -366,36 +463,47 @@ function useOpenImageInFiles(data: ArtifactData, threadId: string, afterOpen: ()
   };
 }
 
-function useAutoOpenLatestImage(items: readonly ArtifactData[], threadId: string): void {
+function useAutoOpenLatestMedia(items: readonly ArtifactData[], threadId: string): void {
   const activeComputerTab = useAppStore((state) => state.activeComputerTab);
   const previewPanelOpen = useAppStore((state) => state.previewPanelOpen);
   const requestFileOpen = useAppStore((state) => state.requestFileOpen);
-  const latestImage = items.findLast(isImageArtifact);
-  const latestImagePath = latestImage ? imageWorkspacePath(latestImage) : null;
+  const latestMedia = items.findLast((item) => isImageArtifact(item) || isVideoArtifact(item));
+  const latestMediaPath = latestMedia
+    ? mediaWorkspacePath(latestMedia, isVideoArtifact(latestMedia) ? "video" : "image")
+    : null;
   useEffect(() => {
-    if (!previewPanelOpen || activeComputerTab !== "files" || !latestImagePath) return;
-    requestFileOpen(threadId, latestImagePath);
-  }, [activeComputerTab, latestImagePath, previewPanelOpen, requestFileOpen, threadId]);
+    if (!previewPanelOpen || activeComputerTab !== "files" || !latestMediaPath) return;
+    requestFileOpen(threadId, latestMediaPath);
+  }, [activeComputerTab, latestMediaPath, previewPanelOpen, requestFileOpen, threadId]);
 }
 
-function imageWorkspacePath(data: ArtifactData): string | null {
-  if (!isImageArtifact(data) || /[/\\]/u.test(data.filename) || data.filename.includes("..")) {
+function mediaWorkspacePath(data: ArtifactData, type: "image" | "video"): string | null {
+  const matchesType = type === "image" ? isImageArtifact(data) : isVideoArtifact(data);
+  if (!matchesType || /[/\\]/u.test(data.filename) || data.filename.includes("..")) {
     return null;
   }
-  return `.cheatcode/assets/images/${data.filename}`;
+  return `.cheatcode/assets/${type === "image" ? "images" : "videos"}/${data.filename}`;
 }
 
 function imageAlt(filename: string): string {
-  const readable = filename
+  const readable = readableFilename(filename);
+  return readable ? `Generated image: ${readable}` : "Generated image";
+}
+
+function readableFilename(filename: string): string {
+  return filename
     .replace(/\.[^.]+$/u, "")
     .replace(/[-_]+/gu, " ")
     .replace(/\s+/gu, " ")
     .trim();
-  return readable ? `Generated image: ${readable}` : "Generated image";
 }
 
 function isImageArtifact(data: ArtifactData): boolean {
   return data.kind === "image" || data.mimeType.startsWith("image/");
+}
+
+function isVideoArtifact(data: ArtifactData): boolean {
+  return data.kind === "video" || data.mimeType.startsWith("video/");
 }
 
 function deliverableIcon(kind: ArtifactData["kind"], mimeType: string) {

--- a/apps/web/src/components/chat/output-preview-support.ts
+++ b/apps/web/src/components/chat/output-preview-support.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { type RefObject, useEffect, useState } from "react";
+
+export interface OutputPreviewIdentity {
+  outputId: string;
+  sizeBytes: number;
+}
+
+export interface OutputPreviewState {
+  hostRef: RefObject<HTMLDivElement | null>;
+  message: string | null;
+  status: "error" | "idle" | "loading" | "ready";
+  url: string | null;
+}
+
+export function useNearViewport(ref: RefObject<HTMLElement | null>): boolean {
+  const [isNear, setNear] = useState(false);
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || typeof IntersectionObserver === "undefined") {
+      setNear(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+        setNear(true);
+        observer.disconnect();
+      },
+      { rootMargin: "320px" },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+  return isNear;
+}

--- a/apps/web/src/components/chat/output-video-preview.ts
+++ b/apps/web/src/components/chat/output-video-preview.ts
@@ -6,18 +6,16 @@ import {
   type OutputPreviewState,
   useNearViewport,
 } from "@/components/chat/output-preview-support";
-import { loadOutputImagePreview } from "@/lib/api/outputs";
+import { createOutputDownloadUrl } from "@/lib/api/outputs";
 
-export type OutputImagePreviewState = OutputPreviewState;
-
-export function useLazyOutputImagePreview(
+export function useLazyOutputVideoPreview(
   data: OutputPreviewIdentity,
   getToken: () => Promise<null | string>,
-): OutputImagePreviewState {
+): OutputPreviewState {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const getTokenRef = useRef(getToken);
   const isNearViewport = useNearViewport(hostRef);
-  const [preview, setPreview] = useState<Omit<OutputImagePreviewState, "hostRef">>({
+  const [preview, setPreview] = useState<Omit<OutputPreviewState, "hostRef">>({
     message: null,
     status: "idle",
     url: null,
@@ -30,17 +28,10 @@ export function useLazyOutputImagePreview(
   useEffect(() => {
     if (!isNearViewport) return;
     const controller = new AbortController();
-    let objectUrl: string | null = null;
     setPreview({ message: null, status: "loading", url: null });
-    void loadOutputImagePreview(
-      () => getTokenRef.current(),
-      data.outputId,
-      data.sizeBytes,
-      controller.signal,
-    )
-      .then((blob) => {
-        objectUrl = URL.createObjectURL(blob);
-        setPreview({ message: null, status: "ready", url: objectUrl });
+    void createOutputDownloadUrl(() => getTokenRef.current(), data.outputId, controller.signal)
+      .then((capability) => {
+        setPreview({ message: null, status: "ready", url: capability.downloadUrl });
       })
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;
@@ -50,11 +41,8 @@ export function useLazyOutputImagePreview(
           url: null,
         });
       });
-    return () => {
-      controller.abort();
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
-    };
-  }, [data.outputId, data.sizeBytes, isNearViewport]);
+    return () => controller.abort();
+  }, [data.outputId, isNearViewport]);
 
   return { ...preview, hostRef };
 }

--- a/packages/agent-core/src/tools/media/execute.ts
+++ b/packages/agent-core/src/tools/media/execute.ts
@@ -207,16 +207,24 @@ async function generateVideo(
 }
 
 function videoConfig(input: GenerateOrExtendVideoInput, references: MediaReference[]) {
+  if (input.reference_video) {
+    return {
+      numberOfVideos: 1,
+      resolution: "720p",
+    };
+  }
   return {
     aspectRatio: input.aspect_ratio ?? "16:9",
     durationSeconds: input.duration ?? 8,
-    generateAudio: true,
     numberOfVideos: 1,
-    referenceImages: references.map((reference) => ({
-      image: referenceImage(reference),
-      referenceType: VideoGenerationReferenceType.ASSET,
-    })),
-    resolution: "1080p",
+    ...(references.length > 0
+      ? {
+          referenceImages: references.map((reference) => ({
+            image: referenceImage(reference),
+            referenceType: VideoGenerationReferenceType.ASSET,
+          })),
+        }
+      : {}),
   };
 }
 

--- a/packages/agent-core/src/tools/media/schemas.ts
+++ b/packages/agent-core/src/tools/media/schemas.ts
@@ -34,6 +34,17 @@ export const GenerateOrExtendVideoInputSchema = z
         path: ["reference_video"],
       });
     }
+    if (
+      (input.reference_images?.length || input.reference_video) &&
+      input.duration !== undefined &&
+      input.duration !== 8
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Reference-based video generation and extension require an 8-second duration.",
+        path: ["duration"],
+      });
+    }
   });
 
 const MediaArtifactShape = {

--- a/skills/generate-media/SKILL.md
+++ b/skills/generate-media/SKILL.md
@@ -44,7 +44,7 @@ image_reference_mode: "edit"
 |---|---|---|
 | `prompt` | Yes | Subject, action, visual style, camera motion, and audio cues |
 | `aspect_ratio` | No | `16:9` or `9:16` |
-| `duration` | No | `4`, `6`, or `8` seconds |
+| `duration` | No | `4`, `6`, or `8` seconds; reference-image generation and extension require `8` |
 | `reference_images` | No | Up to 3 real project paths or public HTTPS URLs |
 | `reference_video` | No | The exact `sandboxPath` from an earlier video result, or a public HTTPS URL |
 
@@ -73,6 +73,7 @@ Order prompts as: **scene and backdrop → subject → action or key details →
 - For product visuals, name the material, camera angle, lighting setup, and whether text, logos, or watermarks are allowed.
 - For rendered text, provide the exact copy, typography direction, and placement.
 - For video, include action, camera movement, pacing, dialogue in quotes, sound effects, and ambience.
+- Veo generates synchronized audio natively from those prompt cues; do not add an audio configuration field.
 - Prefer concrete positive descriptions. State edit invariants explicitly.
 
 ## Execution contract


### PR DESCRIPTION
## Why

Production video generation sent two incompatible Veo options: an explicit audio toggle even though Veo 3.1 audio is native, and forced 1080p for four- and six-second clips even though 1080p requires eight seconds. Successful videos were also presented as generic files despite the product contract promising an in-chat preview.

## What changed

- align text, reference-image, and extension requests with their mode-specific Veo 3.1 configuration
- reject invalid non-eight-second reference and extension requests before provider billing
- keep short text generations on the provider-default 720p path for lower latency
- lazy-load generated video previews from signed output URLs and add direct Files access
- share viewport preview state between image and video deliverables
- retain the shared double-shell Deliverables treatment merged in #275

## Architecture and migration effects

No database migration or new environment variable. The Google AI BYOK boundary and R2 artifact ownership are unchanged.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (existing Knip ignore hint only)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- schema probe: 4-second text accepted, 8-second extension accepted, 4-second extension rejected
- production acceptance test will run after the exact merged SHA is deployed to Cloudflare and Vercel
