### PR TITLE
fix(web): allow signed video playback

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -53,7 +53,7 @@ const CONTENT_SECURITY_POLICY = [
   "style-src 'self' 'unsafe-inline'",
   `img-src 'self' data: blob: https://img.clerk.com ${INTEGRATION_LOGO_ORIGIN}`,
   "font-src 'self' data:",
-  "media-src 'self' data: blob:",
+  `media-src 'self' data: blob: ${GATEWAY_ORIGIN}`,
   `connect-src 'self' ${GATEWAY_ORIGIN} ${PREVIEW_HTTPS_ORIGIN} ${PREVIEW_WSS_ORIGIN} ${CLERK_FRONTEND_ORIGIN} ${CLERK_WEBSOCKET_ORIGIN}`,
   `frame-src 'self' ${PREVIEW_HTTPS_ORIGIN} https://challenges.cloudflare.com`,
   "worker-src 'self' blob:",


### PR DESCRIPTION
## Why

Production generated-video cards received a valid signed gateway URL, but the web CSP permitted that origin only for fetches and not media playback. Chrome rejected the video before issuing its media request.

## What changed

The production `media-src` directive now trusts the same build-validated gateway origin already used by `connect-src`. No wildcard or additional third-party origin was introduced.

## Architecture and migration effects

Web policy only. No Worker, environment, storage, or database change.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode` (existing Knip ignore hint only)
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- production acceptance will reload the already-generated video after the exact Vercel SHA deploys
