### PR TITLE
fix: normalize Cloudflare R2 range metadata

### DIFF
--- a/apps/agent-worker/src/agent-api-system-routes.ts
+++ b/apps/agent-worker/src/agent-api-system-routes.ts
@@ -204,13 +204,14 @@ function resolveOutputRange(
   objectSize: number,
 ): { end: number; length: number; offset: number } | undefined {
   if (!range) return undefined;
-  if ("suffix" in range) {
+  if ("suffix" in range && typeof range.suffix === "number") {
     const length = Math.min(range.suffix, objectSize);
     const offset = objectSize - length;
     return { end: objectSize - 1, length, offset };
   }
-  const offset = range.offset ?? 0;
-  const boundedLength = Math.min(range.length ?? objectSize - offset, objectSize - offset);
+  const offset = "offset" in range && typeof range.offset === "number" ? range.offset : 0;
+  const length = "length" in range && typeof range.length === "number" ? range.length : undefined;
+  const boundedLength = Math.min(length ?? objectSize - offset, objectSize - offset);
   return { end: offset + boundedLength - 1, length: boundedLength, offset };
 }
 


### PR DESCRIPTION
## Summary
- replaces structural R2 range discrimination with numeric property guards
- handles Cloudflare's runtime object shape where optional range keys can be present with `undefined` values
- prevents malformed `Content-Range` offsets while retaining zero-copy R2 streaming

## Root cause
The deployed runtime returned an offset range object that also contained an undefined `suffix` key. The TypeScript union suggests those shapes are exclusive, but an `in` check is not a valid runtime discriminator for this platform object. A production byte-range probe exposed `Content-Range: bytes NaN-...`.

## Verification
- full repository gate chain passed
- production acceptance after merge: expect `206`, `Content-Range: bytes 0-1023/880729`, and a 1,024-byte body
- production acceptance after merge: native video metadata, playback, and seeking in the existing Deliverables card
