### PR TITLE
fix: handle compound nouns in connected-app prompts

### DIFF
--- a/apps/gateway-worker/src/integration-action-presentation-support.ts
+++ b/apps/gateway-worker/src/integration-action-presentation-support.ts
@@ -149,13 +149,7 @@ function naturalActionGoal(value: string): string {
   const nounPhrase = match[2].split(/\s+(?:by|for|from|in|inside|on|to|with)\s+/iu)[0] ?? match[2];
   const firstNoun = nounPhrase.split(/\s+/u)[0]?.toLocaleLowerCase() ?? "";
   const noun = nounPhrase.split(/\s+/u).at(-1)?.toLocaleLowerCase() ?? "";
-  if (
-    !noun ||
-    UNCOUNTABLE_NOUNS.has(firstNoun) ||
-    UNCOUNTABLE_NOUNS.has(noun) ||
-    isPluralNoun(firstNoun) ||
-    isPluralNoun(noun)
-  ) {
+  if (!noun || UNCOUNTABLE_NOUNS.has(noun) || isPluralNoun(firstNoun) || isPluralNoun(noun)) {
     return value;
   }
   const article = articleFor(match[2]);


### PR DESCRIPTION
## Summary
- Fix the shared grammar rule for countable compound nouns such as “data source.”
- Preserve the existing handling for uncountable objects such as “page content.”

## Decision
Countability follows the compound noun’s final word. This is a general language rule in the shared presentation boundary, not a Notion-specific override.

## Verification
- [x] Full live Composio sweep: 424 actions across 20 toolkits, zero detected jargon/grammar/contract violations
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm turbo build --force`
- [x] `pnpm deadcode`
- [x] `pnpm architecture:check`
- [x] `pnpm turbo skills:build`
- [x] Confirmed “Help me search a data source” and unchanged “Help me view page content”