### PR TITLE
fix: restore connected-app execution

### DIFF
--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -177,6 +177,10 @@ so the agent does not rediscover, convert, or screenshot the same file before fi
 
 Composio REST tool discovery and execution responses are byte-bounded before
 parsing, then projected into bounded, valid JSON before entering model context.
+The durable tool executor binds each checkpointed tool-call identity into the
+request context before Mastra execution. Composio quota charging derives its
+idempotency key from that explicit context value instead of relying on
+compatibility-layer execution fields that Mastra does not preserve.
 Toolkit names use the shared open-slug contract from
 `@cheatcode/types/integrations` across API, context, and tool boundaries.
 Discovery first uses Composio's full-text query. Because that query can return zero for an

--- a/packages/agent-core/src/mastra/context.ts
+++ b/packages/agent-core/src/mastra/context.ts
@@ -27,6 +27,7 @@ export const CONTEXT = {
   runIntent: "runIntent",
   selectedSkill: "selectedSkill",
   selectedTool: "selectedTool",
+  toolCallId: "toolCallId",
   userSkillCreator: "userSkillCreator",
   userSkillLoader: "userSkillLoader",
   userSkills: "userSkills",

--- a/packages/agent-core/src/mastra/durable-agent-step.ts
+++ b/packages/agent-core/src/mastra/durable-agent-step.ts
@@ -1,6 +1,7 @@
 import type { RequestContext } from "@mastra/core/request-context";
 import { type JSONValue, type ModelMessage, modelMessageSchema } from "ai";
 import { z } from "zod";
+import { CONTEXT } from "./context";
 import { mastra } from "./index";
 import { cheatcodeTools } from "./tool-defs/tool-set";
 
@@ -122,6 +123,10 @@ export async function executeGeneralAgentTool(
   if (!tool?.execute) {
     throw new Error(`Unknown or non-executable agent tool: ${options.toolName}`);
   }
+  // Mastra's execution wrapper does not preserve arbitrary top-level compatibility
+  // fields. Bind the durable call identity explicitly so request-scoped tools can
+  // derive stable idempotency keys without serializing them into model arguments.
+  options.requestContext.set(CONTEXT.toolCallId, options.toolCallId);
   return tool.execute(options.input, {
     ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
     // Repository tools use requestContext for their runtime dependencies and

--- a/packages/agent-core/src/mastra/tool-defs/composio-tool.ts
+++ b/packages/agent-core/src/mastra/tool-defs/composio-tool.ts
@@ -612,8 +612,8 @@ export const mastraComposioExecute = createTool({
 });
 
 function composioQuotaEventId(context: unknown): string {
-  const record = typeof context === "object" && context !== null ? context : {};
-  const candidate = (record as Record<string, unknown>)["toolCallId"];
+  const requestContext = requestContextFromToolContext(context);
+  const candidate = requestContext.get(CONTEXT.toolCallId);
   if (typeof candidate !== "string" || candidate.length === 0 || candidate.length > 180) {
     throw new Error("Composio execution requires a bounded tool-call id.");
   }


### PR DESCRIPTION
## Summary
- restores connected-app actions that failed before reaching Composio
- binds the durable tool-call identity into Mastra request context
- preserves idempotent quota charging across Workflow retries and every connected toolkit

## Root cause
Cloudflare Workflow checkpoints each model-selected tool call, but Mastra's execution wrapper does not preserve arbitrary top-level compatibility fields. The Composio quota event builder read `toolCallId` from that wrapper, so every action threw before the provider request.

## Architecture
The durable executor is the authoritative boundary that owns the checkpointed call identity. It now writes that identity into the request-scoped Mastra context before tool execution. Composio reads the same validated context used for its credentials and account routing, then derives the stable quota event key.

## Decisions made
| Decision | Choice | Alternatives considered | Reasoning |
|---|---|---|---|
| Tool identity transport | Explicit request-context value | Model arguments; Mastra compatibility fields | Keeps internal idempotency data out of prompts and uses the context contract Mastra preserves |
| Fix scope | Shared durable executor | Gmail-specific bypass | Covers Gmail, Notion, and every connected toolkit/model without special cases |
| Quota behavior | Retain deterministic tool-call idempotency | Disable quota metering | Workflow retries must not double-charge connected-app usage |

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm turbo build --force`
- `pnpm deadcode`
- `pnpm architecture:check`
- `pnpm turbo skills:build`
- production diagnosis: account ownership and OAuth active; direct provider execution succeeds
- production Workflow trace: exact pre-provider failure reproduced as `Composio execution requires a bounded tool-call id.`

## Production acceptance after merge
- [ ] ordinary-language Gmail read returns the requested messages
- [ ] explicit `@Gmail` read succeeds
- [ ] ordinary-language Notion read succeeds
- [ ] explicit `@Notion` read succeeds
- [ ] bare `@` lists active connected apps
- [ ] browser console remains free of new application errors
